### PR TITLE
Address unsatisfiable constraints warnings

### DIFF
--- a/Examples/Examples/BasemapGalleryExampleView.swift
+++ b/Examples/Examples/BasemapGalleryExampleView.swift
@@ -68,7 +68,7 @@ struct BasemapGalleryExampleView: View {
                                         }
                                     }
                             }
-//                            .navigationViewStyle(.stack)
+                            .navigationViewStyle(.stack)
                         } else {
                             BasemapGallery(viewModel: viewModel)
                                 .padding()


### PR DESCRIPTION
This addresses the following warnings logged to the console when the basemap gallery is presented inside a navigation view:

```
[LayoutConstraints] Unable to simultaneously satisfy constraints.
```

Also, changed the Done button to be bold, which is the standard look-and-feel for done buttons.