### PR TITLE
Update package manifest to use the new Swift API Package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         ),
     ],
     dependencies: [
+        // To use a daily build of the Swift API, change the path below to point to the daily build's `output` folder.
         .package(name: "arcgis-runtime-swift", path: "../swift/ArcGIS")
     ],
     targets: [


### PR DESCRIPTION
This can be merged after this [PR](https://devtopia.esri.com/runtime/swift/pull/1332) is merged. 
Also, I did various testing with the toolkit package and examples app. No problems using the local build or the installed SDK.
The only thing that needs to change when using the installed SDK is changing the path [here](https://github.com/ArcGIS/arcgis-runtime-toolkit-swift/blob/b3a4b7883c5524adfc67b766d890ac14ab078e03/Package.swift#L30) to the folder that comes with the installed SDK.