### PR TITLE
Update Testable Reference

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/arcgis-runtime-toolkit-swift.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/arcgis-runtime-toolkit-swift.xcscheme
@@ -74,19 +74,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ArcGISToolkit-SwiftTests"
-               BuildableName = "ArcGISToolkit-SwiftTests"
-               BlueprintName = "ArcGISToolkit-SwiftTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ArcGISToolkitSwiftTests"
-               BuildableName = "ArcGISToolkitSwiftTests"
-               BlueprintName = "ArcGISToolkitSwiftTests"
+               BlueprintIdentifier = "ArcGISToolkitTests"
+               BuildableName = "ArcGISToolkitTests"
+               BlueprintName = "ArcGISToolkitTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
Xcode is automatically adding this change and the other two references to the tests (`ArcGISToolkit-SwiftTests` and `ArcGISToolkitSwiftTests`) are out of date and can be removed.