### PR TITLE
Mhd/floor filter view model

### DIFF
--- a/Examples/Examples/FloorFilterExampleView.swift
+++ b/Examples/Examples/FloorFilterExampleView.swift
@@ -16,8 +16,7 @@ import ArcGISToolkit
 import ArcGIS
 
 struct FloorFilterExampleView: View {
-    @State
-    private var map: Map
+    private let map: Map
     
     @State
     private var viewpoint = Viewpoint(
@@ -26,7 +25,7 @@ struct FloorFilterExampleView: View {
     )
     
     @State
-    private var floorManager: FloorManager? = nil
+    private var isMapLoaded: Bool = false
     
     init() {
         // Create the map from a portal item and assign to the mapView.
@@ -54,7 +53,8 @@ struct FloorFilterExampleView: View {
             viewpoint: viewpoint
         )
             .overlay(alignment: .bottomLeading) {
-                if let floorManager = floorManager {
+                if isMapLoaded,
+                   let floorManager = map.floorManager {
                     FloorFilter(
                         floorManager: floorManager,
                         viewpoint: $viewpoint
@@ -65,7 +65,7 @@ struct FloorFilterExampleView: View {
             .task {
                 do {
                     try await map.load()
-                    floorManager = map.floorManager
+                    isMapLoaded = true
                 } catch {
                     print("load error: \(error)")
                 }

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -41,26 +41,24 @@ public struct FloorFilter: View {
     private var isSelectorVisible: Bool = false
     
     public var body: some View {
-        Group {
-            if viewModel.isLoading {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .esriBorder()
-            } else {
-                HStack(alignment: .bottom) {
-                    Button {
-                        isSelectorVisible.toggle()
-                    } label: {
-                        Image("Site", bundle: .module, label: Text("Site"))
-                    }
-                    .esriBorder()
-                    if isSelectorVisible {
-                        SiteAndFacilitySelector(
-                            floorFilterViewModel: viewModel,
-                            isVisible: $isSelectorVisible
-                        )
-                            .frame(width: 200)
-                    }
+        if viewModel.isLoading {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .esriBorder()
+        } else {
+            HStack(alignment: .bottom) {
+                Button {
+                    isSelectorVisible.toggle()
+                } label: {
+                    Image("Site", bundle: .module, label: Text("Site"))
+                }
+                .esriBorder()
+                if isSelectorVisible {
+                    SiteAndFacilitySelector(
+                        floorFilterViewModel: viewModel,
+                        isVisible: $isSelectorVisible
+                    )
+                        .frame(width: 200)
                 }
             }
         }

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterViewModel.swift
@@ -16,7 +16,7 @@ import ArcGIS
 
 /// Manages the state for a `FloorFilter`.
 @MainActor
-final public class FloorFilterViewModel: ObservableObject {
+final class FloorFilterViewModel: ObservableObject {
     ///  A selected site, floor, or level.
     enum Selection {
         /// A selected site.
@@ -27,7 +27,7 @@ final public class FloorFilterViewModel: ObservableObject {
         case level(FloorLevel)
     }
     
-    /// Creates a `FloorFilterViewModel`
+    /// Creates a `FloorFilterViewModel`.
     /// - Parameters:
     ///   - floorManager: The floor manager used by the `FloorFilterViewModel`.
     ///   - viewpoint: Viewpoint updated when the selected site or facility changes.
@@ -37,24 +37,10 @@ final public class FloorFilterViewModel: ObservableObject {
     ) {
         self.floorManager = floorManager
         self.viewpoint = viewpoint
-        floorManagerDidChange()
-    }
 
-    /// The `Viewpoint` used to pan/zoom to the selected site/facilty.
-    /// If `nil`, there will be no automatic pan/zoom operations.
-    var viewpoint: Binding<Viewpoint>?
-    
-    /// The `FloorManager` containing the site, floor, and level information.
-    var floorManager: FloorManager? = nil {
-        didSet {
-            floorManagerDidChange()
-        }
-    }
-    
-    func floorManagerDidChange() {
         Task {
             do {
-                try await floorManager?.load()
+                try await floorManager.load()
                 if sites.count == 1 {
                     // If we have only one site, select it.
                     selection = .site(sites.first!)
@@ -65,20 +51,27 @@ final public class FloorFilterViewModel: ObservableObject {
             isLoading = false
         }
     }
+
+    /// The `Viewpoint` used to pan/zoom to the selected site/facilty.
+    /// If `nil`, there will be no automatic pan/zoom operations.
+    let viewpoint: Binding<Viewpoint>?
+    
+    /// The `FloorManager` containing the site, floor, and level information.
+    let floorManager: FloorManager
     
     /// The floor manager sites.
-    public var sites: [FloorSite] {
-        floorManager?.sites ?? []
+    var sites: [FloorSite] {
+        floorManager.sites
     }
     
     /// The floor manager facilities.
-    public var facilities: [FloorFacility] {
-        floorManager?.facilities ?? []
+    var facilities: [FloorFacility] {
+        floorManager.facilities
     }
     
     /// The floor manager levels.
-    public var levels: [FloorLevel] {
-        floorManager?.levels ?? []
+    var levels: [FloorLevel] {
+        floorManager.levels
     }
 
     /// `true` if the model is loading it's properties, `false` if not loading.
@@ -135,7 +128,7 @@ final public class FloorFilterViewModel: ObservableObject {
     }
     
     /// Zooms to the selected facility; if there is no selected facility, zooms to the selected site.
-    public func zoomToSelection() {
+    func zoomToSelection() {
         guard let selection = selection else {
             return
         }


### PR DESCRIPTION
This updates the floor filter view model pattern based on these [comments](https://github.com/ArcGIS/arcgis-runtime-toolkit-swift/pull/19#discussion_r798908841).

- `FloorFilterViewModel` is now an internal class
- `FloorFilter` creates it's `FloorFilterViewModel` internally
- `FloorFilter` initializer now takes a `FloorManager` and a `Viewpoint`
- The client/Example code now creates the `FloorFilter` when the map has loaded, by setting a `@State floorManager: FloorManager?` property.
- ~`FloorFilter` sets the model's `floorManager` and `viewpoint` properties in `.onAppear()`.~
- Additional properties the model needs will be set via a modifier on the `FloorFilter` view and then set on the model.

I'd really like to nail down this pattern.  I have the following questions/concerns:

- ~is `.onAppear()` the best way to "forward" properties from the view to the view model?  I tried creating the model inside `FloorFilter.init(...)` with an initializer that took a floor manager and viewpoint, but I got a compile error.~
- Does the rest of it look OK?  Whatever pattern we come up with here would be the basis for future work (and maybe re-tooling the recently-finished components), so I want it to be solid.

I made some improvements after a discussion with @rolson and @dfeinzimer.  The `.onAppear()` method of setting properties on the view model is gone.  Instead, there is now a new initializer on `FloorFilterViewModel`, which is called in the `FloorFilter` initializer using a `StateObject` property wrapper.