### PR TITLE
Fix build and tests

### DIFF
--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -114,8 +114,8 @@ public class SearchViewModel: ObservableObject {
             
             // Check center difference.
             let centerDiff = GeometryEngine.distance(
-                geometry1: lastExtent.center,
-                geometry2: newExtent.center
+                from: lastExtent.center,
+                to: newExtent.center
             )
             let currentExtentAvg = (lastExtent.width + lastExtent.height) / 2.0
             let threshold = currentExtentAvg * 0.25

--- a/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
@@ -203,14 +203,14 @@ class SearchViewModelTests: XCTestCase {
         
         let resultGeometryUnion: Geometry = try XCTUnwrap(
             GeometryEngine.union(
-                geometries: result.compactMap { $0.geoElement?.geometry }
+                of: result.compactMap { $0.geoElement?.geometry }
             )
         )
         
         XCTAssertTrue(
-            GeometryEngine.contains(
-                geometry1: model.queryArea!,
-                geometry2: resultGeometryUnion
+            GeometryEngine.doesGeometry(
+                model.queryArea!,
+                contain: resultGeometryUnion
             )
         )
         
@@ -256,9 +256,9 @@ class SearchViewModelTests: XCTestCase {
         )
         
         var geodeticDistance = try XCTUnwrap (
-            GeometryEngine.distanceGeodetic(
-                point1: .portland,
-                point2: resultPoint,
+            GeometryEngine.geodeticDistance(
+                from: .portland,
+                to: resultPoint,
                 distanceUnit: .meters,
                 azimuthUnit: nil,
                 curveType: .geodesic
@@ -283,9 +283,9 @@ class SearchViewModelTests: XCTestCase {
         
         // Web Mercator distance between .edinburgh and first result.
         geodeticDistance = try XCTUnwrap (
-            GeometryEngine.distanceGeodetic(
-                point1: .edinburgh,
-                point2: resultPoint,
+            GeometryEngine.geodeticDistance(
+                from: .edinburgh,
+                to: resultPoint,
                 distanceUnit: .meters,
                 azimuthUnit: nil,
                 curveType: .geodesic
@@ -311,14 +311,14 @@ class SearchViewModelTests: XCTestCase {
         
         let resultGeometryUnion: Geometry = try XCTUnwrap(
             GeometryEngine.union(
-                geometries: result.compactMap { $0.geoElement?.geometry }
+                of: result.compactMap { $0.geoElement?.geometry }
             )
         )
         
         XCTAssertTrue(
-            GeometryEngine.contains(
-                geometry1: model.geoViewExtent!,
-                geometry2: resultGeometryUnion
+            GeometryEngine.doesGeometry(
+                model.geoViewExtent!,
+                contain: resultGeometryUnion
             )
         )
         


### PR DESCRIPTION
A PR just went in over in the Swift API that renamed all the `GeometryEngine` methods and the toolkit needs updated to use those new method names.