### PR TITLE
Remove `FloorFacility` and `FloorSite` conformance to `Identifiable`

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/FloorFacility.swift
+++ b/Sources/ArcGISToolkit/Extensions/FloorFacility.swift
@@ -16,10 +16,6 @@ import ArcGIS
 
 extension FloorFacility: Equatable {
     public static func == (lhs: FloorFacility, rhs: FloorFacility) -> Bool {
-        lhs.facilityId == rhs.facilityId
+        lhs.id == rhs.id
     }
-}
-
-extension FloorFacility: Identifiable {
-    public var id: String { facilityId }
 }

--- a/Sources/ArcGISToolkit/Extensions/FloorSite.swift
+++ b/Sources/ArcGISToolkit/Extensions/FloorSite.swift
@@ -16,10 +16,6 @@ import ArcGIS
 
 extension FloorSite: Equatable {
     public static func == (lhs: FloorSite, rhs: FloorSite) -> Bool {
-        lhs.siteId == rhs.siteId
+        lhs.id == rhs.id
     }
-}
-
-extension FloorSite: Identifiable {
-    public var id: String { siteId }
 }


### PR DESCRIPTION
They now conform to the protocol inside of `ArcGIS` itself.