### PR TITLE
Add error icon in place of graying out the thumbnail.

### DIFF
--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryCell.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryCell.swift
@@ -67,7 +67,7 @@ struct BasemapGalleryCell: View {
         }).disabled(item.isBasemapLoading)
     }
     
-    /// Creates a partially transparent rectangle, used to denote a basemap with an error.
+    /// Creates a red exclamation mark, used to denote a basemap with an error.
     /// - Returns: A new transparent rectagle view.
     private func makeErrorOverlay() -> some View {
         HStack {


### PR DESCRIPTION
This adds an error icon in the top/trailing portion of the thumbnail, similar to how iOS adds notification badges to icons on the home screen.

#54 