### PR TITLE
Update Color extension doc

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/Color.swift
+++ b/Sources/ArcGISToolkit/Extensions/Color.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 extension Color {
     /// Initializes a new color with RGB integer values.
-    /// - Precondition: `red`, `blue` and `green` are values between 0 and 255 inclusive.
+    /// - Precondition: `red`, `green` and `blue` are values between 0 and 255 inclusive.
     init(red: Int, green: Int, blue: Int) {
         let validRange = 0...255
         precondition(validRange.contains(red))


### PR DESCRIPTION
`red`, `green` and `blue` should be listed in that order to match the parameters they're documenting and the order in the [RGB color model](https://en.wikipedia.org/wiki/RGB_color_model).