### PR TITLE
An alternative viewpoint implementation.

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -32,7 +32,8 @@ public struct FloorFilter: View {
     ) {
         _viewModel = StateObject(wrappedValue: FloorFilterViewModel(
             automaticSelectionMode: automaticSelectionMode,
-            floorManager: floorManager
+            floorManager: floorManager,
+            viewpoint: viewpoint
         ))
         self.alignment = alignment
         self.viewpoint = viewpoint
@@ -97,13 +98,7 @@ public struct FloorFilter: View {
             .esriBorder()
             .opacity(isSitesAndFacilitiesHidden ? .zero : 1)
             .onChange(of: viewpoint.wrappedValue) {
-                viewModel.viewpoint = $0
-            }
-            .onChange(of: viewModel.viewpoint) { newValue in
-                guard newValue != viewpoint.wrappedValue else {
-                    return
-                }
-                viewpoint.wrappedValue = newValue
+                viewModel.onViewpointChanged($0)
             }
     }
     


### PR DESCRIPTION
@dfeinzimer - I've implemented a different "viewpoint" mechanism.  It removes the `Combine` code, makes the model `viewpoint` a Binding, and has the view notify the model when the binding's `wrappedValue` changes.

It was the last bit (determining when the `wrappedValue` changed) that I couldn't figure out how to do in the model.  It's easy in the view using the `.onChanged` modifier, so I used that and just notified the model when that happened.

This allows the single source of truth to be the single viewpoint coming from the example; it allows the model to change it based on the site/facility selection, and the model is notified by the view.

Take a look and let me know what you think.