### PR TITLE
Refactor `Compass` to use heading

### DIFF
--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -31,7 +31,9 @@ public struct Compass: View {
     /// The heading of the compass in degrees.
     @Binding private var heading: Double
     
-    /// Creates a compass with a binding to a heading.
+    /// Creates a compass with a binding to a heading based on compass
+    /// directions (0° indicates a direction toward true North, 90° indicates a
+    /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
     ///   - autoHide: A Boolean value that determines whether the compass
@@ -68,7 +70,9 @@ public struct Compass: View {
 }
 
 public extension Compass {
-    /// Creates a compass with a binding to a viewpoint rotation.
+    /// Creates a compass with a binding to a viewpoint rotation (0° indicates
+    /// a direction toward true North, 90° indicates a direction toward true
+    /// West, etc.).
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.


### PR DESCRIPTION
This PR refactors the `Compass` component to use a heading to determine the orientation of the compass needle The viewpoint-based approach is still supported using a separate initializer.

For future consideration is whether `autoHide` should be a modifier. The way it is now, the default value lives in three places (in each of the initializers).

```swift
public extension Compass {
    func automaticallyHides(_ newAutomaticallyHides: Bool) -> some View {
        var copy = self
        copy.autoHide = newAutomaticallyHides
        return copy
    }
}
```