### PR TITLE
Fix build error

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -265,7 +265,7 @@ public struct UtilityNetworkTrace: View {
             }
         }
         Button {
-            if let selectedStartingPoint {
+            if let selectedStartingPoint = selectedStartingPoint {
                 viewpoint = Viewpoint(targetExtent: selectedStartingPoint.extent)
             }
         } label: {


### PR DESCRIPTION
Reverts new optional unwrapping syntax only supported in Xcode 14.0 / Swift 5.7