### PR TITLE
df/Issue93

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -60,7 +60,7 @@ public struct FloorFilter: View {
     /// The width of the level selector.
     private let filterWidth: CGFloat = 60
     
-    /// The `Viewpoint` used to pan/zoom to the selected site/facilty.
+    /// The `Viewpoint` used to pan/zoom to the selected site/facility.
     /// If `nil`, there will be no automatic pan/zoom operations or automatic selection support.
     private var viewpoint: Binding<Viewpoint?>
     
@@ -103,7 +103,7 @@ public struct FloorFilter: View {
     /// A Boolean value indicating whether the map is currently being navigated.
     private var isNavigating: Binding<Bool>
     
-    /// Indicates that the selector should be presented with a top oriented aligment configuration.
+    /// Indicates that the selector should be presented with a top oriented alignment configuration.
     private var isTopAligned: Bool {
         alignment.vertical == .top
     }


### PR DESCRIPTION
Closes #93 

This is only a slight change to the behavior of the floor filter such that the site and facility selector is hidden by default. This aligns the component with its iOS counterpart and addresses an issue where the selector is immediately visible when the example is opened (#93).