### PR TITLE
Resolve warning in Authentication Example

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/Login.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Login.swift
@@ -196,6 +196,7 @@ private struct LoginView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
+                        focusedField = nil
                         dismissAction()
                         viewModel.cancel()
                     }


### PR DESCRIPTION
Closes #104 

Adding `focusedField = nil` as part of the cancel button's action stops the warning.

The comment at the very bottom of [this thread](https://developer.apple.com/forums/thread/126890) made me think of trying this:

> Basically, it occurs when you have the first responder present in base view and try to present a sheet. So before presenting the sheet Dismiss first responder.

cc @rolson 