### PR TITLE
df/UseFloatingPanelEnhancements

### DIFF
--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -21,6 +21,9 @@ struct UtilityNetworkTraceExampleView: View {
     /// The map containing the utility networks.
     @StateObject private var map = makeMap()
     
+    /// The current detent of the floating panel presenting the trace tool.
+    @State var activeDetent: FloatingPanelDetent = .half
+    
     /// Provides the ability to inspect map components.
     @State var mapViewProxy: MapViewProxy?
     
@@ -51,7 +54,15 @@ struct UtilityNetworkTraceExampleView: View {
             .onViewpointChanged(kind: .centerAndScale) {
                 viewpoint = $0
             }
-            .overlay {
+            .task {
+                await ArcGISRuntimeEnvironment.credentialStore.add(try! await .publicSample)
+            }
+            .floatingPanel(
+                    backgroundColor: Color(uiColor: .systemGroupedBackground),
+                    detent: $activeDetent,
+                    horizontalAlignment: .trailing,
+                    isPresented: .constant(true)
+            ) {
                 UtilityNetworkTrace(
                     graphicsOverlay: $resultGraphicsOverlay,
                     map: map,
@@ -60,9 +71,7 @@ struct UtilityNetworkTraceExampleView: View {
                     mapViewProxy: $mapViewProxy,
                     viewpoint: $viewpoint
                 )
-            }
-            .task {
-                await ArcGISRuntimeEnvironment.credentialStore.add(try! await .publicSample)
+                .floatingPanelDetent($activeDetent)
             }
         }
     }


### PR DESCRIPTION
- This makes use of the changes from #108 to improve the Utility Network Trace tool
  - Some pieces of the UI become conditionally hidden based on the active detent.
  - The detent is programmatically changed based on the users current activity.

- Switches the UN tool to be exposed as a `View` modifier. 
  - I like this pattern because it simplifies things for the user (no need to use `overlay`) and us (no need to overlay over `Color.clear`). I dislike the pattern because it triples the number of places where we need to maintain documentation (the component itself, the view modifier's properties, and the View extension params.) Any thoughts on this @mhdostal?