### PR TITLE
Fix build failures related to `UtilityTraceFunctionType`

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -372,7 +372,7 @@ public struct UtilityNetworkTrace: View {
                                 Text(item.function.networkAttribute?.name ?? "Unnamed")
                                 Spacer()
                                 VStack(alignment: .trailing) {
-                                    Text(item.function.functionType.description)
+                                    Text(item.function.functionType.title)
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                     Text((item.result as? Double)?.description ?? "N/A")

--- a/Sources/ArcGISToolkit/Extensions/UtilityTraceFunction.FunctionType.swift
+++ b/Sources/ArcGISToolkit/Extensions/UtilityTraceFunction.FunctionType.swift
@@ -13,8 +13,8 @@
 
 import ArcGIS
 
-extension UtilityTraceFunctionType: CustomStringConvertible {
-    public var description: String {
+extension UtilityTraceFunction.FunctionType {
+    var title: String {
         switch self {
         case .add: return "Add"
         case .average: return "Average"


### PR DESCRIPTION
The type was nested under `UtilityTraceFunction` as `FunctionType`. Along with this change, I removed conformance to `CustomStringConvertible`. `CustomStringConvertible.description` isn't intended to be used for localized values. While the Examples app isn't localized, users' apps likely are and we don't want to be modeling a bad practice for them.