### PR TITLE
Reverse order of attachments prior to display.

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
@@ -79,7 +79,7 @@ struct AttachmentsPopupElementView: View {
         }
         .task {
             try? await popupElement.fetchAttachments()
-            let attachmentModels = popupElement.attachments.map { attachment in
+            let attachmentModels = popupElement.attachments.reversed().map { attachment in
                 AttachmentModel(attachment: attachment)
             }
             viewModel.attachmentModels.append(contentsOf: attachmentModels)


### PR DESCRIPTION
The attachment added first should be shown at the beginning of the list. This is what AGOL does.

Previously, the attachments were shown in the order returned from the `AttachmentsPopupElement.attachments` property, which is sorted by newest added first.  This PR reverses that order.

Calypso #323
