### PR TITLE
Address build error in SearchResult.swift

### DIFF
--- a/Sources/ArcGISToolkit/Components/Search/SearchResult.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchResult.swift
@@ -99,7 +99,7 @@ extension SearchResult {
                 geometry: geocodeResult.displayLocation,
                 attributes: geocodeResult.attributes
             ),
-            selectionViewpoint: geocodeResult.extent.map(Viewpoint.init)
+            selectionViewpoint: geocodeResult.extent.map { .init(targetExtent: $0) }
         )
     }
 }


### PR DESCRIPTION
The file was using an initializer of `Viewpoint` that no longer exists.