### PR TITLE
Remove conformance of `Bookmark` to `Equatable`

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/Bookmark.swift
+++ b/Sources/ArcGISToolkit/Extensions/Bookmark.swift
@@ -12,13 +12,6 @@
 // limitations under the License.
 
 import ArcGIS
-import Foundation
-
-extension Bookmark: Equatable {
-    public static func == (lhs: Bookmark, rhs: Bookmark) -> Bool {
-        lhs.hashValue == rhs.hashValue
-    }
-}
 
 extension Bookmark: Hashable {
     public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
The conformance has been added at the API level. By the way, `hashValue` should never be used to determine equality. To understand why, consider that `Hashable` refines `Equatable`, not the other way around. Multiple different bookmarks could have the same hash value. When that happens, equality is used to determine whether they are in fact the same. Therefore the implementation of `==` must compare the individual properties themselves and not their hash values.