### PR TITLE
Update Utility Network Tests

### DIFF
--- a/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
@@ -280,6 +280,8 @@ extension UtilityNetworkTraceViewModelTests {
         return map
     }
     
+    /// A token to a sample public utility network dataset as previously published in the
+    /// [Javascript sample](https://developers.arcgis.com/javascript/latest/sample-code/widgets-untrace/).
     var tokenForSampleServer7: ArcGISCredential {
         get async throws {
             try await ArcGISCredential.token(


### PR DESCRIPTION
- Updates `UtilityNetworkTraceViewModelTests` to use publicly available data so that no password entry is needed.
- Because the test data is changed, some implementation details of the tests needed to change to use features that exist in the new data.