### PR TITLE
Add `objectID` to `UtilityTraceFunctionOutput`

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -361,7 +361,7 @@ public struct UtilityNetworkTrace: View {
                             set: { currentActivity = .viewingTraces($0 ? .viewingFunctionResults : nil) }
                         )
                     ) {
-                        ForEach(viewModel.selectedTrace?.functionOutputs ?? []) { item in
+                        ForEach(viewModel.selectedTrace?.functionOutputs ?? [], id: \.objectID) { item in
                             HStack {
                                 Text(item.function.networkAttribute.name)
                                 Spacer()

--- a/Sources/ArcGISToolkit/Extensions/UtilityTraceFunctionOutput.swift
+++ b/Sources/ArcGISToolkit/Extensions/UtilityTraceFunctionOutput.swift
@@ -1,0 +1,20 @@
+// Copyright 2022 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArcGIS
+
+extension UtilityTraceFunctionOutput {
+    var objectID: ObjectIdentifier {
+        return ObjectIdentifier(self)
+    }
+}


### PR DESCRIPTION
Related #152 

To be merged following Swift 3119