### PR TITLE
Use `confirmationDialog` modifier for Clear All Results

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -64,6 +64,10 @@ public struct UtilityNetworkTrace: View {
     /// A Boolean value indicating whether the map should be zoomed to the extent of the trace result.
     @State private var shouldZoomOnTraceCompletion = false
     
+    /// A Boolean value indicating whether the Clear All Results confirmation
+    /// dialog is being shown.
+    @State private var isShowingClearAllResultsConfirmationDialog = false
+    
     /// The view model used by the view. The `UtilityNetworkTraceViewModel` manages state.
     /// The view observes `UtilityNetworkTraceViewModel` for changes in state.
     @StateObject private var viewModel: UtilityNetworkTraceViewModel
@@ -399,19 +403,23 @@ public struct UtilityNetworkTrace: View {
                 }
             }
             .padding([.vertical], 2)
-            Button(role: .destructive) {
-                viewModel.userAlert = .init(
-                    description: "Are you sure? All the trace inputs and results will be lost.",
-                    button: Button(role: .destructive) {
-                        viewModel.deleteAllTraces()
-                        currentActivity = .creatingTrace(nil)
-                    } label: {
-                        Text("OK")
-                    })
-            } label: {
-                Text(clearResultsTitle)
+            Button("Clear All Results", role: .destructive) {
+                isShowingClearAllResultsConfirmationDialog = true
             }
             .buttonStyle(.bordered)
+            .confirmationDialog(
+                "Clear all results?",
+                isPresented: $isShowingClearAllResultsConfirmationDialog
+            ) {
+                Button(role: .destructive) {
+                    viewModel.deleteAllTraces()
+                    currentActivity = .creatingTrace(nil)
+                } label: {
+                    Text("Clear All Results")
+                }
+            } message: {
+                Text("All the trace inputs and results will be lost.")
+            }
         }
     }
     
@@ -697,9 +705,6 @@ public struct UtilityNetworkTrace: View {
             .lineLimit(1)
             .frame(maxWidth: .infinity, alignment: .center)
     }
-    
-    /// Title for the clear all results feature
-    private let clearResultsTitle = "Clear All Results"
     
     /// Title for the feature results section
     private let featureResultsTitle = "Feature Results"


### PR DESCRIPTION
SwiftUI has a built-in modifier to present a confirmation dialog, so it makes sense to use that for this UI. Also, the alert didn't match [the HIG](https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts). I've split the description into a title and message and updated the button title to follow the HIG.

- Dialog no longer has Error as the title, which was quite odd
- Dialog is now presented as an action sheet on iPhone, meaning the buttons are at the bottom, closer to the user's thumb

Before | After
------ | -----
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-28 at 14 08 42](https://user-images.githubusercontent.com/2257493/204395154-f5e4f6b8-1f9b-4612-a751-ac59663640b7.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-28 at 14 30 13](https://user-images.githubusercontent.com/2257493/204395164-9949db9c-4d44-4294-868f-fdd1275e1892.png)
