### PR TITLE
Revert "Remove bookmark "Hashable" conformance"

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/Bookmark.swift
+++ b/Sources/ArcGISToolkit/Extensions/Bookmark.swift
@@ -1,0 +1,21 @@
+// Copyright 2022 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArcGIS
+
+extension Bookmark: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(viewpoint)
+    }
+}


### PR DESCRIPTION
Reverts ArcGIS/arcgis-maps-sdk-swift-toolkit#194

The SDK change is in main, but not in the 200 Release branch.  This needs to go in after the release.