### PR TITLE
Beta - Fix forum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Some of the toolkit components and examples utilize a set of ready-to-use ArcGIS
 * [Developers guide documentation](https://developers.arcgis.com/swift)
 * [Maps SDK API Reference](https://developers.arcgis.com/swift/api-reference/documentation/arcgis)
 * [Samples](https://github.com/Esri/arcgis-maps-sdk-swift-samples)
-* Got a question? Ask the community on our [forum](https://community.esri.com/t5/arcgis-runtime-sdk-for-ios-questions/bd-p/arcgis-runtime-sdk-for-ios-questions)
+* Got a question? Ask the community on our [forum](https://community.esri.com/t5/swift-maps-sdk-questions/bd-p/swift-maps-sdk-questions)
 
 ## Issues
 


### PR DESCRIPTION
Updates the link to the community forums which was still pointing at the iOS board.