### PR TITLE
Fix OverviewMap warning

### DIFF
--- a/Documentation/OverviewMap/README.md
+++ b/Documentation/OverviewMap/README.md
@@ -16,12 +16,12 @@ OverviewMap:
 - Displays a representation of the current `VisibleArea`/`Viewpoint` for a connected `GeoView`.
 - Supports a configurable scaling factor for setting the overview map's zoom level relative to the connected view.
 - Supports a configurable symbol for visualizing the current `VisibleArea`/`Viewpoint` representation (a `FillSymbol` for a connected `MapView`; a `MarkerSymbol` for a connected `SceneView`).
+- Supports using a custom map in the overview map display.
 
 ## Key properties
 
 `OverviewMap` has the following instance methods:
 
-- `map(_ map: Map)` - The `Map` displayed in the `OverviewMap`. For example, you can use `map(_:)` to display a custom base map in the `OverviewMap`.
 - `scaleFactor(_ scaleFactor: Double)` - The scale of the `OverviewMap` relative to the scale of the connected `GeoView`. The `OverviewMap` will display at the a scale equal to: `viewpoint.targetScale` x `scaleFactor`. The default is `25`.
 - `symbol(_ symbol: Symbol)` - The symbol used to visualize the current `VisibleArea`/`Viewpoint`. This is a red rectangle by default for a `MapView`; for a `SceneView`, this is a red cross.
 
@@ -83,5 +83,7 @@ var body: some View {
         )
 }
 ```
+
+To use a custom map in the `OverviewMap`, use the `map` argument in either `OverviewMap.forMapView` or `OverviewMap.forSceneView`.
 
 To see the `OverviewMap` in action, and for examples of `OverviewMap` customization, check out the [Examples](../../Examples) and refer to [OverviewMapExampleView.swift](../../Examples/Examples/OverviewMapExampleView.swift) in the project.

--- a/Examples/Examples/OverviewMapExampleView.swift
+++ b/Examples/Examples/OverviewMapExampleView.swift
@@ -63,12 +63,12 @@ struct OverviewMapForMapView: View {
             .overlay(
                 OverviewMap.forMapView(
                     with: viewpoint,
-                    visibleArea: visibleArea
+                    visibleArea: visibleArea// ,
+                    // map: .customOverviewMap // Uncomment to use a custom map.
                 )
                 // These modifiers show how you can modify the default
                 // values used for the symbol, map, and scaleFactor.
 //                    .symbol(.customFillSymbol)
-//                    .map(.customOverviewMapForMapView)
 //                    .scaleFactor(15.0)
                     .frame(width: 200, height: 132)
                     .padding(),
@@ -89,11 +89,13 @@ struct OverviewMapForSceneView: View {
         SceneView(scene: dataModel.scene)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .overlay(
-                OverviewMap.forSceneView(with: viewpoint)
+                OverviewMap.forSceneView(
+                    with: viewpoint// ,
+                    // map: .customOverviewMap // Uncomment to use a custom map.
+                )
                 // These modifiers show how you can modify the default
                 // values used for the symbol, map, and scaleFactor.
 //                    .symbol(.customMarkerSymbol)
-//                    .map(.customOverviewMapForSceneView)
 //                    .scaleFactor(15.0)
                     .frame(width: 200, height: 132)
                     .padding(),
@@ -131,9 +133,6 @@ private extension Symbol {
 }
 
 private extension Map {
-    /// A custom map for the `OverviewMap` used in a MapView.
-    static let customOverviewMapForMapView = Map(basemapStyle: .arcGISDarkGray)
-
-    /// A custom map for the `OverviewMap` used in a SceneView.
-    static let customOverviewMapForSceneView = Map(basemapStyle: .arcGISDarkGray)
+    /// A custom map for the `OverviewMap`.
+    static let customOverviewMap = Map(basemapStyle: .arcGISDarkGray)
 }

--- a/Examples/Examples/OverviewMapExampleView.swift
+++ b/Examples/Examples/OverviewMapExampleView.swift
@@ -56,6 +56,9 @@ struct OverviewMapForMapView: View {
     
     @State private var visibleArea: ArcGIS.Polygon?
     
+    // A custom map to display as the overview map.
+//    @State var customOverviewMap = Map(basemapStyle: .arcGISDarkGray)
+    
     var body: some View {
         MapView(map: dataModel.map)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
@@ -64,7 +67,7 @@ struct OverviewMapForMapView: View {
                 OverviewMap.forMapView(
                     with: viewpoint,
                     visibleArea: visibleArea// ,
-                    // map: .customOverviewMap // Uncomment to use a custom map.
+                    // map: customOverviewMap // Uncomment to use a custom map.
                 )
                 // These modifiers show how you can modify the default
                 // values used for the symbol, map, and scaleFactor.
@@ -85,13 +88,16 @@ struct OverviewMapForSceneView: View {
     
     @State private var viewpoint: Viewpoint?
     
+    // A custom map to display as the overview map.
+    //    @State var customOverviewMap = Map(basemapStyle: .arcGISDarkGray)
+
     var body: some View {
         SceneView(scene: dataModel.scene)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .overlay(
                 OverviewMap.forSceneView(
                     with: viewpoint// ,
-                    // map: .customOverviewMap // Uncomment to use a custom map.
+                    // map: customOverviewMap // Uncomment to use a custom map.
                 )
                 // These modifiers show how you can modify the default
                 // values used for the symbol, map, and scaleFactor.
@@ -130,9 +136,4 @@ private extension Symbol {
         color: .blue,
         size: 16.0
     )
-}
-
-private extension Map {
-    /// A custom map for the `OverviewMap`.
-    static let customOverviewMap = Map(basemapStyle: .arcGISDarkGray)
 }

--- a/Sources/ArcGISToolkit/Components/OverviewMap.swift
+++ b/Sources/ArcGISToolkit/Components/OverviewMap.swift
@@ -29,13 +29,21 @@ public struct OverviewMap: View {
     private var scaleFactor = 25.0
     
     /// The data model containing the `Map` displayed in the overview map.
-    @StateObject private var dataModel: MapDataModel
+    @StateObject private var dataModel = MapDataModel()
     
     /// The `Graphic` displaying the visible area of the main `GeoView`.
     @StateObject private var graphic: Graphic
     
     /// The `GraphicsOverlay` used to display the visible area graphic.
     @StateObject private var graphicsOverlay: GraphicsOverlay
+    
+    /// The user-defined map used in the overview map. Defaults to `nil`.
+    private let userProvidedMap: Map?
+    
+    /// The actual map used in the overaview map.
+    private var effectiveMap: Map {
+        userProvidedMap ?? dataModel.defaultMap
+    }
     
     /// Creates an `OverviewMap` for use on a `MapView`.
     /// - Parameters:
@@ -56,7 +64,7 @@ public struct OverviewMap: View {
             map: map
         )
     }
-
+    
     /// Creates an `OverviewMap` for use on a `SceneView`.
     /// - Parameters:
     ///   - viewpoint: Viewpoint of the main `SceneView` used to update the
@@ -86,12 +94,6 @@ public struct OverviewMap: View {
         self.viewpoint = viewpoint
         self.symbol = symbol
         
-        _dataModel = StateObject(
-            wrappedValue: MapDataModel(
-                map: map ?? Map(basemapStyle: .arcGISTopographic)
-            )
-        )
-        
         let graphic = Graphic(symbol: self.symbol)
         
         // It is necessary to set the graphic and graphicsOverlay this way
@@ -100,11 +102,13 @@ public struct OverviewMap: View {
         // with the graphic during panning/zooming/rotating.
         _graphic = StateObject(wrappedValue: graphic)
         _graphicsOverlay = StateObject(wrappedValue: GraphicsOverlay(graphics: [graphic]))
+        
+        userProvidedMap = map
     }
     
     public var body: some View {
         MapView(
-            map: dataModel.map,
+            map: effectiveMap,
             viewpoint: makeOverviewViewpoint(),
             graphicsOverlays: [graphicsOverlay]
         )
@@ -198,12 +202,6 @@ private extension Symbol {
 
 /// A very basic data model class containing a Map.
 class MapDataModel: ObservableObject {
-    /// The `Map` used for display in a `MapView`.
-    @Published var map: Map
-    
-    /// Creates a `MapDataModel`.
-    /// - Parameter map: The `Map` used for display.
-    init(map: Map) {
-        self.map = map
-    }
+    /// The default `Map` used for display in a `MapView`.
+    let defaultMap = Map(basemapStyle: .arcGISTopographic)
 }

--- a/Sources/ArcGISToolkit/Components/OverviewMap.swift
+++ b/Sources/ArcGISToolkit/Components/OverviewMap.swift
@@ -29,9 +29,7 @@ public struct OverviewMap: View {
     private var scaleFactor = 25.0
     
     /// The data model containing the `Map` displayed in the overview map.
-    @StateObject private var dataModel = MapDataModel(
-        map: Map(basemapStyle: .arcGISTopographic)
-    )
+    @StateObject private var dataModel: MapDataModel
     
     /// The `Graphic` displaying the visible area of the main `GeoView`.
     @StateObject private var graphic: Graphic
@@ -43,36 +41,56 @@ public struct OverviewMap: View {
     /// - Parameters:
     ///   - viewpoint: Viewpoint of the main `MapView` used to update the `OverviewMap` view.
     ///   - visibleArea: Visible area of the main `MapView ` used to display the extent graphic.
+    ///   - map: The `Map` displayed in the `OverviewMap`. Defaults to `nil`, in which case
+    ///   a map with the `arcGISTopographic` basemap style is used.
     /// - Returns: A new `OverviewMap`.
     public static func forMapView(
         with viewpoint: Viewpoint?,
-        visibleArea: ArcGIS.Polygon?
+        visibleArea: ArcGIS.Polygon?,
+        map: Map? = nil
     ) -> OverviewMap {
-        OverviewMap(viewpoint: viewpoint, visibleArea: visibleArea, symbol: .defaultFill)
+        OverviewMap(
+            viewpoint: viewpoint,
+            visibleArea: visibleArea,
+            symbol: .defaultFill,
+            map: map
+        )
     }
-    
+
     /// Creates an `OverviewMap` for use on a `SceneView`.
-    /// - Parameter viewpoint: Viewpoint of the main `SceneView` used to update the
+    /// - Parameters:
+    ///   - viewpoint: Viewpoint of the main `SceneView` used to update the
     /// `OverviewMap` view.
+    ///   - map: The `Map` displayed in the `OverviewMap`. Defaults to `nil`, in which case
+    ///   a map with the `arcGISTopographic` basemap style is used.
     /// - Returns: A new `OverviewMap`.
     public static func forSceneView(
-        with viewpoint: Viewpoint?
+        with viewpoint: Viewpoint?,
+        map: Map? = nil
     ) -> OverviewMap {
-        OverviewMap(viewpoint: viewpoint, symbol: .defaultMarker)
+        OverviewMap(viewpoint: viewpoint, symbol: .defaultMarker, map: map)
     }
     
     /// Creates an `OverviewMap`. Used for creating an `OverviewMap` for use on a `MapView`.
     /// - Parameters:
     ///   - viewpoint: Viewpoint of the main `GeoView` used to update the `OverviewMap` view.
     ///   - visibleArea: Visible area of the main `GeoView` used to display the extent graphic.
+    ///   - map: The `Map` displayed in the `OverviewMap`.
     init(
         viewpoint: Viewpoint?,
         visibleArea: ArcGIS.Polygon? = nil,
-        symbol: Symbol
+        symbol: Symbol,
+        map: Map?
     ) {
         self.visibleArea = visibleArea
         self.viewpoint = viewpoint
         self.symbol = symbol
+        
+        _dataModel = StateObject(
+            wrappedValue: MapDataModel(
+                map: map ?? Map(basemapStyle: .arcGISTopographic)
+            )
+        )
         
         let graphic = Graphic(symbol: self.symbol)
         
@@ -129,14 +147,6 @@ public struct OverviewMap: View {
     }
     
     // MARK: Modifiers
-    
-    /// The `Map` displayed in the `OverviewMap`.
-    /// - Parameter map: The new map.
-    /// - Returns: The `OverviewMap`.
-    public func map(_ map: Map) -> OverviewMap {
-        self.dataModel.map = map
-        return self
-    }
     
     /// The factor to multiply the main `GeoView`'s scale by.  The `OverviewMap` will display
     /// at the a scale equal to: `viewpoint.targetScale` x `scaleFactor`.


### PR DESCRIPTION
Closes https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/225

This removes the `.map` modifier on `OverviewMap` and replaces it with a `map` argument on both `OverviewMap.forSceneView` and `OverviewMap.forMapView`. The argument defaults to `nil`, in which case the existing default map is used.

It also removes the unnecessary distinction between `customOverviewMapForMapView` and `customOverviewMapForSceneView` and replaces them with just one custom map: `customOverviewMap`.