### PR TITLE
Floor Filter - Fix ability to reselect same site

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -122,6 +122,7 @@ struct SiteAndFacilitySelector: View {
                         },
                         set: { newSite in
                             guard let newSite = newSite else { return }
+                            userBackedOutOfSelectedSite = false
                             viewModel.setSite(newSite, zoomTo: true)
                         }
                     )


### PR DESCRIPTION
Closes #229 

Leaving `userBackedOutOfSelectedSite` set `true` caused the computed binding above on line 121 to return `nil` when it shouldn't have. It was being left `true` because the `.onChange` modifier below at line 148 wasn't firing if the same site was selected as before. 