### PR TITLE
Fix build errors in `SearchViewModelTests.swift`

### DIFF
--- a/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
@@ -446,27 +446,33 @@ extension SearchViewModelTests {
     }
 }
 
-extension Polygon {
-    static let chippewaFalls: Polygon = {
-        let builder = PolygonBuilder(spatialReference: .wgs84)
-        _ = builder.add(Point(x: -91.59127653822401, y: 44.74770908213401, spatialReference: .wgs84))
-        _ = builder.add(Point(x: -91.19322516572637, y: 44.74770908213401, spatialReference: .wgs84))
-        _ = builder.add(Point(x: -91.19322516572637, y: 45.116100854348254, spatialReference: .wgs84))
-        _ = builder.add(Point(x: -91.59127653822401, y: 45.116100854348254, spatialReference: .wgs84))
-        return builder.toGeometry()
-    }()
+extension ArcGIS.Polygon {
+    class var chippewaFalls: ArcGIS.Polygon {
+        let points = [
+            Point(x: -91.59127653822401, y: 44.74770908213401),
+            Point(x: -91.19322516572637, y: 44.74770908213401),
+            Point(x: -91.19322516572637, y: 45.116100854348254),
+            Point(x: -91.59127653822401, y: 45.116100854348254)
+        ]
+        return .init(points: points, spatialReference: .wgs84)
+    }
     
-    static let minneapolis: Polygon = {
-        let builder = PolygonBuilder(spatialReference: .wgs84)
-        _ = builder.add(Point(x: -94.170821328662, y: 44.13656401114444, spatialReference: .wgs84))
-        _ = builder.add(Point(x: -94.170821328662, y: 44.13656401114444, spatialReference: .wgs84))
-        _ = builder.add(Point(x: -92.34544467133114, y: 45.824325577904446, spatialReference: .wgs84))
-        _ = builder.add(Point(x: -92.34544467133114, y: 45.824325577904446, spatialReference: .wgs84))
-        return builder.toGeometry()
-    }()
+    class var minneapolis: ArcGIS.Polygon {
+        let points = [
+            Point(x: -94.170821328662, y: 44.13656401114444),
+            Point(x: -94.170821328662, y: 44.13656401114444),
+            Point(x: -92.34544467133114, y: 45.824325577904446),
+            Point(x: -92.34544467133114, y: 45.824325577904446)
+        ]
+        return .init(points: points, spatialReference: .wgs84)
+    }
 }
 
 extension Point {
-    static let edinburgh = Point(x: -3.188267, y: 55.953251, spatialReference: .wgs84)
-    static let portland = Point(x: -122.658722, y: 45.512230, spatialReference: .wgs84)
+    class var edinburgh: Point {
+        .init(x: -3.188267, y: 55.953251, spatialReference: .wgs84)
+    }
+    class var portland: Point {
+        .init(x: -122.658722, y: 45.512230, spatialReference: .wgs84)
+    }
 }


### PR DESCRIPTION
Some of the references to `Polygon` were not qualified when they needed to be, so they were resolving to the `Polygon` type in the Application Services framework. While I was at it, I made the geometries computed so that they don't stick around longer than necessary. We've also seen problems with re-using geometries.