### PR TITLE
Latest API changes

### DIFF
--- a/Documentation/Search/README.md
+++ b/Documentation/Search/README.md
@@ -40,10 +40,10 @@ public protocol SearchSource {
     var name: String { get set }
 
     /// The maximum results to return when performing a search. Most sources default to `6`.
-    var maximumResults: Int32 { get set }
+    var maximumResults: Int { get set }
 
     /// The maximum suggestions to return. Most sources default to `6`.
-    var maximumSuggestions: Int32 { get set }
+    var maximumSuggestions: Int { get set }
 
     /// Returns the search suggestions for the specified query.
     /// - Parameters:

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "arcgis-maps-sdk-swift", path: "../swift/ArcGIS")
+        .package(url: "https://github.com/Esri/arcgis-maps-sdk-swift", .upToNextMinor(from: "200.0.0-beta"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/Esri/arcgis-maps-sdk-swift", .upToNextMinor(from: "200.0.0-beta"))
+        .package(name: "arcgis-maps-sdk-swift", path: "../swift/ArcGIS")
     ],
     targets: [
         .target(

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartData.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartData.swift
@@ -28,9 +28,7 @@ struct ChartData: Identifiable {
     ///   - value: The value of the data.
     init(label: String, value: Any) {
         self.label = label
-        if let int32 = value as? Int32 {
-            self.value = Double(int32)
-        } else if let int = value as? Int {
+        if let int = value as? Int {
             self.value = Double(int)
         } else if let float = value as? Float {
             self.value = Double(float)

--- a/Sources/ArcGISToolkit/Components/Search/LocatorSearchSource.swift
+++ b/Sources/ArcGISToolkit/Components/Search/LocatorSearchSource.swift
@@ -30,8 +30,8 @@ public class LocatorSearchSource: ObservableObject, SearchSource {
                 string: "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"
             )!
         ),
-        maximumResults: Int32 = 6,
-        maximumSuggestions: Int32 = 6
+        maximumResults: Int = 6,
+        maximumSuggestions: Int = 6
     ) {
         self.name = name
         self.locatorTask = locatorTask
@@ -45,13 +45,13 @@ public class LocatorSearchSource: ObservableObject, SearchSource {
     public var name: String
     
     /// The maximum results to return when performing a search. Most sources default to `6`.
-    public var maximumResults: Int32 {
+    public var maximumResults: Int {
         get { geocodeParameters.maxResults }
         set { geocodeParameters.maxResults = newValue }
     }
     
     /// The maximum suggestions to return. Most sources default to `6`.
-    public var maximumSuggestions: Int32 {
+    public var maximumSuggestions: Int {
         get { suggestParameters.maxResults }
         set { suggestParameters.maxResults = newValue }
     }

--- a/Sources/ArcGISToolkit/Components/Search/SearchSource.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchSource.swift
@@ -19,10 +19,10 @@ public protocol SearchSource {
     var name: String { get set }
     
     /// The maximum results to return when performing a search. Most sources default to `6`.
-    var maximumResults: Int32 { get set }
+    var maximumResults: Int { get set }
     
     /// The maximum suggestions to return. Most sources default to `6`.
-    var maximumSuggestions: Int32 { get set }
+    var maximumSuggestions: Int { get set }
     
     /// Returns the search suggestions for the specified query.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Components/Search/SmartLocatorSearchSource.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SmartLocatorSearchSource.swift
@@ -26,8 +26,8 @@ public class SmartLocatorSearchSource: LocatorSearchSource {
     ///   - repeatSuggestResultThreshold: The minimum number of suggestions to attempt to return.
     public init(
         name: String = "Smart Locator",
-        maximumResults: Int32 = 6,
-        maximumSuggestions: Int32 = 6,
+        maximumResults: Int = 6,
+        maximumSuggestions: Int = 6,
         repeatSearchResultThreshold: Int? = 1,
         repeatSuggestResultThreshold: Int? = 6
     ) {


### PR DESCRIPTION
Use `Int` instead of `Int32` in the `SearchSource` related types.