### PR TITLE
Build fix for `Bookmarks`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -82,9 +82,9 @@ public struct Bookmarks: View {
         bookmarks: [Bookmark],
         viewpoint: Binding<Viewpoint?>? = nil
     ) {
+        _isPresented = isPresented
         self.bookmarks = bookmarks
         self.viewpoint = viewpoint
-        _isPresented = isPresented
     }
     
     /// Creates a `Bookmarks` component.


### PR DESCRIPTION
When building `v.next` with the latest daily binaries, a build error arises in `Bookmarks.swift` that isn't present with building with source.

This area hasn't changed since beta and so I presume the compiler has become more strict in this area.

This can be tested by switching the SDK dependency to the Swift daily repo.