### PR TITLE
updated authentication example and auth manager extension

### DIFF
--- a/AuthenticationExample/AuthenticationExample/ProfileView.swift
+++ b/AuthenticationExample/AuthenticationExample/ProfileView.swift
@@ -17,9 +17,6 @@ import ArcGISToolkit
 
 /// A view that displays the profile of a user.
 struct ProfileView: View {
-    /// The authenticator that has been passed through the environment down to the app.
-    @EnvironmentObject var authenticator: Authenticator
-    
     /// The portal that the user is signed in to.
     @State var portal: Portal
     

--- a/AuthenticationExample/AuthenticationExample/SignInView.swift
+++ b/AuthenticationExample/AuthenticationExample/SignInView.swift
@@ -17,10 +17,7 @@ import ArcGISToolkit
 import CryptoKit
 
 /// A view that allows the user to sign in to a portal.
-struct SignInView: View {
-    /// The authenticator which has been passed from the app through the environment.
-    @EnvironmentObject var authenticator: Authenticator
-    
+struct SignInView: View {    
     /// The error that occurred during an attempt to sign in.
     @State var error: Error?
     

--- a/Sources/ArcGISToolkit/Components/Authentication/AuthenticationManager.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/AuthenticationManager.swift
@@ -16,8 +16,9 @@ import ArcGIS
 public extension AuthenticationManager {
     /// Sets up authenticator as ArcGIS and Network challenge handlers to handle authentication
     /// challenges.
-    /// - Parameter authenticator: The authenticator to be used for handling challenges.
-    func handleChallenges(using authenticator: Authenticator) {
+    /// - Parameter authenticator: The authenticator to be used for handling challenges or `nil` to
+    /// reset the challenge handlers.
+    func handleChallenges(using authenticator: Authenticator?) {
         arcGISAuthenticationChallengeHandler = authenticator
         networkAuthenticationChallengeHandler = authenticator
     }


### PR DESCRIPTION
- Made `AuthenticationManager .handleChallenges` function to take optional so reset challenge handlers
- Two views were not using the `@EnvironmentObject authenticator` so removed.

cc: @yo1995 