### PR TITLE
[Compass] Add `action` parameter

### DIFF
--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -23,9 +23,10 @@ Compass:
     /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
+    ///   - action: An action to perform when the compass is tapped.
     ///   - autoHide: A Boolean value that determines whether the compass
     ///   automatically hides itself when the heading is `0`.
-    public init(heading: Binding<Double>, autoHide: Bool = true)
+    public init(heading: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
 
 ```swift
@@ -35,18 +36,20 @@ Compass:
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
+    ///   - action: An action to perform when the compass is tapped.
     ///   - autoHide: A Boolean value that determines whether the compass
     ///   automatically hides itself when the viewpoint rotation is 0 degrees.
-    public init(viewpointRotation: Binding<Double>, autoHide: Bool = true)
+    public init(viewpointRotation: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
 
 ```swift
     /// Creates a compass with a binding to an optional viewpoint.
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
+    ///   - action: An action to perform when the compass is tapped.
     ///   - autoHide: A Boolean value that determines whether the compass automatically hides itself
     ///   when the viewpoint's rotation is 0 degrees.
-    public init(viewpoint: Binding<Viewpoint?>, autoHide: Bool = true)
+    public init(viewpoint: Binding<Viewpoint?>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
 
 `Compass` has the following modifier:

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -15,7 +15,48 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
+/// An example demonstrating how to use a compass in three different environments.
 struct CompassExampleView: View {
+    /// A scenario represents a type of environment a compass may be used in.
+    enum Scenario: CaseIterable {
+        case map
+        case sceneWithCamera
+        case sceneWithCameraController
+        
+        /// A human-readable label for the scenario.
+        var label: String {
+            switch self {
+            case .map: return "Map"
+            case .sceneWithCamera: return "Scene with camera"
+            case .sceneWithCameraController: return "Scene with camera controller"
+            }
+        }
+    }
+    
+    /// The active scenario.
+    @State private var scenario = Scenario.map
+    
+    var body: some View {
+        VStack {
+            switch scenario {
+            case.map:
+                MapWithViewpoint()
+            case .sceneWithCamera:
+                SceneWithCamera()
+            case .sceneWithCameraController:
+                SceneWithCameraController()
+            }
+            Picker("Scenario", selection: $scenario) {
+                ForEach(Scenario.allCases, id: \.self) { scen in
+                    Text(scen.label)
+                }
+            }
+        }
+    }
+}
+
+/// An example demonstrating how to use a compass with a map view.
+struct MapWithViewpoint: View {
     /// The data model containing the `Map` displayed in the `MapView`.
     @StateObject private var dataModel = MapDataModel(
         map: Map(basemapStyle: .arcGISImagery)
@@ -23,19 +64,129 @@ struct CompassExampleView: View {
     
     /// Allows for communication between the Compass and MapView or SceneView.
     @State private var viewpoint: Viewpoint? = Viewpoint(
-        center: Point(x: -117.19494, y: 34.05723, spatialReference: .wgs84),
+        center: .esriRedlands,
         scale: 10_000,
         rotation: -45
     )
     
     var body: some View {
-        MapView(map: dataModel.map, viewpoint: viewpoint)
-            .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
-            .overlay(alignment: .topTrailing) {
-                Compass(viewpoint: $viewpoint)
+        MapViewReader { mapViewProxy in
+            MapView(map: dataModel.map, viewpoint: viewpoint)
+                .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
+                .overlay(alignment: .topTrailing) {
+                    Compass(viewpoint: $viewpoint)
                     // Optionally provide a different size for the compass.
-                    // .compassSize(size: <#T##CGFloat#>)
-                    .padding()
+                    //    .compassSize(size: T##CGFloat)
+                        .padding()
+                        .onTapGesture {
+                            Task {
+                                try? await mapViewProxy.setViewpointRotation(0)
+                            }
+                        }
+                }
+        }
+    }
+}
+
+/// An example demonstrating how to use a compass with a scene view and camera.
+struct SceneWithCamera: View {
+    /// The camera used by the scene view.
+    @State private var camera: Camera? = Camera(
+        lookingAt: .esriRedlands,
+        distance: 1_000,
+        heading: 45,
+        pitch: 45,
+        roll: .zero
+    )
+    
+    /// The data model containing the `Scene` displayed in the `SceneView`.
+    @StateObject private var dataModel = SceneDataModel(
+        scene: Scene(basemapStyle: .arcGISImagery)
+    )
+    
+    /// The current heading as reported by the scene view.
+    var heading: Binding<Double> {
+        Binding {
+            if let camera {
+                return camera.heading
+            } else {
+                return .zero
             }
+        } set: { _ in
+        }
+    }
+    
+    var body: some View {
+        SceneViewReader { sceneViewProxy in
+            SceneView(scene: dataModel.scene, camera: $camera)
+                .overlay(alignment: .topTrailing) {
+                    Compass(viewpointRotation: heading)
+                        .padding()
+                        .onTapGesture {
+                            if let camera {
+                                let newCamera = Camera(
+                                    location: camera.location,
+                                    heading: .zero,
+                                    pitch: camera.pitch,
+                                    roll: camera.roll
+                                )
+                                Task {
+                                    try? await sceneViewProxy.setViewpointCamera(
+                                        newCamera,
+                                        duration: 0.3
+                                    )
+                                }
+                            }
+                        }
+                }
+        }
+    }
+}
+
+/// An example demonstrating how to use a compass with a scene view and camera controller.
+struct SceneWithCameraController: View {
+    /// The data model containing the `Scene` displayed in the `SceneView`.
+    @StateObject private var dataModel = SceneDataModel(
+        scene: Scene(basemapStyle: .arcGISImagery)
+    )
+    
+    /// The current heading as reported by the scene view.
+    @State private var heading: Double = .zero
+    
+    /// The orbit location camera controller used by the scene view.
+    private let cameraController = OrbitLocationCameraController(
+        targetPoint: .esriRedlands,
+        distance: 10_000
+    )!
+    
+    var body: some View {
+        SceneView(scene: dataModel.scene, cameraController: cameraController)
+            .onCameraChanged { newCamera in
+                heading = newCamera.heading.rounded()
+            }
+            .overlay(alignment: .topTrailing) {
+                Compass(viewpointRotation: $heading)
+                    .padding()
+                    .onTapGesture {
+                        Task {
+                            try? await cameraController.moveCamera(
+                                distanceDelta: .zero,
+                                headingDelta: heading > 180 ? 360 - heading : -heading,
+                                pitchDelta: .zero,
+                                duration: 0.3
+                            )
+                        }
+                    }
+            }
+    }
+}
+
+private extension Point {
+    static var esriRedlands: Point {
+        .init(
+            x: -117.19494,
+            y: 34.05723,
+            spatialReference: .wgs84
+        )
     }
 }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -57,10 +57,8 @@ struct CompassExampleView: View {
 
 /// An example demonstrating how to use a compass with a map view.
 struct MapWithViewpoint: View {
-    /// The data model containing the `Map` displayed in the `MapView`.
-    @StateObject private var dataModel = MapDataModel(
-        map: Map(basemapStyle: .arcGISImagery)
-    )
+    /// The `Map` displayed in the `MapView`.
+    @State private var map = Map(basemapStyle: .arcGISImagery)
     
     /// Allows for communication between the Compass and MapView or SceneView.
     @State private var viewpoint: Viewpoint? = Viewpoint(
@@ -71,12 +69,10 @@ struct MapWithViewpoint: View {
     
     var body: some View {
         MapViewReader { mapViewProxy in
-            MapView(map: dataModel.map, viewpoint: viewpoint)
+            MapView(map: map, viewpoint: viewpoint)
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
                     Compass(viewpoint: $viewpoint)
-                    // Optionally provide a different size for the compass.
-                    //    .compassSize(size: T##CGFloat)
                         .padding()
                         .onTapGesture {
                             Task {
@@ -146,12 +142,10 @@ struct SceneWithCamera: View {
 /// An example demonstrating how to use a compass with a scene view and camera controller.
 struct SceneWithCameraController: View {
     /// The data model containing the `Scene` displayed in the `SceneView`.
-    @StateObject private var dataModel = SceneDataModel(
-        scene: Scene(basemapStyle: .arcGISImagery)
-    )
+    @State private var scene = Scene(basemapStyle: .arcGISImagery)
     
     /// The current heading as reported by the scene view.
-    @State private var heading: Double = .zero
+    @State private var heading = Double.zero
     
     /// The orbit location camera controller used by the scene view.
     private let cameraController = OrbitLocationCameraController(
@@ -160,7 +154,7 @@ struct SceneWithCameraController: View {
     )
     
     var body: some View {
-        SceneView(scene: dataModel.scene, cameraController: cameraController)
+        SceneView(scene: scene, cameraController: cameraController)
             .onCameraChanged { newCamera in
                 heading = newCamera.heading.rounded()
             }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -18,34 +18,39 @@ import SwiftUI
 /// An example demonstrating how to use a compass in three different environments.
 struct CompassExampleView: View {
     /// A scenario represents a type of environment a compass may be used in.
-    enum Scenario: CaseIterable {
+    enum Scenario: String {
         case map
-        case sceneWithCameraController
-        
-        /// A human-readable label for the scenario.
-        var label: String {
-            switch self {
-            case .map: return "Map"
-            case .sceneWithCameraController: return "Scene with camera controller"
-            }
-        }
+        case scene
     }
     
     /// The active scenario.
     @State private var scenario = Scenario.map
     
     var body: some View {
-        VStack {
+        Group {
             switch scenario {
-            case.map:
+            case .map:
                 MapWithViewpoint()
-            case .sceneWithCameraController:
+            case .scene:
                 SceneWithCameraController()
             }
-            Picker("Scenario", selection: $scenario) {
-                ForEach(Scenario.allCases, id: \.self) { scen in
-                    Text(scen.label)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu(scenario.rawValue.capitalized) {
+                    Button {
+                        scenario = .map
+                    } label: {
+                        Label("Map", systemImage: "map.fill")
+                    }
+                    
+                    Button {
+                        scenario = .scene
+                    } label: {
+                        Label("Scene", systemImage: "globe.americas.fill")
+                    }
                 }
+                .labelStyle(.titleAndIcon)
             }
         }
     }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -155,9 +155,9 @@ struct SceneWithCameraController: View {
     
     /// The orbit location camera controller used by the scene view.
     private let cameraController = OrbitLocationCameraController(
-        targetPoint: .esriRedlands,
+        target: .esriRedlands,
         distance: 10_000
-    )!
+    )
     
     var body: some View {
         SceneView(scene: dataModel.scene, cameraController: cameraController)

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -17,10 +17,6 @@ import SwiftUI
 /// A `Compass` (alias North arrow) shows where north is in a `MapView` or
 /// `SceneView`.
 public struct Compass: View {
-    /// A Boolean value indicating whether  the compass should automatically
-    /// hide/show itself when the heading is `0`.
-    private let autoHide: Bool
-    
     /// The last time the compass was tapped.
     @State private var lastTapTime: Date?
     
@@ -28,16 +24,20 @@ public struct Compass: View {
     @State private var opacity: Double = .zero
     
     /// An action to perform when the compass is tapped.
-    private var action: (() async -> Void)?
+    private let action: (() async -> Void)?
+    
+    /// A Boolean value indicating whether  the compass should automatically
+    /// hide/show itself when the heading is `0`.
+    private let autoHide: Bool
     
     /// A Boolean value indicating whether the compass should hide based on the
     ///  current heading and whether the compass automatically hides.
-    var shouldHide: Bool {
+    private var shouldHide: Bool {
         (heading.isZero || heading.isNaN) && autoHide
     }
     
     /// The width and height of the compass.
-    var size: CGFloat = 44
+    private var size: CGFloat = 44
     
     /// The heading of the compass in degrees.
     @Binding private var heading: Double

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -29,7 +29,7 @@ public struct Compass: View {
     
     /// A Boolean value indicating whether the compass should hide based on the
     ///  current heading and whether the compass automatically hides.
-    private var shouldHide: Bool {
+    var shouldHide: Bool {
         (heading.isZero || heading.isNaN) && autoHide
     }
     

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -17,9 +17,6 @@ import SwiftUI
 /// A `Compass` (alias North arrow) shows where north is in a `MapView` or
 /// `SceneView`.
 public struct Compass: View {
-    /// The last time the compass was tapped.
-    @State private var lastTapTime: Date?
-    
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
@@ -78,15 +75,14 @@ public struct Compass: View {
                         opacity = newOpacity
                     }
                 }
-                .onTapGesture { lastTapTime = .now }
-                .accessibilityLabel("Compass, heading \(Int(heading.rounded())) degrees \(CompassDirection(heading).rawValue)")
-                .task(id: lastTapTime) {
+                .onTapGesture {
                     if let action {
-                        await action()
+                        Task { await action() }
                     } else {
                         heading = .zero
                     }
                 }
+                .accessibilityLabel("Compass, heading \(Int(heading.rounded())) degrees \(CompassDirection(heading).rawValue)")
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -60,7 +60,6 @@ public struct Compass: View {
                 }
                 .aspectRatio(1, contentMode: .fit)
                 .opacity(opacity)
-                .onTapGesture { heading = .zero }
                 .frame(width: size, height: size)
                 .onChange(of: heading) { _ in
                     let newOpacity: Double = shouldHide ? .zero : 1


### PR DESCRIPTION
Closes #25, #266

- Adds an optional `action` parameter to the Compass initializer(s) that takes an async task. This allows users to perform animated heading changes. If no `action` is provided, behavior remains unchanged.
- The name "`action`" is borrowed from [`Button.init(action:label:)`](https://developer.apple.com/documentation/swiftui/button/init(action:label:))