### PR TITLE
Utility Network Trace - Improve identification

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -615,7 +615,7 @@ public struct UtilityNetworkTrace: View {
             currentActivity = .creatingTrace(.viewingStartingPoints)
             activeDetent = .half
             Task {
-                await viewModel.addStartingPoint(
+                await viewModel.addStartingPoints(
                     at: viewPoint,
                     mapPoint: mapPoint,
                     with: mapViewProxy

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
@@ -132,7 +132,7 @@ import SwiftUI
         
         var identifyLayerResults = [IdentifyLayerResult]()
         
-        for layer in layers ?? [] {
+        for layer in network?.layers ?? [] {
             if let r = await identify(layer, point) {
                 identifyLayerResults.append(r)
             }
@@ -147,10 +147,6 @@ import SwiftUI
                 await processAndAdd(startingPoint: startingPoint)
             }
         }
-    }
-    
-    var layers: [Layer]? {
-        network?.definition?.networkSources.compactMap { $0.featureTable.layer }
     }
     
     /// Deletes all of the completed traces.
@@ -519,5 +515,11 @@ extension UtilityNetworkTraceViewModel {
             fractionalLengthClosestTo: point,
             tolerance: 10
         )
+    }
+}
+
+extension UtilityNetwork {
+    var layers: [Layer] {
+        definition?.networkSources.compactMap { $0.featureTable.layer } ?? []
     }
 }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
@@ -505,6 +505,7 @@ extension UtilityNetworkTraceViewModel {
 }
 
 extension UtilityNetwork {
+    /// The defined in the network.
     var layers: [Layer] {
         definition?.networkSources.compactMap { $0.featureTable.layer } ?? []
     }


### PR DESCRIPTION
Closes #269 

- Refactors `UtilityNetworkTraceViewModel.addStartingPoint(at:mapPoint:with:)` into a new func `addStartingPoints(at:mapPoint:with:)` where we only run an identify operation on the layers within the utility network.
- The method is renamed to a plural form because it has the potential to add multiple starting points.