### PR TITLE
Mhd/refactor compass action

### DIFF
--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -25,7 +25,7 @@ Compass:
     /// - Parameters:
     ///   - heading: The heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    public init(heading: Binding<Double>, action: (() async -> Void)? = nil)
+    public init(heading: Binding<Double>, action: (() -> Void)? = nil)
 ```
 
 ```swift
@@ -36,7 +36,7 @@ Compass:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    public init(viewpointRotation: Binding<Double>, action: (() async -> Void)? = nil)
+    public init(viewpointRotation: Binding<Double>, action: (() -> Void)? = nil)
 ```
 
 ```swift
@@ -44,7 +44,7 @@ Compass:
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    public init(viewpoint: Binding<Viewpoint?>, action: (() async -> Void)? = nil)
+    public init(viewpoint: Binding<Viewpoint?>, action: (() -> Void)? = nil)
 ```
 
 `Compass` has the following modifiers:

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -23,9 +23,10 @@ Compass:
     /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
+    ///   - action: An action to perform when the compass is tapped.
     ///   - autoHide: A Boolean value that determines whether the compass
     ///   automatically hides itself when the heading is `0`.
-    public init(heading: Binding<Double>, autoHide: Bool = true)
+    public init(heading: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
 
 ```swift
@@ -35,18 +36,20 @@ Compass:
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
+    ///   - action: An action to perform when the compass is tapped.
     ///   - autoHide: A Boolean value that determines whether the compass
     ///   automatically hides itself when the viewpoint rotation is 0 degrees.
-    public init(viewpointRotation: Binding<Double>, autoHide: Bool = true)
+    public init(viewpointRotation: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
 
 ```swift
     /// Creates a compass with a binding to an optional viewpoint.
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
+    ///   - action: An action to perform when the compass is tapped.
     ///   - autoHide: A Boolean value that determines whether the compass automatically hides itself
     ///   when the viewpoint's rotation is 0 degrees.
-    public init(viewpoint: Binding<Viewpoint?>, autoHide: Bool = true)
+    public init(viewpoint: Binding<Viewpoint?>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
 
 `Compass` has the following modifier:

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -50,7 +50,7 @@ Compass:
 `Compass` has the following modifiers:
 
 - `func compassSize(size: CGFloat)` - The size of the `Compass`, specifying both the width and height of the compass.
-- `func automaticallyHides(newAutomaticallyHides: Bool)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
+- `func automaticallyHides(_:)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
 
 ## Behavior:
 

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -10,7 +10,8 @@ The ArcGIS Maps SDK for Swift currently supports rotating MapViews and SceneView
 
 Compass:
 
-- Can be configured to automatically hide when the rotation is zero.
+- Automatically hides when the rotation is zero.
+- Can be configured to be always visible.
 - Will reset the map/scene rotation to North when tapped on.
 
 ## Key properties
@@ -24,8 +25,7 @@ Compass:
     /// - Parameters:
     ///   - heading: The heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   automatically hides itself when the heading is `0`.
-    public init(heading: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
+    public init(heading: Binding<Double>, action: (() async -> Void)? = nil)
 ```
 
 ```swift
@@ -36,8 +36,7 @@ Compass:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   automatically hides itself when the viewpoint rotation is 0 degrees.
-    public init(viewpointRotation: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
+    public init(viewpointRotation: Binding<Double>, action: (() async -> Void)? = nil)
 ```
 
 ```swift
@@ -45,17 +44,17 @@ Compass:
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   when the viewpoint's rotation is 0 degrees.
-    public init(viewpoint: Binding<Viewpoint?>, action: (() async -> Void)? = nil, autoHide: Bool = true)
+    public init(viewpoint: Binding<Viewpoint?>, action: (() async -> Void)? = nil)
 ```
 
-`Compass` has the following modifier:
+`Compass` has the following modifiers:
 
 - `func compassSize(size: CGFloat)` - The size of the `Compass`, specifying both the width and height of the compass.
+- `func automaticallyHides(newAutomaticallyHides: Bool)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
 
 ## Behavior:
 
-Whenever the map is not orientated North (non-zero bearing) the compass appears. When reset to north, it disappears. An initializer argument allows you to disable the auto-hide feature so that it always appears.
+Whenever the map is not orientated North (non-zero bearing) the compass appears. When reset to north, it disappears. The `automaticallyHides` view modifier allows you to disable the auto-hide feature so that it is always displayed.
 
 When the compass is tapped, the map orients back to north (zero bearing).
 

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -24,7 +24,6 @@ Compass:
     /// - Parameters:
     ///   - heading: The heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   - autoHide: A Boolean value that determines whether the compass
     ///   automatically hides itself when the heading is `0`.
     public init(heading: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
@@ -37,7 +36,6 @@ Compass:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   - autoHide: A Boolean value that determines whether the compass
     ///   automatically hides itself when the viewpoint rotation is 0 degrees.
     public init(viewpointRotation: Binding<Double>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```
@@ -47,7 +45,6 @@ Compass:
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   - autoHide: A Boolean value that determines whether the compass automatically hides itself
     ///   when the viewpoint's rotation is 0 degrees.
     public init(viewpoint: Binding<Viewpoint?>, action: (() async -> Void)? = nil, autoHide: Bool = true)
 ```

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -74,11 +74,13 @@ struct MapWithViewpoint: View {
                 .overlay(alignment: .topTrailing) {
                     Compass(viewpoint: $viewpoint) {
                         guard let viewpoint else { return }
-                        // Animate the map view to zero when the compass is tapped.
-                        await proxy.setViewpoint(
-                            viewpoint.withRotation(0),
-                            duration: 0.25
-                        )
+                        Task {
+                            // Animate the map view to zero when the compass is tapped.
+                            await proxy.setViewpoint(
+                                viewpoint.withRotation(0),
+                                duration: 0.25
+                            )
+                        }
                     }
                     .padding()
                 }
@@ -108,12 +110,14 @@ struct SceneWithCameraController: View {
             .overlay(alignment: .topTrailing) {
                 Compass(viewpointRotation: $heading) {
                     // Animate the scene view when the compass is tapped.
-                    _ = try? await cameraController.moveCamera(
-                        distanceDelta: .zero,
-                        headingDelta: heading > 180 ? 360 - heading : -heading,
-                        pitchDelta: .zero,
-                        duration: 0.3
-                    )
+                    Task {
+                        _ = try? await cameraController.moveCamera(
+                            distanceDelta: .zero,
+                            headingDelta: heading > 180 ? 360 - heading : -heading,
+                            pitchDelta: .zero,
+                            duration: 0.3
+                        )
+                    }
                 }
                 .padding()
             }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -50,7 +50,6 @@ struct CompassExampleView: View {
                         Label("Scene", systemImage: "globe.americas.fill")
                     }
                 }
-                .labelStyle(.titleAndIcon)
             }
         }
     }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -15,7 +15,48 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
+/// An example demonstrating how to use a compass in three different environments.
 struct CompassExampleView: View {
+    /// A scenario represents a type of environment a compass may be used in.
+    enum Scenario: CaseIterable {
+        case map
+        case sceneWithCamera
+        case sceneWithCameraController
+        
+        /// A human-readable label for the scenario.
+        var label: String {
+            switch self {
+            case .map: return "Map"
+            case .sceneWithCamera: return "Scene with camera"
+            case .sceneWithCameraController: return "Scene with camera controller"
+            }
+        }
+    }
+    
+    /// The active scenario.
+    @State private var scenario = Scenario.map
+    
+    var body: some View {
+        VStack {
+            switch scenario {
+            case.map:
+                MapWithViewpoint()
+            case .sceneWithCamera:
+                SceneWithCamera()
+            case .sceneWithCameraController:
+                SceneWithCameraController()
+            }
+            Picker("Scenario", selection: $scenario) {
+                ForEach(Scenario.allCases, id: \.self) { scen in
+                    Text(scen.label)
+                }
+            }
+        }
+    }
+}
+
+/// An example demonstrating how to use a compass with a map view.
+struct MapWithViewpoint: View {
     /// The data model containing the `Map` displayed in the `MapView`.
     @StateObject private var dataModel = MapDataModel(
         map: Map(basemapStyle: .arcGISImagery)
@@ -23,19 +64,129 @@ struct CompassExampleView: View {
     
     /// Allows for communication between the Compass and MapView or SceneView.
     @State private var viewpoint: Viewpoint? = Viewpoint(
-        center: Point(x: -117.19494, y: 34.05723, spatialReference: .wgs84),
+        center: .esriRedlands,
         scale: 10_000,
         rotation: -45
     )
     
     var body: some View {
-        MapView(map: dataModel.map, viewpoint: viewpoint)
-            .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
-            .overlay(alignment: .topTrailing) {
-                Compass(viewpoint: $viewpoint)
+        MapViewReader { mapViewProxy in
+            MapView(map: dataModel.map, viewpoint: viewpoint)
+                .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
+                .overlay(alignment: .topTrailing) {
+                    Compass(viewpoint: $viewpoint)
                     // Optionally provide a different size for the compass.
-                    // .compassSize(size: <#T##CGFloat#>)
-                    .padding()
+                    //    .compassSize(size: T##CGFloat)
+                        .padding()
+                        .onTapGesture {
+                            Task {
+                                try? await mapViewProxy.setViewpointRotation(0)
+                            }
+                        }
+                }
+        }
+    }
+}
+
+/// An example demonstrating how to use a compass with a scene view and camera.
+struct SceneWithCamera: View {
+    /// The camera used by the scene view.
+    @State private var camera: Camera? = Camera(
+        lookingAt: .esriRedlands,
+        distance: 1_000,
+        heading: 45,
+        pitch: 45,
+        roll: .zero
+    )
+    
+    /// The data model containing the `Scene` displayed in the `SceneView`.
+    @StateObject private var dataModel = SceneDataModel(
+        scene: Scene(basemapStyle: .arcGISImagery)
+    )
+    
+    /// The current heading as reported by the scene view.
+    var heading: Binding<Double> {
+        Binding {
+            if let camera {
+                return camera.heading
+            } else {
+                return .zero
             }
+        } set: { _ in
+        }
+    }
+    
+    var body: some View {
+        SceneViewReader { sceneViewProxy in
+            SceneView(scene: dataModel.scene, camera: $camera)
+                .overlay(alignment: .topTrailing) {
+                    Compass(viewpointRotation: heading)
+                        .padding()
+                        .onTapGesture {
+                            if let camera {
+                                let newCamera = Camera(
+                                    location: camera.location,
+                                    heading: .zero,
+                                    pitch: camera.pitch,
+                                    roll: camera.roll
+                                )
+                                Task {
+                                    try? await sceneViewProxy.setViewpointCamera(
+                                        newCamera,
+                                        duration: 0.3
+                                    )
+                                }
+                            }
+                        }
+                }
+        }
+    }
+}
+
+/// An example demonstrating how to use a compass with a scene view and camera controller.
+struct SceneWithCameraController: View {
+    /// The data model containing the `Scene` displayed in the `SceneView`.
+    @StateObject private var dataModel = SceneDataModel(
+        scene: Scene(basemapStyle: .arcGISImagery)
+    )
+    
+    /// The current heading as reported by the scene view.
+    @State private var heading: Double = .zero
+    
+    /// The orbit location camera controller used by the scene view.
+    private let cameraController = OrbitLocationCameraController(
+        targetPoint: .esriRedlands,
+        distance: 10_000
+    )!
+    
+    var body: some View {
+        SceneView(scene: dataModel.scene, cameraController: cameraController)
+            .onCameraChanged { newCamera in
+                heading = newCamera.heading.rounded()
+            }
+            .overlay(alignment: .topTrailing) {
+                Compass(viewpointRotation: $heading)
+                    .padding()
+                    .onTapGesture {
+                        Task {
+                            try? await cameraController.moveCamera(
+                                distanceDelta: .zero,
+                                headingDelta: heading > 180 ? 360 - heading : -heading,
+                                pitchDelta: .zero,
+                                duration: 0.3
+                            )
+                        }
+                    }
+            }
+    }
+}
+
+private extension Point {
+    static var esriRedlands: Point {
+        .init(
+            x: -117.19494,
+            y: 34.05723,
+            spatialReference: .wgs84
+        )
     }
 }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -76,7 +76,7 @@ struct MapWithViewpoint: View {
                     Compass(viewpoint: $viewpoint) {
                         guard let viewpoint else { return }
                         // Animate the map view to zero when the compass is tapped.
-                        _ = await proxy.setViewpoint(
+                        await proxy.setViewpoint(
                             viewpoint.withRotation(0),
                             duration: 0.25
                         )

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -57,10 +57,8 @@ struct CompassExampleView: View {
 
 /// An example demonstrating how to use a compass with a map view.
 struct MapWithViewpoint: View {
-    /// The data model containing the `Map` displayed in the `MapView`.
-    @StateObject private var dataModel = MapDataModel(
-        map: Map(basemapStyle: .arcGISImagery)
-    )
+    /// The `Map` displayed in the `MapView`.
+    @State private var map = Map(basemapStyle: .arcGISImagery)
     
     /// Allows for communication between the Compass and MapView or SceneView.
     @State private var viewpoint: Viewpoint? = Viewpoint(
@@ -71,12 +69,10 @@ struct MapWithViewpoint: View {
     
     var body: some View {
         MapViewReader { mapViewProxy in
-            MapView(map: dataModel.map, viewpoint: viewpoint)
+            MapView(map: map, viewpoint: viewpoint)
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
                     Compass(viewpoint: $viewpoint)
-                    // Optionally provide a different size for the compass.
-                    //    .compassSize(size: T##CGFloat)
                         .padding()
                         .onTapGesture {
                             Task {
@@ -146,12 +142,10 @@ struct SceneWithCamera: View {
 /// An example demonstrating how to use a compass with a scene view and camera controller.
 struct SceneWithCameraController: View {
     /// The data model containing the `Scene` displayed in the `SceneView`.
-    @StateObject private var dataModel = SceneDataModel(
-        scene: Scene(basemapStyle: .arcGISImagery)
-    )
+    @State private var scene = Scene(basemapStyle: .arcGISImagery)
     
     /// The current heading as reported by the scene view.
-    @State private var heading: Double = .zero
+    @State private var heading = Double.zero
     
     /// The orbit location camera controller used by the scene view.
     private let cameraController = OrbitLocationCameraController(
@@ -160,7 +154,7 @@ struct SceneWithCameraController: View {
     )
     
     var body: some View {
-        SceneView(scene: dataModel.scene, cameraController: cameraController)
+        SceneView(scene: scene, cameraController: cameraController)
             .onCameraChanged { newCamera in
                 heading = newCamera.heading.rounded()
             }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -74,7 +74,9 @@ struct MapWithViewpoint: View {
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
                     Compass(viewpoint: $viewpoint) {
-                        _ = try? await proxy.setViewpoint(
+                        guard let viewpoint else { return }
+                        // Animate the map view to zero when the compass is tapped.
+                        _ = await proxy.setViewpoint(
                             viewpoint.withRotation(0),
                             duration: 0.25
                         )
@@ -106,6 +108,7 @@ struct SceneWithCameraController: View {
             }
             .overlay(alignment: .topTrailing) {
                 Compass(viewpointRotation: $heading) {
+                    // Animate the scene view when the compass is tapped.
                     _ = try? await cameraController.moveCamera(
                         distanceDelta: .zero,
                         headingDelta: heading > 180 ? 360 - heading : -heading,

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -111,7 +111,7 @@ struct SceneWithCameraController: View {
                 Compass(viewpointRotation: $heading) {
                     // Animate the scene view when the compass is tapped.
                     Task {
-                        _ = try? await cameraController.moveCamera(
+                        await cameraController.moveCamera(
                             distanceDelta: .zero,
                             headingDelta: heading > 180 ? 360 - heading : -heading,
                             pitchDelta: .zero,

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -18,34 +18,39 @@ import SwiftUI
 /// An example demonstrating how to use a compass in three different environments.
 struct CompassExampleView: View {
     /// A scenario represents a type of environment a compass may be used in.
-    enum Scenario: CaseIterable {
+    enum Scenario: String {
         case map
-        case sceneWithCameraController
-        
-        /// A human-readable label for the scenario.
-        var label: String {
-            switch self {
-            case .map: return "Map"
-            case .sceneWithCameraController: return "Scene with camera controller"
-            }
-        }
+        case scene
     }
     
     /// The active scenario.
     @State private var scenario = Scenario.map
     
     var body: some View {
-        VStack {
+        Group {
             switch scenario {
-            case.map:
+            case .map:
                 MapWithViewpoint()
-            case .sceneWithCameraController:
+            case .scene:
                 SceneWithCameraController()
             }
-            Picker("Scenario", selection: $scenario) {
-                ForEach(Scenario.allCases, id: \.self) { scen in
-                    Text(scen.label)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu(scenario.rawValue.capitalized) {
+                    Button {
+                        scenario = .map
+                    } label: {
+                        Label("Map", systemImage: "map.fill")
+                    }
+                    
+                    Button {
+                        scenario = .scene
+                    } label: {
+                        Label("Scene", systemImage: "globe.americas.fill")
+                    }
                 }
+                .labelStyle(.titleAndIcon)
             }
         }
     }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -155,9 +155,9 @@ struct SceneWithCameraController: View {
     
     /// The orbit location camera controller used by the scene view.
     private let cameraController = OrbitLocationCameraController(
-        targetPoint: .esriRedlands,
+        target: .esriRedlands,
         distance: 10_000
-    )!
+    )
     
     var body: some View {
         SceneView(scene: dataModel.scene, cameraController: cameraController)

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -69,12 +69,19 @@ struct MapWithViewpoint: View {
     )
     
     var body: some View {
-        MapView(map: map, viewpoint: viewpoint)
-            .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
-            .overlay(alignment: .topTrailing) {
-                Compass(viewpoint: $viewpoint)
+        MapViewReader { proxy in
+            MapView(map: map, viewpoint: viewpoint)
+                .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
+                .overlay(alignment: .topTrailing) {
+                    Compass(viewpoint: $viewpoint) {
+                        _ = try? await proxy.setViewpoint(
+                            viewpoint.withRotation(0),
+                            duration: 0.25
+                        )
+                    }
                     .padding()
-            }
+                }
+        }
     }
 }
 
@@ -98,17 +105,14 @@ struct SceneWithCameraController: View {
                 heading = newCamera.heading.rounded()
             }
             .overlay(alignment: .topTrailing) {
-                Compass(
-                    viewpointRotation: $heading,
-                    action: {
-                        _ = try? await cameraController.moveCamera(
-                            distanceDelta: .zero,
-                            headingDelta: heading > 180 ? 360 - heading : -heading,
-                            pitchDelta: .zero,
-                            duration: 0.3
-                        )
-                    }
-                )
+                Compass(viewpointRotation: $heading) {
+                    _ = try? await cameraController.moveCamera(
+                        distanceDelta: .zero,
+                        headingDelta: heading > 180 ? 360 - heading : -heading,
+                        pitchDelta: .zero,
+                        duration: 0.3
+                    )
+                }
                 .padding()
             }
     }

--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -19,7 +19,7 @@ struct PopupExampleView: View {
     static func makeMap() -> Map {
         let portalItem = PortalItem(
             portal: .arcGISOnline(connection: .anonymous),
-            id: Item.ID(rawValue: "9f3a674e998f461580006e626611f9ad")!
+            id: Item.ID("9f3a674e998f461580006e626611f9ad")!
         )
         return Map(item: portalItem)
     }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -17,10 +17,6 @@ import SwiftUI
 /// A `Compass` (alias North arrow) shows where north is in a `MapView` or
 /// `SceneView`.
 public struct Compass: View {
-    /// A Boolean value indicating whether  the compass should automatically
-    /// hide/show itself when the heading is `0`.
-    private let autoHide: Bool
-    
     /// The last time the compass was tapped.
     @State private var lastTapTime: Date?
     
@@ -28,16 +24,20 @@ public struct Compass: View {
     @State private var opacity: Double = .zero
     
     /// An action to perform when the compass is tapped.
-    private var action: (() async -> Void)?
+    private let action: (() async -> Void)?
+    
+    /// A Boolean value indicating whether  the compass should automatically
+    /// hide/show itself when the heading is `0`.
+    private let autoHide: Bool
     
     /// A Boolean value indicating whether the compass should hide based on the
     ///  current heading and whether the compass automatically hides.
-    var shouldHide: Bool {
+    private var shouldHide: Bool {
         (heading.isZero || heading.isNaN) && autoHide
     }
     
     /// The width and height of the compass.
-    var size: CGFloat = 44
+    private var size: CGFloat = 44
     
     /// The heading of the compass in degrees.
     @Binding private var heading: Double

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -21,7 +21,7 @@ public struct Compass: View {
     @State private var opacity: Double = .zero
     
     /// An action to perform when the compass is tapped.
-    private let action: (() async -> Void)?
+    private let action: (() -> Void)?
     
     /// A Boolean value indicating whether  the compass should automatically
     /// hide/show itself when the heading is `0`.
@@ -47,7 +47,7 @@ public struct Compass: View {
     ///   - action: An action to perform when the compass is tapped.
     public init(
         heading: Binding<Double>,
-        action: (() async -> Void)? = nil
+        action: (() -> Void)? = nil
     ) {
         _heading = heading
         self.action = action
@@ -73,7 +73,7 @@ public struct Compass: View {
                 }
                 .onTapGesture {
                     if let action {
-                        Task { await action() }
+                        action()
                     } else {
                         heading = .zero
                     }
@@ -93,7 +93,7 @@ public extension Compass {
     ///   - action: An action to perform when the compass is tapped.
     init(
         viewpointRotation: Binding<Double>,
-        action: (() async -> Void)? = nil
+        action: (() -> Void)? = nil
     ) {
         let heading = Binding(get: {
             viewpointRotation.wrappedValue.isZero ? .zero : 360 - viewpointRotation.wrappedValue
@@ -110,7 +110,7 @@ public extension Compass {
     ///   when the viewpoint's rotation is 0 degrees.
     init(
         viewpoint: Binding<Viewpoint?>,
-        action: (() async -> Void)? = nil
+        action: (() -> Void)? = nil
     ) {
         let viewpointRotation = Binding {
             viewpoint.wrappedValue?.rotation ?? .nan

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -134,7 +134,7 @@ public extension Compass {
     }
     
     /// Specifies whether the ``Compass`` should automatically hide when the heading is 0.
-    /// - Parameter flag: A Boolean value indicating whether  the compass should automatically
+    /// - Parameter flag: A Boolean value indicating whether the compass should automatically
     /// hide/show itself when the heading is `0`.
     func automaticallyHides(_ flag: Bool) -> some View {
         var copy = self

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -29,7 +29,7 @@ public struct Compass: View {
     
     /// A Boolean value indicating whether the compass should hide based on the
     ///  current heading and whether the compass automatically hides.
-    private var shouldHide: Bool {
+    var shouldHide: Bool {
         (heading.isZero || heading.isNaN) && autoHide
     }
     

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -17,9 +17,6 @@ import SwiftUI
 /// A `Compass` (alias North arrow) shows where north is in a `MapView` or
 /// `SceneView`.
 public struct Compass: View {
-    /// The last time the compass was tapped.
-    @State private var lastTapTime: Date?
-    
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
@@ -78,15 +75,14 @@ public struct Compass: View {
                         opacity = newOpacity
                     }
                 }
-                .onTapGesture { lastTapTime = .now }
-                .accessibilityLabel("Compass, heading \(Int(heading.rounded())) degrees \(CompassDirection(heading).rawValue)")
-                .task(id: lastTapTime) {
+                .onTapGesture {
                     if let action {
-                        await action()
+                        Task { await action() }
                     } else {
                         heading = .zero
                     }
                 }
+                .accessibilityLabel("Compass, heading \(Int(heading.rounded())) degrees \(CompassDirection(heading).rawValue)")
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -45,8 +45,6 @@ public struct Compass: View {
     /// - Parameters:
     ///   - heading: The heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   - autoHide: A Boolean value that determines whether the compass
-    ///   automatically hides itself when the heading is `0`.
     public init(
         heading: Binding<Double>,
         action: (() async -> Void)? = nil
@@ -93,8 +91,6 @@ public extension Compass {
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   - autoHide: A Boolean value that determines whether the compass
-    ///   automatically hides itself when the viewpoint rotation is 0 degrees.
     init(
         viewpointRotation: Binding<Double>,
         action: (() async -> Void)? = nil
@@ -111,7 +107,6 @@ public extension Compass {
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
     ///   - action: An action to perform when the compass is tapped.
-    ///   - autoHide: A Boolean value that determines whether the compass automatically hides itself
     ///   when the viewpoint's rotation is 0 degrees.
     init(
         viewpoint: Binding<Viewpoint?>,

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -60,7 +60,6 @@ public struct Compass: View {
                 }
                 .aspectRatio(1, contentMode: .fit)
                 .opacity(opacity)
-                .onTapGesture { heading = .zero }
                 .frame(width: size, height: size)
                 .onChange(of: heading) { _ in
                     let newOpacity: Double = shouldHide ? .zero : 1

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -25,7 +25,7 @@ public struct Compass: View {
     
     /// A Boolean value indicating whether  the compass should automatically
     /// hide/show itself when the heading is `0`.
-    private let autoHide: Bool
+    private var autoHide: Bool = true
     
     /// A Boolean value indicating whether the compass should hide based on the
     ///  current heading and whether the compass automatically hides.
@@ -49,12 +49,10 @@ public struct Compass: View {
     ///   automatically hides itself when the heading is `0`.
     public init(
         heading: Binding<Double>,
-        action: (() async -> Void)? = nil,
-        autoHide: Bool = true
+        action: (() async -> Void)? = nil
     ) {
         _heading = heading
         self.action = action
-        self.autoHide = autoHide
     }
     
     public var body: some View {
@@ -99,15 +97,14 @@ public extension Compass {
     ///   automatically hides itself when the viewpoint rotation is 0 degrees.
     init(
         viewpointRotation: Binding<Double>,
-        action: (() async -> Void)? = nil,
-        autoHide: Bool = true
+        action: (() async -> Void)? = nil
     ) {
         let heading = Binding(get: {
             viewpointRotation.wrappedValue.isZero ? .zero : 360 - viewpointRotation.wrappedValue
         }, set: { newHeading in
             viewpointRotation.wrappedValue = newHeading.isZero ? .zero : 360 - newHeading
         })
-        self.init(heading: heading, action: action, autoHide: autoHide)
+        self.init(heading: heading, action: action)
     }
     
     /// Creates a compass with a binding to an optional viewpoint.
@@ -118,8 +115,7 @@ public extension Compass {
     ///   when the viewpoint's rotation is 0 degrees.
     init(
         viewpoint: Binding<Viewpoint?>,
-        action: (() async -> Void)? = nil,
-        autoHide: Bool = true
+        action: (() async -> Void)? = nil
     ) {
         let viewpointRotation = Binding {
             viewpoint.wrappedValue?.rotation ?? .nan
@@ -131,7 +127,7 @@ public extension Compass {
                 rotation: newViewpointRotation
             )
         }
-        self.init(viewpointRotation: viewpointRotation, action: action, autoHide: autoHide)
+        self.init(viewpointRotation: viewpointRotation, action: action)
     }
     
     /// Define a custom size for the compass.
@@ -139,6 +135,15 @@ public extension Compass {
     func compassSize(size: CGFloat) -> Self {
         var copy = self
         copy.size = size
+        return copy
+    }
+    
+    /// Specifies whether the ``Compass`` should automatically hide when the heading is 0.
+    /// - Parameter newAutomaticallyHides: A Boolean value indicating whether  the compass should automatically
+    /// hide/show itself when the heading is `0`.
+    func automaticallyHides(_ newAutomaticallyHides: Bool) -> some View {
+        var copy = self
+        copy.autoHide = newAutomaticallyHides
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -134,11 +134,11 @@ public extension Compass {
     }
     
     /// Specifies whether the ``Compass`` should automatically hide when the heading is 0.
-    /// - Parameter newAutomaticallyHides: A Boolean value indicating whether  the compass should automatically
+    /// - Parameter flag: A Boolean value indicating whether  the compass should automatically
     /// hide/show itself when the heading is `0`.
-    func automaticallyHides(_ newAutomaticallyHides: Bool) -> some View {
+    func automaticallyHides(_ flag: Bool) -> some View {
         var copy = self
-        copy.autoHide = newAutomaticallyHides
+        copy.autoHide = flag
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/Viewpoint.swift
+++ b/Sources/ArcGISToolkit/Extensions/Viewpoint.swift
@@ -1,0 +1,35 @@
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArcGIS
+
+public extension Viewpoint {
+    /// Creates a new viewpoint with the same target geometry and scale but with a new rotation.
+    /// - Parameter rotation: The rotation for the new viewpoint.
+    /// - Returns: A new viewpoint.
+    func withRotation(_ rotation: Double) -> Viewpoint {
+        switch self.kind {
+        case .centerAndScale:
+            return Viewpoint(
+                center: self.targetGeometry as! Point,
+                scale: self.targetScale,
+                rotation: rotation
+            )
+        case.boundingGeometry:
+            return Viewpoint(
+                boundingGeometry: self.targetGeometry,
+                rotation: rotation
+            )
+        }
+    }
+}

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -24,14 +24,15 @@ final class CompassTests: XCTestCase {
         let finalValue = 90.0
         var _viewpoint: Viewpoint? = makeViewpoint(rotation: initialValue)
         let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })
-        let compass = Compass(viewpoint: viewpoint, autoHide: false)
+        let compass = Compass(viewpoint: viewpoint)
+            .automaticallyHides(false) as! Compass
         XCTAssertFalse(compass.shouldHide)
         _viewpoint = makeViewpoint(rotation: finalValue)
         XCTAssertFalse(compass.shouldHide)
     }
     
     /// Verifies that the compass accurately indicates when the compass should be hidden when
-    /// `autoHide` is `true`.
+    /// `autoHide` is `true` (which is the default).
     func testHiddenWithAutoHideOn() {
         let initialValue = 0.0
         let finalValue = 90.0
@@ -51,8 +52,9 @@ final class CompassTests: XCTestCase {
     
     /// Verifies that the compass correctly initializes when given a `nil` viewpoint, and `autoHide` is
     /// `false`.
-    func testInitNoAutoHide() {
-        let compass = Compass(viewpoint: .constant(nil), autoHide: false)
+    func testAutomaticallyHidesNoAutoHide() {
+        let compass = Compass(viewpoint: .constant(nil))
+            .automaticallyHides(false) as! Compass
         XCTAssertFalse(compass.shouldHide)
     }
     
@@ -64,7 +66,8 @@ final class CompassTests: XCTestCase {
     
     /// Verifies that the compass correctly initializes when given only a viewpoint.
     func testInitWithViewpointAndAutoHide() {
-        let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)), autoHide: false)
+        let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)))
+            .automaticallyHides(false) as! Compass
         XCTAssertFalse(compass.shouldHide)
     }
 }

--- a/Tests/ArcGISToolkitTests/ViewpointTests.swift
+++ b/Tests/ArcGISToolkitTests/ViewpointTests.swift
@@ -1,0 +1,66 @@
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArcGIS
+import XCTest
+@testable import ArcGISToolkit
+
+final class ViewpointTests: XCTestCase {
+    func testWithRotation() async {
+        let viewpoint = Viewpoint(center: .esriRedlands, scale: 15_000)
+        let expectedViewpoint = viewpoint.withRotation(45)
+        
+        XCTAssertEqual(expectedViewpoint.rotation, 45)
+        XCTAssertEqual(expectedViewpoint.targetScale, viewpoint.targetScale)
+        XCTAssertEqual(expectedViewpoint.targetGeometry, viewpoint.targetGeometry)
+    }
+    
+    func testWithRotationWithBoundingGeometry() {
+        let rotatedViewpoint = Viewpoint(boundingGeometry: Polyline.simple.extent, rotation: -45)
+        XCTAssertEqual(rotatedViewpoint.rotation, -45)
+        
+        let nonRotatedViewpoint = rotatedViewpoint.withRotation(.zero)
+        XCTAssertEqual(nonRotatedViewpoint.rotation, 0)
+        XCTAssertEqual(nonRotatedViewpoint.targetGeometry, rotatedViewpoint.targetGeometry)
+    }
+    
+    func testWithRotationWithCenterAndScale() {
+        let rotatedViewpoint = Viewpoint(center: .esriRedlands, scale: 1_000, rotation: 45)
+        XCTAssertEqual(rotatedViewpoint.rotation, 45)
+        
+        let nonRotatedViewpoint = rotatedViewpoint.withRotation(.zero)
+        XCTAssertEqual(nonRotatedViewpoint.rotation, 0)
+        XCTAssertEqual(nonRotatedViewpoint.targetScale, rotatedViewpoint.targetScale)
+        XCTAssertEqual(nonRotatedViewpoint.targetGeometry, rotatedViewpoint.targetGeometry)
+    }
+}
+
+extension Point {
+    static var esriRedlands: Point {
+        .init(
+            x: -117.19494,
+            y: 34.05723,
+            spatialReference: .wgs84
+        )
+    }
+}
+
+private extension Polyline {
+    static var simple: Polyline {
+        .init(points: [
+            Point(x: -117, y: 34, spatialReference: .wgs84),
+            Point(x: -116, y: 34, spatialReference: .wgs84),
+            Point(x: -116, y: 33, spatialReference: .wgs84)
+        ])
+    }
+}


### PR DESCRIPTION
Closes #25, #266

This takes #281 and updates it a bit:

- Add `automaticallyHides` view modifier and removes `autoHide` from the constructors
- Removing `autoHide` allows the `action` to be a closure
- Adds `Viewpoint.withViewpoint(rotation:)` extension for ease of viewpoint creation when only the rotation changed.
- updates the MapView compass example to animate taps on the compass (rotation to 0).
- 
it includes these changes from the original PR:

- Adds an optional `action` parameter to the Compass initializer(s) that takes an async task. This allows users to perform animated heading changes. If no `action` is provided, behavior remains unchanged.
- The name "`action`" is borrowed from [`Button.init(action:label:)`](https://developer.apple.com/documentation/swiftui/button/init(action:label:))