### PR TITLE
Fix warning - "Info.plist contained no UIScene configuration dictionary"

### DIFF
--- a/Examples/ExamplesApp/Info.plist
+++ b/Examples/ExamplesApp/Info.plist
@@ -24,6 +24,8 @@
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>


### PR DESCRIPTION
Thanks to @yo1995 and [samples #149](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/149) I realized we we're experiencing the same warning in the toolkit's examples app.

<img width="654" alt="Screenshot 2023-03-31 at 11 30 52" src="https://user-images.githubusercontent.com/16397058/229201886-2091f343-8ecf-41aa-afd4-0da0fe22fac9.png">

This PR simply adds the one entry to resolve that warning

<img width="820" alt="Screenshot 2023-03-31 at 11 30 46" src="https://user-images.githubusercontent.com/16397058/229201941-010fe763-10ed-41b5-a8e8-2228c2654d19.png">