### PR TITLE
`Compass.automaticallyHides(_:)`-> `autoHideDisabled(_:)`

### DIFF
--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -50,7 +50,7 @@ Compass:
 `Compass` has the following modifiers:
 
 - `func compassSize(size: CGFloat)` - The size of the `Compass`, specifying both the width and height of the compass.
-- `func automaticallyHides(_:)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
+- `func disableAutoHide(_:)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
 
 ## Behavior:
 

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -50,7 +50,7 @@ Compass:
 `Compass` has the following modifiers:
 
 - `func compassSize(size: CGFloat)` - The size of the `Compass`, specifying both the width and height of the compass.
-- `func disableAutoHide(_:)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
+- `func autoHideDisabled(_:)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
 
 ## Behavior:
 

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -136,7 +136,7 @@ public extension Compass {
     /// Specifies whether the ``Compass`` should automatically hide when the heading is 0.
     /// - Parameter disable: A Boolean value indicating whether the compass should automatically
     /// hide/show itself when the heading is `0`.
-    func disableAutoHide(_ disable: Bool = true) -> some View {
+    func autoHideDisabled(_ disable: Bool = true) -> some View {
         var copy = self
         copy.autoHide = !disable
         return copy

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -134,11 +134,11 @@ public extension Compass {
     }
     
     /// Specifies whether the ``Compass`` should automatically hide when the heading is 0.
-    /// - Parameter flag: A Boolean value indicating whether the compass should automatically
+    /// - Parameter disable: A Boolean value indicating whether the compass should automatically
     /// hide/show itself when the heading is `0`.
-    func automaticallyHides(_ flag: Bool) -> some View {
+    func disableAutoHide(_ disable: Bool = true) -> some View {
         var copy = self
-        copy.autoHide = flag
+        copy.autoHide = !disable
         return copy
     }
 }

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -25,7 +25,7 @@ final class CompassTests: XCTestCase {
         var _viewpoint: Viewpoint? = makeViewpoint(rotation: initialValue)
         let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })
         let compass = Compass(viewpoint: viewpoint)
-            .disableAutoHide() as! Compass
+            .autoHideDisabled() as! Compass
         XCTAssertFalse(compass.shouldHide)
         _viewpoint = makeViewpoint(rotation: finalValue)
         XCTAssertFalse(compass.shouldHide)
@@ -54,7 +54,7 @@ final class CompassTests: XCTestCase {
     /// `false`.
     func testAutomaticallyHidesNoAutoHide() {
         let compass = Compass(viewpoint: .constant(nil))
-            .disableAutoHide() as! Compass
+            .autoHideDisabled() as! Compass
         XCTAssertFalse(compass.shouldHide)
     }
     
@@ -67,7 +67,7 @@ final class CompassTests: XCTestCase {
     /// Verifies that the compass correctly initializes when given only a viewpoint.
     func testInitWithViewpointAndAutoHide() {
         let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)))
-            .disableAutoHide() as! Compass
+            .autoHideDisabled() as! Compass
         XCTAssertFalse(compass.shouldHide)
     }
 }

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -25,7 +25,7 @@ final class CompassTests: XCTestCase {
         var _viewpoint: Viewpoint? = makeViewpoint(rotation: initialValue)
         let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })
         let compass = Compass(viewpoint: viewpoint)
-            .automaticallyHides(false) as! Compass
+            .disableAutoHide() as! Compass
         XCTAssertFalse(compass.shouldHide)
         _viewpoint = makeViewpoint(rotation: finalValue)
         XCTAssertFalse(compass.shouldHide)
@@ -54,7 +54,7 @@ final class CompassTests: XCTestCase {
     /// `false`.
     func testAutomaticallyHidesNoAutoHide() {
         let compass = Compass(viewpoint: .constant(nil))
-            .automaticallyHides(false) as! Compass
+            .disableAutoHide() as! Compass
         XCTAssertFalse(compass.shouldHide)
     }
     
@@ -67,7 +67,7 @@ final class CompassTests: XCTestCase {
     /// Verifies that the compass correctly initializes when given only a viewpoint.
     func testInitWithViewpointAndAutoHide() {
         let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)))
-            .automaticallyHides(false) as! Compass
+            .disableAutoHide() as! Compass
         XCTAssertFalse(compass.shouldHide)
     }
 }


### PR DESCRIPTION
[See also](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/286#discussion_r1156207860)

[Named after](https://developer.apple.com/documentation/swiftui/view/autocorrectiondisabled(_:))