### PR TITLE
[Compass] Remove `action` parameter, add `mapViewProxy` parameter, support rotation animation

### DIFF
--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -24,8 +24,8 @@ Compass:
     /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
-    ///   - action: An action to perform when the compass is tapped.
-    public init(heading: Binding<Double>, action: (() -> Void)? = nil)
+    ///   - mapViewProxy: Provides access to viewpoint animation.
+    public init(heading: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
 ```
 
 ```swift
@@ -35,16 +35,16 @@ Compass:
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
-    ///   - action: An action to perform when the compass is tapped.
-    public init(viewpointRotation: Binding<Double>, action: (() -> Void)? = nil)
+    ///   - mapViewProxy: Provides access to viewpoint animation.
+    public init(viewpointRotation: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
 ```
 
 ```swift
     /// Creates a compass with a binding to an optional viewpoint.
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - action: An action to perform when the compass is tapped.
-    public init(viewpoint: Binding<Viewpoint?>, action: (() -> Void)? = nil)
+    ///   - mapViewProxy: Provides access to viewpoint animation.
+    public init(viewpoint: Binding<Viewpoint?>, mapViewProxy: MapViewProxy? = nil)
 ```
 
 `Compass` has the following modifiers:
@@ -63,7 +63,7 @@ When the compass is tapped, the map orients back to north (zero bearing).
 ### Basic usage for displaying a `Compass`.
 
 ```swift
-@StateObject var map = Map(basemapStyle: .arcGISImagery)
+@State private var map = Map(basemapStyle: .arcGISImagery)
 
 /// Allows for communication between the Compass and MapView or SceneView.
 @State private var viewpoint: Viewpoint? = Viewpoint(
@@ -73,12 +73,14 @@ When the compass is tapped, the map orients back to north (zero bearing).
 )
 
 var body: some View {
-    MapView(map: map, viewpoint: viewpoint)
-        .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
-        .overlay(alignment: .topTrailing) {
-            Compass(viewpoint: $viewpoint)
-                .padding()
-        }
+    MapViewReader { proxy in
+        MapView(map: map, viewpoint: viewpoint)
+            .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
+            .overlay(alignment: .topTrailing) {
+                Compass(viewpoint: $viewpoint, mapViewProxy: proxy)
+                    .padding()
+            }
+    }
 }
 ```
 

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -24,7 +24,7 @@ Compass:
     /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
-    ///   - mapViewProxy: Provides access to viewpoint animation.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     public init(heading: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
 ```
 
@@ -35,7 +35,7 @@ Compass:
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
-    ///   - mapViewProxy: Provides access to viewpoint animation.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     public init(viewpointRotation: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
 ```
 
@@ -43,7 +43,7 @@ Compass:
     /// Creates a compass with a binding to an optional viewpoint.
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - mapViewProxy: Provides access to viewpoint animation.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     public init(viewpoint: Binding<Viewpoint?>, mapViewProxy: MapViewProxy? = nil)
 ```
 

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -16,35 +16,15 @@ Compass:
 
 ## Key properties
 
-`Compass` has the following initializers:
+`Compass` has the following initializer:
 
 ```swift
-    /// Creates a compass with a binding to a heading based on compass
-    /// directions (0° indicates a direction toward true North, 90° indicates a
-    /// direction toward true East, etc.).
+    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
+    /// a direction toward true West, etc.).
     /// - Parameters:
-    ///   - heading: The heading of the compass.
+    ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(heading: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
-```
-
-```swift
-    /// Creates a compass with a binding to a viewpoint rotation (0° indicates
-    /// a direction toward true North, 90° indicates a direction toward true
-    /// West, etc.).
-    /// - Parameters:
-    ///   - viewpointRotation: The viewpoint rotation whose value determines the
-    ///   heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpointRotation: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
-```
-
-```swift
-    /// Creates a compass with a binding to an optional viewpoint.
-    /// - Parameters:
-    ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpoint: Binding<Viewpoint?>, mapViewProxy: MapViewProxy? = nil)
+    public init(rotation: Double?, mapViewProxy: MapViewProxy)
 ```
 
 `Compass` has the following modifiers:
@@ -65,19 +45,14 @@ When the compass is tapped, the map orients back to north (zero bearing).
 ```swift
 @State private var map = Map(basemapStyle: .arcGISImagery)
 
-/// Allows for communication between the Compass and MapView or SceneView.
-@State private var viewpoint: Viewpoint? = Viewpoint(
-    center: Point(x: -117.19494, y: 34.05723, spatialReference: .wgs84),
-    scale: 10_000,
-    rotation: -45
-)
+@State private var viewpoint: Viewpoint?
 
 var body: some View {
     MapViewReader { proxy in
         MapView(map: map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .overlay(alignment: .topTrailing) {
-                Compass(viewpoint: $viewpoint, mapViewProxy: proxy)
+                Compass(rotation: viewpoint?.rotation, mapViewProxy: proxy)
                     .padding()
             }
     }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -15,101 +15,32 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
-/// An example demonstrating how to use a compass in three different environments.
-struct CompassExampleView: View {
-    /// A scenario represents a type of environment a compass may be used in.
-    enum Scenario: String {
-        case scene
-        case viewpoint
-    }
-    
-    /// The active scenario.
-    @State private var scenario = Scenario.viewpoint
-    
-    var body: some View {
-        Group {
-            switch scenario {
-            case .viewpoint:
-                MapWithViewpoint()
-            case .scene:
-                SceneWithCameraController()
-            }
-        }
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Menu(scenario.rawValue.capitalized) {
-                    Button {
-                        scenario = .viewpoint
-                    } label: {
-                        Text("Viewpoint")
-                    }
-                    
-                    Button {
-                        scenario = .scene
-                    } label: {
-                        Label("Scene", systemImage: "globe.americas.fill")
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// An example demonstrating how to use a compass with a map view.
-struct MapWithViewpoint: View {
+struct CompassExampleView: View {
     /// The `Map` displayed in the `MapView`.
     @State private var map = Map(basemapStyle: .arcGISImagery)
     
     /// Allows for communication between the Compass and MapView or SceneView.
-    @State private var viewpoint: Viewpoint? = Viewpoint(
-        center: .esriRedlands,
-        scale: 10_000,
-        rotation: -45
-    )
+    @State private var viewpoint: Viewpoint? = .esriRedlands
     
     var body: some View {
         MapViewReader { proxy in
             MapView(map: map, viewpoint: viewpoint)
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
-                    Compass(viewpoint: $viewpoint, geoViewProxy: proxy)
+                    Compass(viewpoint: $viewpoint, mapViewProxy: proxy)
                         .padding()
                 }
         }
     }
 }
 
-/// An example demonstrating how to use a compass with a scene view and camera controller.
-struct SceneWithCameraController: View {
-    /// The data model containing the `Scene` displayed in the `SceneView`.
-    @State private var scene = Scene(basemapStyle: .arcGISImagery)
-    
-    /// The current heading as reported by the scene view.
-    @State private var heading = Double.zero
-    
-    /// The orbit location camera controller used by the scene view.
-    private let cameraController = OrbitLocationCameraController(
-        target: .esriRedlands,
-        distance: 10_000
-    )
-    
-    var body: some View {
-        SceneView(scene: scene, cameraController: cameraController)
-            .onCameraChanged { newCamera in
-                heading = newCamera.heading.rounded()
-            }
-            .overlay(alignment: .topTrailing) {
-                Compass(viewpointRotation: $heading)
-            }
-    }
-}
-
-private extension Point {
-    static var esriRedlands: Point {
+private extension Viewpoint {
+    static var esriRedlands: Viewpoint {
         .init(
-            x: -117.19494,
-            y: 34.05723,
-            spatialReference: .wgs84
+            center: .init(x: -117.19494, y: 34.05723, spatialReference: .wgs84),
+            scale: 10_000,
+            rotation: -45
         )
     }
 }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -19,17 +19,17 @@ import SwiftUI
 struct CompassExampleView: View {
     /// A scenario represents a type of environment a compass may be used in.
     enum Scenario: String {
-        case map
         case scene
+        case viewpoint
     }
     
     /// The active scenario.
-    @State private var scenario = Scenario.map
+    @State private var scenario = Scenario.viewpoint
     
     var body: some View {
         Group {
             switch scenario {
-            case .map:
+            case .viewpoint:
                 MapWithViewpoint()
             case .scene:
                 SceneWithCameraController()
@@ -39,9 +39,9 @@ struct CompassExampleView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Menu(scenario.rawValue.capitalized) {
                     Button {
-                        scenario = .map
+                        scenario = .viewpoint
                     } label: {
-                        Label("Map", systemImage: "map.fill")
+                        Text("Viewpoint")
                     }
                     
                     Button {
@@ -72,17 +72,8 @@ struct MapWithViewpoint: View {
             MapView(map: map, viewpoint: viewpoint)
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
-                    Compass(viewpoint: $viewpoint) {
-                        guard let viewpoint else { return }
-                        Task {
-                            // Animate the map view to zero when the compass is tapped.
-                            await proxy.setViewpoint(
-                                viewpoint.withRotation(0),
-                                duration: 0.25
-                            )
-                        }
-                    }
-                    .padding()
+                    Compass(viewpoint: $viewpoint, geoViewProxy: proxy)
+                        .padding()
                 }
         }
     }
@@ -108,18 +99,7 @@ struct SceneWithCameraController: View {
                 heading = newCamera.heading.rounded()
             }
             .overlay(alignment: .topTrailing) {
-                Compass(viewpointRotation: $heading) {
-                    // Animate the scene view when the compass is tapped.
-                    Task {
-                        await cameraController.moveCamera(
-                            distanceDelta: .zero,
-                            headingDelta: heading > 180 ? 360 - heading : -heading,
-                            pitchDelta: .zero,
-                            duration: 0.3
-                        )
-                    }
-                }
-                .padding()
+                Compass(viewpointRotation: $heading)
             }
     }
 }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -28,7 +28,7 @@ struct CompassExampleView: View {
             MapView(map: map, viewpoint: viewpoint)
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
-                    Compass(viewpoint: $viewpoint, mapViewProxy: proxy)
+                    Compass(rotation: viewpoint?.rotation, mapViewProxy: proxy)
                         .padding()
                 }
         }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -20,8 +20,8 @@ public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
-    /// An action to perform when the compass is tapped.
-    private let action: (() -> Void)?
+    /// <#Description#>
+    private var geoViewProxy: GeoViewProxy?
     
     /// A Boolean value indicating whether  the compass should automatically
     /// hide/show itself when the heading is `0`.
@@ -44,13 +44,13 @@ public struct Compass: View {
     /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
-    ///   - action: An action to perform when the compass is tapped.
+    ///   - geoViewProxy: <#Description#>
     public init(
         heading: Binding<Double>,
-        action: (() -> Void)? = nil
+        geoViewProxy: GeoViewProxy? = nil
     ) {
         _heading = heading
-        self.action = action
+        self.geoViewProxy = geoViewProxy
     }
     
     public var body: some View {
@@ -72,8 +72,8 @@ public struct Compass: View {
                     }
                 }
                 .onTapGesture {
-                    if let action {
-                        action()
+                    if let mapViewProxy = geoViewProxy as? MapViewProxy {
+                        Task { await mapViewProxy.setViewpointRotation(0) }
                     } else {
                         heading = .zero
                     }
@@ -90,27 +90,26 @@ public extension Compass {
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
-    ///   - action: An action to perform when the compass is tapped.
+    ///   - geoViewProxy: <#Description#>
     init(
         viewpointRotation: Binding<Double>,
-        action: (() -> Void)? = nil
+        geoViewProxy: GeoViewProxy? = nil
     ) {
         let heading = Binding(get: {
             viewpointRotation.wrappedValue.isZero ? .zero : 360 - viewpointRotation.wrappedValue
         }, set: { newHeading in
             viewpointRotation.wrappedValue = newHeading.isZero ? .zero : 360 - newHeading
         })
-        self.init(heading: heading, action: action)
+        self.init(heading: heading, geoViewProxy: geoViewProxy)
     }
     
     /// Creates a compass with a binding to an optional viewpoint.
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - action: An action to perform when the compass is tapped.
-    ///   when the viewpoint's rotation is 0 degrees.
+    ///   - geoViewProxy: <#Description#>
     init(
         viewpoint: Binding<Viewpoint?>,
-        action: (() -> Void)? = nil
+        geoViewProxy: GeoViewProxy? = nil
     ) {
         let viewpointRotation = Binding {
             viewpoint.wrappedValue?.rotation ?? .nan
@@ -122,7 +121,7 @@ public extension Compass {
                 rotation: newViewpointRotation
             )
         }
-        self.init(viewpointRotation: viewpointRotation, action: action)
+        self.init(viewpointRotation: viewpointRotation, geoViewProxy: geoViewProxy)
     }
     
     /// Define a custom size for the compass.

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -20,7 +20,7 @@ public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
-    /// Provides access to viewpoint animation.
+    /// The proxy to provide access to map view operations.
     private var mapViewProxy: MapViewProxy?
     
     /// A Boolean value indicating whether  the compass should automatically
@@ -44,7 +44,7 @@ public struct Compass: View {
     /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
-    ///   - mapViewProxy: Provides access to viewpoint animation.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     public init(
         heading: Binding<Double>,
         mapViewProxy: MapViewProxy? = nil
@@ -90,7 +90,7 @@ public extension Compass {
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
-    ///   - mapViewProxy: Provides access to viewpoint animation.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
         viewpointRotation: Binding<Double>,
         mapViewProxy: MapViewProxy? = nil
@@ -106,7 +106,7 @@ public extension Compass {
     /// Creates a compass with a binding to an optional viewpoint.
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - mapViewProxy: Provides access to viewpoint animation.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
         viewpoint: Binding<Viewpoint?>,
         mapViewProxy: MapViewProxy? = nil

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -20,8 +20,8 @@ public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
-    /// <#Description#>
-    private var geoViewProxy: GeoViewProxy?
+    /// Provides access to viewpoint animation.
+    private var mapViewProxy: MapViewProxy?
     
     /// A Boolean value indicating whether  the compass should automatically
     /// hide/show itself when the heading is `0`.
@@ -44,13 +44,13 @@ public struct Compass: View {
     /// direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
-    ///   - geoViewProxy: <#Description#>
+    ///   - mapViewProxy: Provides access to viewpoint animation.
     public init(
         heading: Binding<Double>,
-        geoViewProxy: GeoViewProxy? = nil
+        mapViewProxy: MapViewProxy? = nil
     ) {
         _heading = heading
-        self.geoViewProxy = geoViewProxy
+        self.mapViewProxy = mapViewProxy
     }
     
     public var body: some View {
@@ -72,7 +72,7 @@ public struct Compass: View {
                     }
                 }
                 .onTapGesture {
-                    if let mapViewProxy = geoViewProxy as? MapViewProxy {
+                    if let mapViewProxy {
                         Task { await mapViewProxy.setViewpointRotation(0) }
                     } else {
                         heading = .zero
@@ -90,26 +90,26 @@ public extension Compass {
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the
     ///   heading of the compass.
-    ///   - geoViewProxy: <#Description#>
+    ///   - mapViewProxy: Provides access to viewpoint animation.
     init(
         viewpointRotation: Binding<Double>,
-        geoViewProxy: GeoViewProxy? = nil
+        mapViewProxy: MapViewProxy? = nil
     ) {
         let heading = Binding(get: {
             viewpointRotation.wrappedValue.isZero ? .zero : 360 - viewpointRotation.wrappedValue
         }, set: { newHeading in
             viewpointRotation.wrappedValue = newHeading.isZero ? .zero : 360 - newHeading
         })
-        self.init(heading: heading, geoViewProxy: geoViewProxy)
+        self.init(heading: heading, mapViewProxy: mapViewProxy)
     }
     
     /// Creates a compass with a binding to an optional viewpoint.
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - geoViewProxy: <#Description#>
+    ///   - mapViewProxy: Provides access to viewpoint animation.
     init(
         viewpoint: Binding<Viewpoint?>,
-        geoViewProxy: GeoViewProxy? = nil
+        mapViewProxy: MapViewProxy? = nil
     ) {
         let viewpointRotation = Binding {
             viewpoint.wrappedValue?.rotation ?? .nan
@@ -121,7 +121,7 @@ public extension Compass {
                 rotation: newViewpointRotation
             )
         }
-        self.init(viewpointRotation: viewpointRotation, geoViewProxy: geoViewProxy)
+        self.init(viewpointRotation: viewpointRotation, mapViewProxy: mapViewProxy)
     }
     
     /// Define a custom size for the compass.

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -17,76 +17,37 @@ import XCTest
 @testable import ArcGISToolkit
 
 final class CompassTests: XCTestCase {
-    /// Verifies that the compass accurately indicates when the compass should be hidden when
-    /// `autoHide` is `false`.
+    /// Verifies that the compass accurately indicates it shouldn't be hidden when `autoHideDisabled`
+    /// is applied.
     func testHiddenWithAutoHideOff() {
-        let initialValue = 0.0
-        let finalValue = 90.0
-        var _viewpoint: Viewpoint? = makeViewpoint(rotation: initialValue)
-        let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })
-        let compass = Compass(viewpoint: viewpoint)
+        let compass1Heading = Double.zero
+        let compass1 = Compass(heading: compass1Heading)
             .autoHideDisabled() as! Compass
-        XCTAssertFalse(compass.shouldHide)
-        _viewpoint = makeViewpoint(rotation: finalValue)
-        XCTAssertFalse(compass.shouldHide)
+        XCTAssertFalse(compass1.shouldHide(forHeading: compass1Heading))
+        
+        let compass2Heading = 45.0
+        let compass2 = Compass(heading: compass2Heading)
+            .autoHideDisabled() as! Compass
+        XCTAssertFalse(compass2.shouldHide(forHeading: compass2Heading))
+        
+        let compass3Heading = Double.nan
+        let compass3 = Compass(heading: compass3Heading)
+            .autoHideDisabled() as! Compass
+        XCTAssertFalse(compass3.shouldHide(forHeading: compass3Heading))
     }
     
-    /// Verifies that the compass accurately indicates when the compass should be hidden when
-    /// `autoHide` is `true` (which is the default).
+    /// Verifies that the compass accurately indicates when it should be hidden.
     func testHiddenWithAutoHideOn() {
-        let initialValue = 0.0
-        let finalValue = 90.0
-        var _viewpoint: Viewpoint? = makeViewpoint(rotation: initialValue)
-        let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })
-        let compass = Compass(viewpoint: viewpoint)
-        XCTAssertTrue(compass.shouldHide)
-        _viewpoint = makeViewpoint(rotation: finalValue)
-        XCTAssertFalse(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given a `nil` viewpoint.
-    func testInit() {
-        let compass = Compass(viewpoint: .constant(nil))
-        XCTAssertTrue(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given a `nil` viewpoint, and `autoHide` is
-    /// `false`.
-    func testAutomaticallyHidesNoAutoHide() {
-        let compass = Compass(viewpoint: .constant(nil))
-            .autoHideDisabled() as! Compass
-        XCTAssertFalse(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given only a viewpoint.
-    func testInitWithViewpoint() {
-        let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)))
-        XCTAssertTrue(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given only a viewpoint.
-    func testInitWithViewpointAndAutoHide() {
-        let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)))
-            .autoHideDisabled() as! Compass
-        XCTAssertFalse(compass.shouldHide)
-    }
-}
-
-extension CompassTests {
-    /// An arbitrary point to use for testing.
-    var point: Point {
-        Point(x: -117.19494, y: 34.05723, spatialReference: .wgs84)
-    }
-    
-    /// An arbitrary scale to use for testing.
-    var scale: Double {
-        10_000.00
-    }
-    
-    /// Builds viewpoints to use for tests.
-    /// - Parameter rotation: The rotation to use for the resulting viewpoint.
-    /// - Returns: A viewpoint object for tests.
-    func makeViewpoint(rotation: Double) -> Viewpoint {
-        return Viewpoint(center: point, scale: scale, rotation: rotation)
+        let compass1Heading: Double = .zero
+        let compass1 = Compass(heading: compass1Heading)
+        XCTAssertTrue(compass1.shouldHide(forHeading: compass1Heading))
+        
+        let compass2Heading = 45.0
+        let compass2 = Compass(heading: compass2Heading)
+        XCTAssertFalse(compass2.shouldHide(forHeading: compass2Heading))
+        
+        let compass3Heading = Double.nan
+        let compass3 = Compass(heading: compass3Heading)
+        XCTAssertTrue(compass3.shouldHide(forHeading: compass3Heading))
     }
 }


### PR DESCRIPTION
- Closes #295 
- In Swift 3882, a conclusion was reached that toolkit components should take proxy parameters where needed.
- In the case of the Compass, a map view proxy is used to animate the map view's heading to zero.
- SceneView compass animations will not be supported.
- See also #260 