### PR TITLE
[Search] Add `geoViewProxy` parameter, support viewpoint animation

### DIFF
--- a/Documentation/Search/README.md
+++ b/Documentation/Search/README.md
@@ -24,9 +24,11 @@
     ///   - sources: A collection of search sources to be used.
     ///   - viewpoint: The `Viewpoint` used to pan/zoom to results. If `nil`, there will be
     ///   no zooming to results.
+    ///   - geoViewProxy: The proxy to provide access to geo view operations.
     public init(
         sources: [SearchSource] = [],
-        viewpoint: Binding<Viewpoint?>? = nil
+        viewpoint: Binding<Viewpoint?>? = nil,
+        geoViewProxy: GeoViewProxy? = nil
     )
 ```
 
@@ -170,7 +172,8 @@ The `SearchView` will display the results list view at half height, exposing a p
 ```swift
 SearchView(
     sources: [locatorDataSource],
-    viewpoint: $searchResultViewpoint
+    viewpoint: $searchResultViewpoint,
+    geoViewProxy: mapViewProxy
 )
 .resultsOverlay(searchResultsOverlay)
 .queryCenter($queryCenter)

--- a/Examples/Examples/SearchExampleView.swift
+++ b/Examples/Examples/SearchExampleView.swift
@@ -51,35 +51,38 @@ struct SearchExampleView: View {
     @State private var queryCenter: Point?
     
     var body: some View {
-        MapView(
-            map: dataModel.map,
-            viewpoint: searchResultViewpoint,
-            graphicsOverlays: [searchResultsOverlay]
-        )
-        .onNavigatingChanged { isGeoViewNavigating = $0 }
-        .onViewpointChanged(kind: .centerAndScale) {
-            queryCenter = $0.targetGeometry as? Point
-        }
-        .onVisibleAreaChanged { newValue in
-            // For "Repeat Search Here" behavior, use the `geoViewExtent` and
-            // `isGeoViewNavigating` modifiers on the `SearchView`.
-            geoViewExtent = newValue.extent
-            
-            // The visible area can be used to limit the results by
-            // using the `queryArea` modifier on the `SearchView`.
-//            queryArea = newValue
-        }
-        .overlay {
-            SearchView(
-                sources: [locatorDataSource],
-                viewpoint: $searchResultViewpoint
+        MapViewReader { mapViewProxy in
+            MapView(
+                map: dataModel.map,
+                viewpoint: searchResultViewpoint,
+                graphicsOverlays: [searchResultsOverlay]
             )
-            .resultsOverlay(searchResultsOverlay)
-//            .queryArea($queryArea)
-            .queryCenter($queryCenter)
-            .geoViewExtent($geoViewExtent)
-            .isGeoViewNavigating($isGeoViewNavigating)
-            .padding()
+            .onNavigatingChanged { isGeoViewNavigating = $0 }
+            .onViewpointChanged(kind: .centerAndScale) {
+                queryCenter = $0.targetGeometry as? Point
+            }
+            .onVisibleAreaChanged { newValue in
+                // For "Repeat Search Here" behavior, use the `geoViewExtent` and
+                // `isGeoViewNavigating` modifiers on the `SearchView`.
+                geoViewExtent = newValue.extent
+                
+                // The visible area can be used to limit the results by
+                // using the `queryArea` modifier on the `SearchView`.
+//                queryArea = newValue
+            }
+            .overlay {
+                SearchView(
+                    sources: [locatorDataSource],
+                    viewpoint: $searchResultViewpoint,
+                    geoViewProxy: mapViewProxy
+                )
+                .resultsOverlay(searchResultsOverlay)
+//                .queryArea($queryArea)
+                .queryCenter($queryCenter)
+                .geoViewExtent($geoViewExtent)
+                .isGeoViewNavigating($isGeoViewNavigating)
+                .padding()
+            }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -21,7 +21,7 @@ public struct SearchView: View {
     ///   - sources: A collection of search sources to be used.
     ///   - viewpoint: The `Viewpoint` used to pan/zoom to results. If `nil`, there will be
     ///   no zooming to results.
-    ///   - geoViewProxy: <#Description#>
+    ///   - geoViewProxy: The proxy to provide access to geo view operations.
     public init(
         sources: [SearchSource] = [],
         viewpoint: Binding<Viewpoint?>? = nil,

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -21,13 +21,16 @@ public struct SearchView: View {
     ///   - sources: A collection of search sources to be used.
     ///   - viewpoint: The `Viewpoint` used to pan/zoom to results. If `nil`, there will be
     ///   no zooming to results.
+    ///   - geoViewProxy: <#Description#>
     public init(
         sources: [SearchSource] = [],
-        viewpoint: Binding<Viewpoint?>? = nil
+        viewpoint: Binding<Viewpoint?>? = nil,
+        geoViewProxy: GeoViewProxy? = nil
     ) {
         _viewModel = StateObject(wrappedValue: SearchViewModel(
             sources: sources.isEmpty ? [LocatorSearchSource()] : sources,
-            viewpoint: viewpoint
+            viewpoint: viewpoint,
+            geoViewProxy: geoViewProxy
         ))
         
         _queryArea = .constant(nil)

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -44,7 +44,7 @@ public enum SearchOutcome {
     ///   - sources: Collection of search sources to be used.
     ///   - viewpoint: The `Viewpoint` used to pan/zoom to results. If `nil`, there will be
     ///   no zooming to results.
-    ///   - geoViewProxy: <#Description#>
+    ///   - geoViewProxy: The proxy to provide access to geo view operations.
     init(
         sources: [SearchSource] = [],
         viewpoint: Binding<Viewpoint?>? = nil,
@@ -119,7 +119,7 @@ public enum SearchOutcome {
         }
     }
     
-    /// <#Description#>
+    /// The proxy to provide access to geo view operations.
     private var geoViewProxy: GeoViewProxy?
     
     /// `true` when the geoView is navigating, `false` otherwise. Set by the external client.

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -386,14 +386,7 @@ private extension SearchViewModel {
             let builder = EnvelopeBuilder(envelope: envelope)
             builder.expand(by: 1.1)
             let targetExtent = builder.toGeometry()
-            let newViewpoint = Viewpoint(boundingGeometry: targetExtent)
-            if let geoViewProxy {
-                Task {
-                    await geoViewProxy.setViewpoint(newViewpoint, duration: nil)
-                }
-            } else {
-                viewpoint.wrappedValue = newViewpoint
-            }
+            display(newViewpoint: Viewpoint(boundingGeometry: targetExtent))
             lastSearchExtent = targetExtent
         } else {
             viewpoint.wrappedValue = nil
@@ -404,13 +397,16 @@ private extension SearchViewModel {
     
     func display(selectedResult: SearchResult?) {
         guard let selectedResult = selectedResult else { return }
+        display(newViewpoint: selectedResult.selectionViewpoint)
+    }
     
-        if let geoViewProxy, let viewpoint = selectedResult.selectionViewpoint {
-            Task {
-                await geoViewProxy.setViewpoint(viewpoint, duration: nil)
-            }
+    /// Update the viewpoint to the new viewpoint, if a geo view proxy was supplied, the transition
+    /// will be animated.
+    func display(newViewpoint: Viewpoint?) {
+        if let geoViewProxy, let newViewpoint {
+            Task { await geoViewProxy.setViewpoint(newViewpoint, duration: nil) }
         } else {
-            viewpoint?.wrappedValue = selectedResult.selectionViewpoint
+            viewpoint?.wrappedValue = newViewpoint
         }
     }
 }


### PR DESCRIPTION
Related #260 

- Adds a new `geoViewProxy` parameter to the search module. This is used to perform animated viewpoints now.
- In the example, a map view proxy is added to demonstrate usage of the new parameter.