### PR TITLE
Fix warnings

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/Attachments/AttachmentList.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/Attachments/AttachmentList.swift
@@ -95,8 +95,6 @@ struct AttachmentLoadButton: View  {
                         .aspectRatio(contentMode: .fit)
                         .foregroundColor(.red)
                         .background(Color.clear)
-                @unknown default:
-                    EmptyView()
                 }
             }
             .frame(width: 24, height: 24)

--- a/Sources/ArcGISToolkit/Extensions/Viewpoint.swift
+++ b/Sources/ArcGISToolkit/Extensions/Viewpoint.swift
@@ -18,16 +18,16 @@ public extension Viewpoint {
     /// - Parameter rotation: The rotation for the new viewpoint.
     /// - Returns: A new viewpoint.
     func withRotation(_ rotation: Double) -> Viewpoint {
-        switch self.kind {
+        switch kind {
         case .centerAndScale:
             return Viewpoint(
-                center: self.targetGeometry as! Point,
-                scale: self.targetScale,
+                center: targetGeometry as! Point,
+                scale: targetScale,
                 rotation: rotation
             )
         case .boundingGeometry:
             return Viewpoint(
-                boundingGeometry: self.targetGeometry,
+                boundingGeometry: targetGeometry,
                 rotation: rotation
             )
         @unknown default:

--- a/Sources/ArcGISToolkit/Extensions/Viewpoint.swift
+++ b/Sources/ArcGISToolkit/Extensions/Viewpoint.swift
@@ -25,11 +25,13 @@ public extension Viewpoint {
                 scale: self.targetScale,
                 rotation: rotation
             )
-        case.boundingGeometry:
+        case .boundingGeometry:
             return Viewpoint(
                 boundingGeometry: self.targetGeometry,
                 rotation: rotation
             )
+        @unknown default:
+            return self
         }
     }
 }


### PR DESCRIPTION
I'm using the most recent 200.1 build. 

Fixes these warnings:

![Screenshot 2023-04-11 at 10 22 57 AM](https://user-images.githubusercontent.com/74069582/231241225-ba985526-83d1-4085-bcdc-3be8fba67730.png)

This enum needs to check for other cases.

![Screenshot 2023-04-11 at 10 21 32 AM](https://user-images.githubusercontent.com/74069582/231241230-7e05029d-093c-4952-af44-61d94d5006cd.png)

The `LoadStatus` enum is now frozen so we don't need to check for new cases.
