### PR TITLE
Fix `AuthenticatorTests` compile failure

### DIFF
--- a/Tests/ArcGISToolkitTests/AuthenticatorTests.swift
+++ b/Tests/ArcGISToolkitTests/AuthenticatorTests.swift
@@ -13,7 +13,7 @@
 
 import XCTest
 @testable import ArcGISToolkit
-@testable import ArcGIS
+import ArcGIS
 import Combine
 
 @MainActor final class AuthenticatorTests: XCTestCase {


### PR DESCRIPTION
The toolkit is released with the closed-source SDK so we cannot use the `@testable` attribute.