### PR TITLE
[UN Trace] - Rename `viewPoint` to `screenPoint`, support viewpoint animation, make proxy a non-binding property

### DIFF
--- a/Documentation/UtilityNetworkTrace/README.md
+++ b/Documentation/UtilityNetworkTrace/README.md
@@ -24,8 +24,7 @@ A named trace configuration defined for a utility network in a webmap comprises 
     ///   - map: The map containing the utility network(s).
     ///   - mapPoint: Acts as the point at which newly selected starting point graphics will be created.
     ///   - screenPoint: Acts as the point of identification for items tapped in the utility network.
-    ///   - mapViewProxy: Provides a method of layer identification when starting points are being
-    ///   chosen.
+    ///   - mapViewProxy: Provides access to the map view's identification and animation functionality.
     ///   - viewpoint: Allows the utility network trace tool to update the parent map view's viewpoint.
     ///   - startingPoints: An optional list of programmatically provided starting points.
     public init(

--- a/Documentation/UtilityNetworkTrace/README.md
+++ b/Documentation/UtilityNetworkTrace/README.md
@@ -23,7 +23,7 @@ A named trace configuration defined for a utility network in a webmap comprises 
     ///   - graphicsOverlay: The graphics overlay to hold generated starting point and trace graphics.
     ///   - map: The map containing the utility network(s).
     ///   - mapPoint: Acts as the point at which newly selected starting point graphics will be created.
-    ///   - viewPoint: Acts as the point of identification for items tapped in the utility network.
+    ///   - screenPoint: Acts as the point of identification for items tapped in the utility network.
     ///   - mapViewProxy: Provides a method of layer identification when starting points are being
     ///   chosen.
     ///   - viewpoint: Allows the utility network trace tool to update the parent map view's viewpoint.
@@ -32,7 +32,7 @@ A named trace configuration defined for a utility network in a webmap comprises 
         graphicsOverlay: Binding<GraphicsOverlay>,
         map: Map,
         mapPoint: Binding<Point?>,
-        viewPoint: Binding<CGPoint?>,
+        screenPoint: Binding<CGPoint?>,
         mapViewProxy: Binding<MapViewProxy?>,
         viewpoint: Binding<Viewpoint?>,
         startingPoints: Binding<[UtilityNetworkTraceStartingPoint]> = .constant([])

--- a/Documentation/UtilityNetworkTrace/README.md
+++ b/Documentation/UtilityNetworkTrace/README.md
@@ -24,7 +24,7 @@ A named trace configuration defined for a utility network in a webmap comprises 
     ///   - map: The map containing the utility network(s).
     ///   - mapPoint: Acts as the point at which newly selected starting point graphics will be created.
     ///   - screenPoint: Acts as the point of identification for items tapped in the utility network.
-    ///   - mapViewProxy: Provides access to the map view's identification and animation functionality.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     ///   - viewpoint: Allows the utility network trace tool to update the parent map view's viewpoint.
     ///   - startingPoints: An optional list of programmatically provided starting points.
     public init(

--- a/Documentation/UtilityNetworkTrace/README.md
+++ b/Documentation/UtilityNetworkTrace/README.md
@@ -32,7 +32,7 @@ A named trace configuration defined for a utility network in a webmap comprises 
         map: Map,
         mapPoint: Binding<Point?>,
         screenPoint: Binding<CGPoint?>,
-        mapViewProxy: Binding<MapViewProxy?>,
+        mapViewProxy: MapViewProxy?,
         viewpoint: Binding<Viewpoint?>,
         startingPoints: Binding<[UtilityNetworkTraceStartingPoint]> = .constant([])
     )

--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -24,9 +24,6 @@ struct UtilityNetworkTraceExampleView: View {
     /// The current detent of the floating panel presenting the trace tool.
     @State var activeDetent: FloatingPanelDetent = .half
     
-    /// Provides the ability to inspect map components.
-    @State var mapViewProxy: MapViewProxy?
-    
     /// Provides the ability to detect tap locations in the context of the map view.
     @State var mapPoint: Point?
     
@@ -49,7 +46,6 @@ struct UtilityNetworkTraceExampleView: View {
             .onSingleTapGesture { screenPoint, mapPoint in
                 self.screenPoint = screenPoint
                 self.mapPoint = mapPoint
-                self.mapViewProxy = mapViewProxy
             }
             .onViewpointChanged(kind: .centerAndScale) {
                 viewpoint = $0
@@ -69,7 +65,7 @@ struct UtilityNetworkTraceExampleView: View {
                     map: map,
                     mapPoint: $mapPoint,
                     screenPoint: $screenPoint,
-                    mapViewProxy: $mapViewProxy,
+                    mapViewProxy: mapViewProxy,
                     viewpoint: $viewpoint
                 )
                 .floatingPanelDetent($activeDetent)

--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -15,8 +15,8 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
-/// A demonstration of the utility network trace tool which runs traces on a web map published with a utility
-/// network and trace configurations.
+/// A demonstration of the utility network trace tool which runs traces on a web map published with
+/// a utility network and trace configurations.
 struct UtilityNetworkTraceExampleView: View {
     /// The data model containing a `Map` with the utility networks.
     @StateObject private var dataModel = MapDataModel(
@@ -33,7 +33,7 @@ struct UtilityNetworkTraceExampleView: View {
     @State var mapPoint: Point?
     
     /// Provides the ability to detect tap locations in the context of the screen.
-    @State var viewPoint: CGPoint?
+    @State var screenPoint: CGPoint?
     
     /// A container for graphical trace results.
     @State var resultGraphicsOverlay = GraphicsOverlay()
@@ -48,8 +48,8 @@ struct UtilityNetworkTraceExampleView: View {
                 viewpoint: viewpoint,
                 graphicsOverlays: [resultGraphicsOverlay]
             )
-            .onSingleTapGesture { viewPoint, mapPoint in
-                self.viewPoint = viewPoint
+            .onSingleTapGesture { screenPoint, mapPoint in
+                self.screenPoint = screenPoint
                 self.mapPoint = mapPoint
                 self.mapViewProxy = mapViewProxy
             }
@@ -70,7 +70,7 @@ struct UtilityNetworkTraceExampleView: View {
                     graphicsOverlay: $resultGraphicsOverlay,
                     map: dataModel.map,
                     mapPoint: $mapPoint,
-                    viewPoint: $viewPoint,
+                    screenPoint: $screenPoint,
                     mapViewProxy: $mapViewProxy,
                     viewpoint: $viewpoint
                 )

--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -18,10 +18,8 @@ import SwiftUI
 /// A demonstration of the utility network trace tool which runs traces on a web map published with
 /// a utility network and trace configurations.
 struct UtilityNetworkTraceExampleView: View {
-    /// The data model containing a `Map` with the utility networks.
-    @StateObject private var dataModel = MapDataModel(
-        map: makeMap()
-    )
+    /// The map with the utility networks.
+    @State private var map = makeMap()
     
     /// The current detent of the floating panel presenting the trace tool.
     @State var activeDetent: FloatingPanelDetent = .half
@@ -44,7 +42,7 @@ struct UtilityNetworkTraceExampleView: View {
     var body: some View {
         MapViewReader { mapViewProxy in
             MapView(
-                map: dataModel.map,
+                map: map,
                 viewpoint: viewpoint,
                 graphicsOverlays: [resultGraphicsOverlay]
             )
@@ -68,7 +66,7 @@ struct UtilityNetworkTraceExampleView: View {
             ) {
                 UtilityNetworkTrace(
                     graphicsOverlay: $resultGraphicsOverlay,
-                    map: dataModel.map,
+                    map: map,
                     mapPoint: $mapPoint,
                     screenPoint: $screenPoint,
                     mapViewProxy: $mapViewProxy,

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -545,8 +545,7 @@ public struct UtilityNetworkTrace: View {
     ///   - map: The map containing the utility network(s).
     ///   - mapPoint: Acts as the point at which newly selected starting point graphics will be created.
     ///   - screenPoint: Acts as the point of identification for items tapped in the utility network.
-    ///   - mapViewProxy: Provides a method of layer identification when starting points are being
-    ///   chosen.
+    ///   - mapViewProxy: Provides access to the map view's identification and animation functionality.
     ///   - viewpoint: Allows the utility network trace tool to update the parent map view's viewpoint.
     ///   - startingPoints: An optional list of programmatically provided starting points.
     public init(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -439,7 +439,12 @@ public struct UtilityNetworkTrace: View {
             Button("Zoom To") {
                 if let selectedStartingPoint = selectedStartingPoint,
                    let extent = selectedStartingPoint.geoElement.geometry?.extent {
-                    viewpoint = Viewpoint(boundingGeometry: extent)
+                    let newViewpoint = Viewpoint(boundingGeometry: extent)
+                    if let mapViewProxy {
+                        Task { await mapViewProxy.setViewpoint(newViewpoint, duration: nil) }
+                    } else {
+                        viewpoint = newViewpoint
+                    }
                 }
             }
             Button("Delete", role: .destructive) {

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -15,6 +15,9 @@ import ArcGIS
 import SwiftUI
 
 public struct UtilityNetworkTrace: View {
+    /// The proxy to provide access to map view operations.
+    private var mapViewProxy: MapViewProxy?
+    
     // MARK: Enums
     
     /// Activities users will perform while creating a new trace.
@@ -79,9 +82,6 @@ public struct UtilityNetworkTrace: View {
     
     /// The graphics overlay to hold generated starting point and trace graphics.
     @Binding private var graphicsOverlay: GraphicsOverlay
-    
-    /// The proxy to provide access to map view operations.
-    @Binding private var mapViewProxy: MapViewProxy?
     
     /// Acts as the point of identification for items tapped in the utility network.
     @Binding private var screenPoint: CGPoint?
@@ -553,14 +553,14 @@ public struct UtilityNetworkTrace: View {
         map: Map,
         mapPoint: Binding<Point?>,
         screenPoint: Binding<CGPoint?>,
-        mapViewProxy: Binding<MapViewProxy?>,
+        mapViewProxy: MapViewProxy?,
         viewpoint: Binding<Viewpoint?>,
         startingPoints: Binding<[UtilityNetworkTraceStartingPoint]> = .constant([])
     ) {
+        self.mapViewProxy = mapViewProxy
         _activeDetent = .constant(nil)
         _screenPoint = screenPoint
         _mapPoint = mapPoint
-        _mapViewProxy = mapViewProxy
         _graphicsOverlay = graphicsOverlay
         _viewpoint = viewpoint
         _externalStartingPoints = startingPoints

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -84,7 +84,7 @@ public struct UtilityNetworkTrace: View {
     @Binding private var mapViewProxy: MapViewProxy?
     
     /// Acts as the point of identification for items tapped in the utility network.
-    @Binding private var viewPoint: CGPoint?
+    @Binding private var screenPoint: CGPoint?
     
     /// Acts as the point at which newly selected starting point graphics will be created.
     @Binding private var mapPoint: Point?
@@ -534,7 +534,7 @@ public struct UtilityNetworkTrace: View {
     ///   - graphicsOverlay: The graphics overlay to hold generated starting point and trace graphics.
     ///   - map: The map containing the utility network(s).
     ///   - mapPoint: Acts as the point at which newly selected starting point graphics will be created.
-    ///   - viewPoint: Acts as the point of identification for items tapped in the utility network.
+    ///   - screenPoint: Acts as the point of identification for items tapped in the utility network.
     ///   - mapViewProxy: Provides a method of layer identification when starting points are being
     ///   chosen.
     ///   - viewpoint: Allows the utility network trace tool to update the parent map view's viewpoint.
@@ -543,13 +543,13 @@ public struct UtilityNetworkTrace: View {
         graphicsOverlay: Binding<GraphicsOverlay>,
         map: Map,
         mapPoint: Binding<Point?>,
-        viewPoint: Binding<CGPoint?>,
+        screenPoint: Binding<CGPoint?>,
         mapViewProxy: Binding<MapViewProxy?>,
         viewpoint: Binding<Viewpoint?>,
         startingPoints: Binding<[UtilityNetworkTraceStartingPoint]> = .constant([])
     ) {
         _activeDetent = .constant(nil)
-        _viewPoint = viewPoint
+        _screenPoint = screenPoint
         _mapPoint = mapPoint
         _mapViewProxy = mapViewProxy
         _graphicsOverlay = graphicsOverlay
@@ -605,18 +605,18 @@ public struct UtilityNetworkTrace: View {
         }
         .background(Color(uiColor: .systemGroupedBackground))
         .animation(.default, value: currentActivity)
-        .onChange(of: viewPoint) { newValue in
+        .onChange(of: screenPoint) { newScreenPoint in
             guard isFocused(traceCreationActivity: .addingStartingPoints),
                   let mapViewProxy = mapViewProxy,
                   let mapPoint = mapPoint,
-                  let viewPoint = viewPoint else {
+                  let screenPoint = newScreenPoint else {
                 return
             }
             currentActivity = .creatingTrace(.viewingStartingPoints)
             activeDetent = .half
             Task {
                 await viewModel.addStartingPoints(
-                    at: viewPoint,
+                    at: screenPoint,
                     mapPoint: mapPoint,
                     with: mapViewProxy
                 )

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -324,7 +324,12 @@ public struct UtilityNetworkTrace: View {
             Menu(selectedTrace.name) {
                 if let resultExtent = selectedTrace.resultExtent {
                     Button("Zoom To") {
-                        viewpoint = Viewpoint(boundingGeometry: resultExtent)
+                        let newViewpoint = Viewpoint(boundingGeometry: resultExtent)
+                        if let mapViewProxy {
+                            Task { await mapViewProxy.setViewpoint(newViewpoint, duration: nil) }
+                        } else {
+                            viewpoint = newViewpoint
+                        }
                     }
                 }
                 Button("Delete", role: .destructive) {

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -80,7 +80,7 @@ public struct UtilityNetworkTrace: View {
     /// The graphics overlay to hold generated starting point and trace graphics.
     @Binding private var graphicsOverlay: GraphicsOverlay
     
-    /// Provides a method of layer identification when starting points are being chosen.
+    /// The proxy to provide access to map view operations.
     @Binding private var mapViewProxy: MapViewProxy?
     
     /// Acts as the point of identification for items tapped in the utility network.
@@ -545,7 +545,7 @@ public struct UtilityNetworkTrace: View {
     ///   - map: The map containing the utility network(s).
     ///   - mapPoint: Acts as the point at which newly selected starting point graphics will be created.
     ///   - screenPoint: Acts as the point of identification for items tapped in the utility network.
-    ///   - mapViewProxy: Provides access to the map view's identification and animation functionality.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     ///   - viewpoint: Allows the utility network trace tool to update the parent map view's viewpoint.
     ///   - startingPoints: An optional list of programmatically provided starting points.
     public init(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -149,7 +149,12 @@ public struct UtilityNetworkTrace: View {
                                     Task {
                                         if let feature = await viewModel.feature(for: element),
                                            let geometry = feature.geometry {
-                                            viewpoint = Viewpoint(boundingGeometry: geometry.extent)
+                                            let newViewpoint = Viewpoint(boundingGeometry: geometry.extent)
+                                            if let mapViewProxy {
+                                                Task { await mapViewProxy.setViewpoint(newViewpoint, duration: nil) }
+                                            } else {
+                                                viewpoint = newViewpoint
+                                            }
                                         }
                                     }
                                 } label: {

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
@@ -117,18 +117,18 @@ import SwiftUI
     
     /// Adds new starting points to the pending trace.
     /// - Parameters:
-    ///   - point: A point on the map in screen coordinates.
+    ///   - screenPoint: A point on the map in screen coordinates.
     ///   - mapPoint: A point on the map in map coordinates.
     ///   - proxy: Provides a method of layer identification.
     ///
     /// An identify operation will run on each layer in the network. Every element returned from
     /// each layer will be added as a new starting point.
-    func addStartingPoints(at point: CGPoint, mapPoint: Point, with proxy: MapViewProxy) async {
+    func addStartingPoints(at screenPoint: CGPoint, mapPoint: Point, with proxy: MapViewProxy) async {
         await withTaskGroup(of: Void.self) { [weak self] taskGroup in
             guard let self else { return }
             for layer in network?.layers ?? [] {
                 taskGroup.addTask {
-                    if let result = try? await proxy.identify(on: layer, screenPoint: point, tolerance: 10) {
+                    if let result = try? await proxy.identify(on: layer, screenPoint: screenPoint, tolerance: 10) {
                         for element in result.geoElements {
                             await self.processAndAdd(
                                 startingPoint: UtilityNetworkTraceStartingPoint(geoElement: element, mapPoint: mapPoint)


### PR DESCRIPTION
Related #260 

- The `viewPoint` parameter is renamed to `screenPoint` to match the new default names provided when adding the `onSingleTapGesture` to a geo view.
- The proxy is no longer a binding property. There was no need for it be a binding and it simplifies the usage.
- In the sample, the map is now simple a `@State` property rather than a `MapDataModel`
- Tapping "Zoom To" either on a completed trace name or starting point will perform an animated zoom to the proper extent.