### PR TITLE
[Compass] Re-think API

### DIFF
--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -19,8 +19,8 @@ Compass:
 `Compass` has the following initializer:
 
 ```swift
-    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
-    /// a direction toward true West, etc.).
+    /// Creates a compass with a rotation (0° indicates a map rotation towards true North, 90°
+    /// indicates a map rotation towards true East, etc.).
     /// - Parameters:
     ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -23,7 +23,7 @@ Compass:
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpoint: Viewpoint?, mapViewProxy: MapViewProxy? = nil)
+    public init(viewpoint: Viewpoint?, mapViewProxy: MapViewProxy)
 ```
 
 ```swift
@@ -33,7 +33,7 @@ Compass:
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpointRotation: Double?, mapViewProxy: MapViewProxy? = nil)
+    public init(viewpointRotation: Double?, mapViewProxy: MapViewProxy)
 ```
 
 `Compass` has the following modifiers:

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -19,22 +19,11 @@ Compass:
 `Compass` has the following initializers:
 
 ```swift
-    /// Creates a compass with a binding to a heading based on compass
-    /// directions (0° indicates a direction toward true North, 90° indicates a
-    /// direction toward true East, etc.).
-    /// - Parameters:
-    ///   - heading: The heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(heading: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
-```
-
-```swift
     /// Creates a compass with a binding to a viewpoint rotation (0° indicates
     /// a direction toward true North, 90° indicates a direction toward true
     /// West, etc.).
     /// - Parameters:
-    ///   - viewpointRotation: The viewpoint rotation whose value determines the
-    ///   heading of the compass.
+    ///   - viewpointRotation: The viewpoint rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     public init(viewpointRotation: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
 ```
@@ -65,19 +54,14 @@ When the compass is tapped, the map orients back to north (zero bearing).
 ```swift
 @State private var map = Map(basemapStyle: .arcGISImagery)
 
-/// Allows for communication between the Compass and MapView or SceneView.
-@State private var viewpoint: Viewpoint? = Viewpoint(
-    center: Point(x: -117.19494, y: 34.05723, spatialReference: .wgs84),
-    scale: 10_000,
-    rotation: -45
-)
+@State private var viewpoint: Viewpoint?
 
 var body: some View {
     MapViewReader { proxy in
         MapView(map: map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .overlay(alignment: .topTrailing) {
-                Compass(viewpoint: $viewpoint, mapViewProxy: proxy)
+                Compass(viewpoint: viewpoint, mapViewProxy: proxy)
                     .padding()
             }
     }

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -19,8 +19,8 @@ Compass:
 `Compass` has the following initializer:
 
 ```swift
-    /// Creates a compass with a rotation (0° indicates a map rotation towards true North, 90°
-    /// indicates a map rotation towards true East, etc.).
+    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
+    /// a direction toward true West, etc.).
     /// - Parameters:
     ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -16,22 +16,14 @@ Compass:
 
 ## Key properties
 
-`Compass` has the following initializers:
-
-```swift
-    /// Creates a compass with a binding to an optional viewpoint.
-    /// - Parameters:
-    ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpoint: Viewpoint?, mapViewProxy: MapViewProxy)
-```
+`Compass` has the following initializer:
 
 ```swift
     /// Creates a compass with a binding to a viewpoint rotation (0° indicates
     /// a direction toward true North, 90° indicates a direction toward true
     /// West, etc.).
     /// - Parameters:
-    ///   - viewpointRotation: The viewpoint rotation whose value determines the heading of the compass.
+    ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     public init(viewpointRotation: Double?, mapViewProxy: MapViewProxy)
 ```
@@ -61,7 +53,7 @@ var body: some View {
         MapView(map: map, viewpoint: viewpoint)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .overlay(alignment: .topTrailing) {
-                Compass(viewpoint: viewpoint, mapViewProxy: proxy)
+                Compass(rotation: viewpoint?.rotation, mapViewProxy: proxy)
                     .padding()
             }
     }

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -19,6 +19,14 @@ Compass:
 `Compass` has the following initializers:
 
 ```swift
+    /// Creates a compass with a binding to an optional viewpoint.
+    /// - Parameters:
+    ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
+    public init(viewpoint: Viewpoint?, mapViewProxy: MapViewProxy? = nil)
+```
+
+```swift
     /// Creates a compass with a binding to a viewpoint rotation (0° indicates
     /// a direction toward true North, 90° indicates a direction toward true
     /// West, etc.).
@@ -26,14 +34,6 @@ Compass:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     public init(viewpointRotation: Double?, mapViewProxy: MapViewProxy? = nil)
-```
-
-```swift
-    /// Creates a compass with a binding to an optional viewpoint.
-    /// - Parameters:
-    ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpoint: Viewpoint?, mapViewProxy: MapViewProxy? = nil)
 ```
 
 `Compass` has the following modifiers:

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -19,13 +19,12 @@ Compass:
 `Compass` has the following initializer:
 
 ```swift
-    /// Creates a compass with a binding to a viewpoint rotation (0° indicates
-    /// a direction toward true North, 90° indicates a direction toward true
-    /// West, etc.).
+    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
+    /// a direction toward true West, etc.).
     /// - Parameters:
     ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpointRotation: Double?, mapViewProxy: MapViewProxy)
+    public init(rotation: Double?, mapViewProxy: MapViewProxy)
 ```
 
 `Compass` has the following modifiers:

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -25,7 +25,7 @@ Compass:
     /// - Parameters:
     ///   - viewpointRotation: The viewpoint rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpointRotation: Binding<Double>, mapViewProxy: MapViewProxy? = nil)
+    public init(viewpointRotation: Double?, mapViewProxy: MapViewProxy? = nil)
 ```
 
 ```swift
@@ -33,7 +33,7 @@ Compass:
     /// - Parameters:
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(viewpoint: Binding<Viewpoint?>, mapViewProxy: MapViewProxy? = nil)
+    public init(viewpoint: Viewpoint?, mapViewProxy: MapViewProxy? = nil)
 ```
 
 `Compass` has the following modifiers:

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -28,7 +28,7 @@ struct CompassExampleView: View {
             MapView(map: map, viewpoint: viewpoint)
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
-                    Compass(viewpoint: $viewpoint, mapViewProxy: proxy)
+                    Compass(viewpoint: viewpoint, mapViewProxy: proxy)
                         .padding()
                 }
         }

--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -28,7 +28,7 @@ struct CompassExampleView: View {
             MapView(map: map, viewpoint: viewpoint)
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
-                    Compass(viewpoint: viewpoint, mapViewProxy: proxy)
+                    Compass(rotation: viewpoint?.rotation, mapViewProxy: proxy)
                         .padding()
                 }
         }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -14,8 +14,7 @@
 import ArcGIS
 import SwiftUI
 
-/// A `Compass` (alias North arrow) shows where north is in a `MapView` or
-/// `SceneView`.
+/// A `Compass` (alias North arrow) shows where north is in a `MapView` or `SceneView`.
 public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
@@ -28,7 +27,7 @@ public struct Compass: View {
     private var heading: Double
     
     /// The proxy to provide access to map view operations.
-    private var mapViewProxy: MapViewProxy
+    private var mapViewProxy: MapViewProxy?
     
     /// The width and height of the compass.
     private var size: CGFloat = 44
@@ -41,7 +40,7 @@ public struct Compass: View {
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
         heading: Double,
-        mapViewProxy: MapViewProxy
+        mapViewProxy: MapViewProxy? = nil
     ) {
         self.heading = heading
         self.mapViewProxy = mapViewProxy
@@ -66,7 +65,7 @@ public struct Compass: View {
                     }
                 }
                 .onTapGesture {
-                    Task { await mapViewProxy.setViewpointRotation(0) }
+                    Task { await mapViewProxy?.setViewpointRotation(0) }
                 }
                 .accessibilityLabel("Compass, heading \(Int(heading.rounded())) degrees \(CompassDirection(heading).rawValue)")
         }
@@ -88,8 +87,7 @@ public extension Compass {
     /// a direction toward true North, 90° indicates a direction toward true
     /// West, etc.).
     /// - Parameters:
-    ///   - viewpointRotation: The viewpoint rotation whose value determines the
-    ///   heading of the compass.
+    ///   - viewpointRotation: The viewpoint rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
         viewpointRotation: Double?,

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -82,8 +82,8 @@ extension Compass {
 }
 
 public extension Compass {
-    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
-    /// a direction toward true West, etc.).
+    /// Creates a compass with a rotation (0° indicates a map rotation towards true North, 90°
+    /// indicates a map rotation towards true East, etc.).
     /// - Parameters:
     ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -83,6 +83,20 @@ extension Compass {
 }
 
 public extension Compass {
+    /// Creates a compass with a binding to an optional viewpoint.
+    /// - Parameters:
+    ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
+    init(
+        viewpoint: Viewpoint?,
+        mapViewProxy: MapViewProxy
+    ) {
+        self.init(
+            viewpointRotation: viewpoint?.rotation ?? .nan,
+            mapViewProxy: mapViewProxy
+        )
+    }
+    
     /// Creates a compass with a binding to a viewpoint rotation (0° indicates
     /// a direction toward true North, 90° indicates a direction toward true
     /// West, etc.).
@@ -101,20 +115,6 @@ public extension Compass {
         } else {
             self.init(heading: .nan, mapViewProxy: mapViewProxy)
         }
-    }
-    
-    /// Creates a compass with a binding to an optional viewpoint.
-    /// - Parameters:
-    ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations.
-    init(
-        viewpoint: Viewpoint?,
-        mapViewProxy: MapViewProxy
-    ) {
-        self.init(
-            viewpointRotation: viewpoint?.rotation ?? .nan,
-            mapViewProxy: mapViewProxy
-        )
     }
     
     /// Define a custom size for the compass.

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -83,33 +83,19 @@ extension Compass {
 }
 
 public extension Compass {
-    /// Creates a compass with a binding to an optional viewpoint.
-    /// - Parameters:
-    ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations.
-    init(
-        viewpoint: Viewpoint?,
-        mapViewProxy: MapViewProxy
-    ) {
-        self.init(
-            viewpointRotation: viewpoint?.rotation ?? .nan,
-            mapViewProxy: mapViewProxy
-        )
-    }
-    
     /// Creates a compass with a binding to a viewpoint rotation (0° indicates
     /// a direction toward true North, 90° indicates a direction toward true
     /// West, etc.).
     /// - Parameters:
-    ///   - viewpointRotation: The viewpoint rotation whose value determines the heading of the compass.
+    ///   - rotation: The viewpoint rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
-        viewpointRotation: Double?,
+        rotation: Double?,
         mapViewProxy: MapViewProxy
     ) {
         let heading: Double
-        if let viewpointRotation {
-            heading = viewpointRotation.isZero ? .zero : 360 - viewpointRotation
+        if let rotation {
+            heading = rotation.isZero ? .zero : 360 - rotation
         } else {
             heading = .nan
         }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -107,14 +107,13 @@ public extension Compass {
         viewpointRotation: Double?,
         mapViewProxy: MapViewProxy
     ) {
+        let heading: Double
         if let viewpointRotation {
-            self.init(
-                heading: viewpointRotation.isZero ? .zero : 360 - viewpointRotation,
-                mapViewProxy: mapViewProxy
-            )
+            heading = viewpointRotation.isZero ? .zero : 360 - viewpointRotation
         } else {
-            self.init(heading: .nan, mapViewProxy: mapViewProxy)
+            heading = .nan
         }
+        self.init(heading: heading, mapViewProxy: mapViewProxy)
     }
     
     /// Define a custom size for the compass.

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -32,9 +32,8 @@ public struct Compass: View {
     /// The width and height of the compass.
     private var size: CGFloat = 44
     
-    /// Creates a compass with a binding to a heading based on compass
-    /// directions (0° indicates a direction toward true North, 90° indicates a
-    /// direction toward true East, etc.).
+    /// Creates a compass with a heading based on compass directions (0° indicates a direction
+    /// toward true North, 90° indicates a direction toward true East, etc.).
     /// - Parameters:
     ///   - heading: The heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
@@ -83,11 +82,10 @@ extension Compass {
 }
 
 public extension Compass {
-    /// Creates a compass with a binding to a viewpoint rotation (0° indicates
-    /// a direction toward true North, 90° indicates a direction toward true
-    /// West, etc.).
+    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
+    /// a direction toward true West, etc.).
     /// - Parameters:
-    ///   - rotation: The viewpoint rotation whose value determines the heading of the compass.
+    ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
         rotation: Double?,

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -79,8 +79,7 @@ extension Compass {
     /// - Parameter heading: The heading used to determine if the compass should hide.
     /// - Returns: `true` if the compass should hide, `false` otherwise.
     func shouldHide(forHeading heading: Double) -> Bool {
-        print(heading)
-        return (heading.rounded(.up) == 360 || heading.rounded(.down) == 0 || heading.isNaN) && autoHide
+        (heading.rounded(.up) == 360 || heading.rounded(.down) == 0 || heading.isNaN) && autoHide
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -14,7 +14,7 @@
 import ArcGIS
 import SwiftUI
 
-/// A `Compass` (alias North arrow) shows where north is in a `MapView` or `SceneView`.
+/// A `Compass` (alias North arrow) shows where north is in a `MapView`.
 public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -79,7 +79,7 @@ extension Compass {
     /// - Parameter heading: The heading used to determine if the compass should hide.
     /// - Returns: `true` if the compass should hide, `false` otherwise.
     func shouldHide(forHeading heading: Double) -> Bool {
-        (heading.rounded(.up) == 360 || heading.rounded(.down) == 0 || heading.isNaN) && autoHide
+        (heading.isZero || heading.isNaN) && autoHide
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -20,24 +20,18 @@ public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
-    /// The proxy to provide access to map view operations.
-    private var mapViewProxy: MapViewProxy?
-    
     /// A Boolean value indicating whether  the compass should automatically
     /// hide/show itself when the heading is `0`.
     private var autoHide: Bool = true
     
-    /// A Boolean value indicating whether the compass should hide based on the
-    ///  current heading and whether the compass automatically hides.
-    var shouldHide: Bool {
-        (heading.isZero || heading.isNaN) && autoHide
-    }
+    /// The heading of the compass in degrees.
+    private var heading: Double
+    
+    /// The proxy to provide access to map view operations.
+    private var mapViewProxy: MapViewProxy
     
     /// The width and height of the compass.
     private var size: CGFloat = 44
-    
-    /// The heading of the compass in degrees.
-    @Binding private var heading: Double
     
     /// Creates a compass with a binding to a heading based on compass
     /// directions (0° indicates a direction toward true North, 90° indicates a
@@ -45,11 +39,11 @@ public struct Compass: View {
     /// - Parameters:
     ///   - heading: The heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
-    public init(
-        heading: Binding<Double>,
-        mapViewProxy: MapViewProxy? = nil
+    init(
+        heading: Double,
+        mapViewProxy: MapViewProxy
     ) {
-        _heading = heading
+        self.heading = heading
         self.mapViewProxy = mapViewProxy
     }
     
@@ -63,23 +57,30 @@ public struct Compass: View {
                 .aspectRatio(1, contentMode: .fit)
                 .opacity(opacity)
                 .frame(width: size, height: size)
-                .onAppear { opacity = shouldHide ? 0 : 1 }
-                .onChange(of: heading) { _ in
-                    let newOpacity: Double = shouldHide ? .zero : 1
+                .onAppear { opacity = shouldHide(forHeading: heading) ? 0 : 1 }
+                .onChange(of: heading) { newHeading in
+                    let newOpacity: Double = shouldHide(forHeading: newHeading) ? .zero : 1
                     guard opacity != newOpacity else { return }
-                    withAnimation(.default.delay(shouldHide ? 0.25 : 0)) {
+                    withAnimation(.default.delay(shouldHide(forHeading: newHeading) ? 0.25 : 0)) {
                         opacity = newOpacity
                     }
                 }
                 .onTapGesture {
-                    if let mapViewProxy {
-                        Task { await mapViewProxy.setViewpointRotation(0) }
-                    } else {
-                        heading = .zero
-                    }
+                    Task { await mapViewProxy.setViewpointRotation(0) }
                 }
                 .accessibilityLabel("Compass, heading \(Int(heading.rounded())) degrees \(CompassDirection(heading).rawValue)")
         }
+    }
+}
+
+extension Compass {
+    /// Returns a Boolean value indicating whether the compass should hide based on the
+    /// provided heading and whether the compass has been configured to automatically hide.
+    /// - Parameter heading: The heading used to determine if the compass should hide.
+    /// - Returns: `true` if the compass should hide, `false` otherwise.
+    func shouldHide(forHeading heading: Double) -> Bool {
+        print(heading)
+        return (heading.rounded(.up) == 360 || heading.rounded(.down) == 0 || heading.isNaN) && autoHide
     }
 }
 
@@ -92,15 +93,17 @@ public extension Compass {
     ///   heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
-        viewpointRotation: Binding<Double>,
-        mapViewProxy: MapViewProxy? = nil
+        viewpointRotation: Double?,
+        mapViewProxy: MapViewProxy
     ) {
-        let heading = Binding(get: {
-            viewpointRotation.wrappedValue.isZero ? .zero : 360 - viewpointRotation.wrappedValue
-        }, set: { newHeading in
-            viewpointRotation.wrappedValue = newHeading.isZero ? .zero : 360 - newHeading
-        })
-        self.init(heading: heading, mapViewProxy: mapViewProxy)
+        if let viewpointRotation {
+            self.init(
+                heading: viewpointRotation.isZero ? .zero : 360 - viewpointRotation,
+                mapViewProxy: mapViewProxy
+            )
+        } else {
+            self.init(heading: .nan, mapViewProxy: mapViewProxy)
+        }
     }
     
     /// Creates a compass with a binding to an optional viewpoint.
@@ -108,20 +111,13 @@ public extension Compass {
     ///   - viewpoint: The viewpoint whose rotation determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
-        viewpoint: Binding<Viewpoint?>,
-        mapViewProxy: MapViewProxy? = nil
+        viewpoint: Viewpoint?,
+        mapViewProxy: MapViewProxy
     ) {
-        let viewpointRotation = Binding {
-            viewpoint.wrappedValue?.rotation ?? .nan
-        } set: { newViewpointRotation in
-            guard let oldViewpoint = viewpoint.wrappedValue else { return }
-            viewpoint.wrappedValue = Viewpoint(
-                center: oldViewpoint.targetGeometry.extent.center,
-                scale: oldViewpoint.targetScale,
-                rotation: newViewpointRotation
-            )
-        }
-        self.init(viewpointRotation: viewpointRotation, mapViewProxy: mapViewProxy)
+        self.init(
+            viewpointRotation: viewpoint?.rotation ?? .nan,
+            mapViewProxy: mapViewProxy
+        )
     }
     
     /// Define a custom size for the compass.

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -82,8 +82,8 @@ extension Compass {
 }
 
 public extension Compass {
-    /// Creates a compass with a rotation (0° indicates a map rotation towards true North, 90°
-    /// indicates a map rotation towards true East, etc.).
+    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
+    /// a direction toward true West, etc.).
     /// - Parameters:
     ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -17,76 +17,37 @@ import XCTest
 @testable import ArcGISToolkit
 
 final class CompassTests: XCTestCase {
-    /// Verifies that the compass accurately indicates when the compass should be hidden when
-    /// `autoHide` is `false`.
+    /// Verifies that the compass accurately indicates it shouldn't be hidden when `autoHideDisabled`
+    /// is applied.
     func testHiddenWithAutoHideOff() {
-        let initialValue = 0.0
-        let finalValue = 90.0
-        var _viewpoint: Viewpoint? = makeViewpoint(rotation: initialValue)
-        let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })
-        let compass = Compass(viewpoint: viewpoint)
+        let compass1Heading = Double.zero
+        let compass1 = Compass(heading: compass1Heading)
             .autoHideDisabled() as! Compass
-        XCTAssertFalse(compass.shouldHide)
-        _viewpoint = makeViewpoint(rotation: finalValue)
-        XCTAssertFalse(compass.shouldHide)
+        XCTAssertFalse(compass1.shouldHide(forHeading: compass1Heading))
+        
+        let compass2Heading = 45.0
+        let compass2 = Compass(heading: compass2Heading)
+            .autoHideDisabled() as! Compass
+        XCTAssertFalse(compass2.shouldHide(forHeading: compass2Heading))
+        
+        let compass3Heading = Double.nan
+        let compass3 = Compass(heading: compass3Heading)
+            .autoHideDisabled() as! Compass
+        XCTAssertFalse(compass3.shouldHide(forHeading: compass3Heading))
     }
     
-    /// Verifies that the compass accurately indicates when the compass should be hidden when
-    /// `autoHide` is `true` (which is the default).
+    /// Verifies that the compass accurately indicates when it should be hidden.
     func testHiddenWithAutoHideOn() {
-        let initialValue = 0.0
-        let finalValue = 90.0
-        var _viewpoint: Viewpoint? = makeViewpoint(rotation: initialValue)
-        let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })
-        let compass = Compass(viewpoint: viewpoint)
-        XCTAssertTrue(compass.shouldHide)
-        _viewpoint = makeViewpoint(rotation: finalValue)
-        XCTAssertFalse(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given a `nil` viewpoint.
-    func testInit() {
-        let compass = Compass(viewpoint: .constant(nil))
-        XCTAssertTrue(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given a `nil` viewpoint, and `autoHide` is
-    /// `false`.
-    func testAutomaticallyHidesNoAutoHide() {
-        let compass = Compass(viewpoint: .constant(nil))
-            .autoHideDisabled() as! Compass
-        XCTAssertFalse(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given only a viewpoint.
-    func testInitWithViewpoint() {
-        let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)))
-        XCTAssertTrue(compass.shouldHide)
-    }
-    
-    /// Verifies that the compass correctly initializes when given only a viewpoint.
-    func testInitWithViewpointAndAutoHide() {
-        let compass = Compass(viewpoint: .constant(makeViewpoint(rotation: .zero)))
-            .autoHideDisabled() as! Compass
-        XCTAssertFalse(compass.shouldHide)
-    }
-}
-
-extension CompassTests {
-    /// An arbitrary point to use for testing.
-    var point: Point {
-        Point(x: -117.19494, y: 34.05723, spatialReference: .wgs84)
-    }
-    
-    /// An arbitrary scale to use for testing.
-    var scale: Double {
-        10_000.00
-    }
-    
-    /// Builds viewpoints to use for tests.
-    /// - Parameter rotation: The rotation to use for the resulting viewpoint.
-    /// - Returns: A viewpoint object for tests.
-    func makeViewpoint(rotation: Double) -> Viewpoint {
-        return Viewpoint(center: point, scale: scale, rotation: rotation)
+        let compass1Heading: Double = .zero
+        let compass1 = Compass(heading: compass1Heading)
+        XCTAssertTrue(compass1.shouldHide(forHeading: compass1Heading))
+        
+        let compass2Heading = 45.0
+        let compass2 = Compass(heading: compass2Heading)
+        XCTAssertFalse(compass2.shouldHide(forHeading: compass2Heading))
+        
+        let compass3Heading = Double.nan
+        let compass3 = Compass(heading: compass3Heading)
+        XCTAssertTrue(compass3.shouldHide(forHeading: compass3Heading))
     }
 }


### PR DESCRIPTION
Given a mixture of feedback from Phil R. and Mark on #298 I propose the following Compass API:

Public initializer:
```swift
Compass(rotation: Double?, mapViewProxy: MapViewProxy)
```
Internal initializer:
```swift
Compass(heading: Double, mapViewProxy: MapViewProxy? = nil)
```

- In the public initializer the proxy isn't nullable as the majority of users will want animation. In the internal initializer, the proxy is nullable to keep the compass testable.

Thoughts appreciated from @rolson, @philium 

Additional note:

- Because heading is no longer a binding, when `shouldHide` was accessed from `.onChange(of: heading)` and the change was triggered by snap-to-north, `heading` would still have the pre-snap value causing `shouldHide` to compute incorrectly. For this reason, `shouldHide` became `func shouldHide(forHeading:)` so that `.onChange(of: heading)` could pass its new value.