### PR TITLE
[Floor Filter] Fix automatic selection in compact width

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -120,12 +120,6 @@ public struct FloorFilter: View {
         alignment.vertical == .top
     }
     
-    /// Reports a viewpoint change to the view model if the map is not navigating.
-    private func reportChange(of viewpoint: Viewpoint?) {
-        guard isNavigating.wrappedValue else { return }
-        viewModel.onViewpointChanged(viewpoint)
-    }
-    
     /// A view that allows selecting between levels.
     @ViewBuilder private var levelSelector: some View {
         LevelSelector(
@@ -189,8 +183,9 @@ public struct FloorFilter: View {
             selection?.wrappedValue = newValue
         }
         .onChange(of: viewpoint.wrappedValue) { newViewpoint in
+            guard isNavigating.wrappedValue else { return }
             if let newViewpoint {
-                reportChange(of: newViewpoint)
+                viewModel.onViewpointChanged(newViewpoint)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -146,18 +146,12 @@ public struct FloorFilter: View {
             Color.clear
                 .sheet(isPresented: .constant(!$isSitesAndFacilitiesHidden.wrappedValue)) {
                     SiteAndFacilitySelector(isHidden: $isSitesAndFacilitiesHidden)
-                        .onChange(of: viewpoint.wrappedValue) { viewpoint in
-                            reportChange(of: viewpoint)
-                        }
                 }
         } else {
             ZStack {
                 Color.clear
                     .esriBorder()
                 SiteAndFacilitySelector(isHidden: $isSitesAndFacilitiesHidden)
-                    .onChange(of: viewpoint.wrappedValue) { viewpoint in
-                        reportChange(of: viewpoint)
-                    }
                     .padding([.top, .leading, .trailing], 2.5)
                     .padding(.bottom)
             }
@@ -193,6 +187,11 @@ public struct FloorFilter: View {
             // Prevent a double-set if the user triggered the original change.
             guard selection?.wrappedValue != newValue else { return }
             selection?.wrappedValue = newValue
+        }
+        .onChange(of: viewpoint.wrappedValue) { newViewpoint in
+            if let newViewpoint {
+                reportChange(of: newViewpoint)
+            }
         }
     }
     


### PR DESCRIPTION
- Closes #307 

- Viewpoint changes should always be reported to the model, despite whether the site and facility selector is open or not.