### PR TITLE
Remove `LoginViewModel.signInButtonEnabled`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/Login.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Login.swift
@@ -28,17 +28,10 @@ struct LoginCredential: Hashable {
 @MainActor
 final class LoginViewModel: ObservableObject {
     /// The username.
-    @Published var username = "" {
-        didSet { updateSignInButtonEnabled() }
-    }
+    @Published var username = ""
     
     /// The password.
-    @Published var password = "" {
-        didSet { updateSignInButtonEnabled() }
-    }
-    
-    /// A Boolean value indicating if the sign-in button is enabled.
-    @Published var signInButtonEnabled = false
+    @Published var password = ""
     
     /// The action to perform when the user signs in. This is a closure that takes a username
     /// and password, respectively.
@@ -61,10 +54,6 @@ final class LoginViewModel: ObservableObject {
         self.challengingHost = challengingHost
         self.signInAction = signInAction
         self.cancelAction = cancelAction
-    }
-    
-    private func updateSignInButtonEnabled() {
-        signInButtonEnabled = !username.isEmpty && !password.isEmpty
     }
     
     /// The host that initiated the challenge.

--- a/Tests/ArcGISToolkitTests/LoginViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/LoginViewModelTests.swift
@@ -39,23 +39,10 @@ import XCTest
         XCTAssertEqual(model.challengingHost, "host.com")
         XCTAssertNotNil(model.signInAction)
         XCTAssertNotNil(model.cancelAction)
-        XCTAssertFalse(model.signInButtonEnabled)
         XCTAssertTrue(model.username.isEmpty)
         XCTAssertTrue(model.password.isEmpty)
         XCTAssertFalse(signInCalled)
         XCTAssertFalse(cancelCalled)
-        
-        model.username = "abc"
-        XCTAssertFalse(model.signInButtonEnabled)
-        
-        model.password = "123"
-        XCTAssertTrue(model.signInButtonEnabled)
-        
-        model.password = ""
-        XCTAssertFalse(model.signInButtonEnabled)
-        
-        model.password = "123"
-        XCTAssertTrue(model.signInButtonEnabled)
         
         model.signIn()
         XCTAssertTrue(signInCalled)


### PR DESCRIPTION
It isn't being used. If it ends up being needed in the future, it could just be a computed property (since each of the values it depends on are published) on the view (since the model shouldn't really know about things like buttons).