### PR TITLE
[Authenticator] Replace `task` with `onAppear`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -34,7 +34,7 @@ struct TrustHostViewModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         content
-            .task {
+            .onAppear {
                 // Present the alert right away. This makes it animated.
                 isPresented = true
             }


### PR DESCRIPTION
While recently reviewing nearby code @philium suggested this should use `onAppear` as no asynchronous work is performed within.

This change can be tested on branch "ryan2" by opening the regular toolkit sample app, GeoView -> Authentication -> Multiple token secured resources