### PR TITLE
[Authenticator] Update language in the trust host modifier

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -39,14 +39,14 @@ struct TrustHostViewModifier: ViewModifier {
                 isPresented = true
             }
             .alert("Certificate Trust Warning", isPresented: $isPresented, presenting: challenge) { _ in
-                Button("Dangerous: Allow Connection", role: .destructive) {
+                Button("Allow", role: .destructive) {
                     challenge.resume(with: .continueWithCredential(.serverTrust))
                 }
                 Button("Cancel", role: .cancel) {
                     challenge.resume(with: .cancel)
                 }
             } message: { _ in
-                Text("The certificate provided by '\(challenge.host)' is not signed by a trusted authority.")
+                Text("Dangerous: The certificate provided by '\(challenge.host)' is not signed by a trusted authority.")
             }
     }
 }


### PR DESCRIPTION
While recently reviewing nearby code @philium suggested we might consider changing the language of the trust host modifier:

> "Dangerous: Allow Connection" is a really odd name for a button. It seems like the button should just be named "Allow" and the part about it being dangerous should be in the alert's message.

"Continue" is another possibility for the button that I would consider.

<img width="300" alt="Screenshot 2023-04-24 at 17 08 21" src="https://user-images.githubusercontent.com/16397058/234145404-d881ed0e-1584-4619-9b25-51adeed1ee90.png">

