### PR TITLE
SceneView support for Compass

### DIFF
--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -43,7 +43,7 @@ Compass:
 
 Whenever the map is not orientated North (non-zero bearing) the compass appears. When reset to north, it disappears. The `autoHideDisabled` view modifier allows you to disable the auto-hide feature so that it is always displayed.
 
-When the compass is tapped, the map orients back to north (zero bearing). 
+When the compass is tapped, the map orients back to north (zero bearing).
 
 ## Usage
 

--- a/Documentation/Compass/README.md
+++ b/Documentation/Compass/README.md
@@ -16,24 +16,28 @@ Compass:
 
 ## Key properties
 
-`Compass` has the following initializer:
+`Compass` has the following initializers:
 
 ```swift
     /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
     /// a direction toward true West, etc.).
     /// - Parameters:
     ///   - rotation: The rotation whose value determines the heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations. If `mapViewProxy`
-    ///   is non-`nil`, the proxy will be used to set the rotation to `.zero` when the compass is
-    ///   tapped on. Otherwise, the `action` will be called (set using the `action` view modifier).
-    public init(rotation: Double?, mapViewProxy: MapViewProxy? = nil)
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
+    public init(rotation: Double?, mapViewProxy: MapViewProxy)
+    
+    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
+    /// a direction toward true West, etc.).
+    /// - Parameters:
+    ///   - rotation: The rotation whose value determines the heading of the compass.
+    ///   - action: The action to perform when the compass is tapped.
+    public init(rotation: Double?, action: @escaping () -> Void)
 ```
 
 `Compass` has the following modifiers:
 
 - `func compassSize(size: CGFloat)` - The size of the `Compass`, specifying both the width and height of the compass.
 - `func autoHideDisabled(_:)` - Specifies whether the ``Compass`` should automatically hide when the heading is 0.
-- `action(perform action: @escaping () -> Void)` - An action to perform when the compass is tapped. If `mapViewProxy` is non-`nil`, then this will have no effect.
 
 ## Behavior:
 
@@ -62,7 +66,7 @@ var body: some View {
 }
 ```
 
-To add a `Compass` to a scene view, you would not pass in a `mapViewProxy` argument in the initalizer, but use the `action` modifier to perform a custom action when the compass is tapped on.
+To add a `Compass` to a SceneView, use the initializer which takes an `action` argument to perform a custom action when the compass is tapped on.
 
 ```swift
 @State private var scene = Scene(basemapStyle: .arcGISImagery)
@@ -74,15 +78,14 @@ var body: some View {
         SceneView(scene: scene)
             .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
             .overlay(alignment: .topTrailing) {
-                Compass(rotation: viewpoint?.rotation)
-                    .action {
-                        if let viewpoint {
-                            Task {
-                                await proxy.setViewpoint(viewpoint.withRotation(.zero))
-                            }
+                Compass(rotation: viewpoint?.rotation) {
+                    if let viewpoint {
+                        Task {
+                            await proxy.setViewpoint(viewpoint.withRotation(.zero))
                         }
                     }
-                    .padding()
+                }
+                .padding()
             }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -121,15 +121,15 @@ public extension Compass {
     /// Specifies whether the ``Compass`` should automatically hide when the heading is 0.
     /// - Parameter disable: A Boolean value indicating whether the compass should automatically
     /// hide/show itself when the heading is `0`.
-    func autoHideDisabled(_ disable: Bool = true) -> some View {
+    func autoHideDisabled(_ disable: Bool = true) -> Self {
         var copy = self
         copy.autoHide = !disable
         return copy
     }
     
     /// An action to perform when the compass is tapped. If `mapViewProxy` is non-`nil`,
-    /// then this will have no affect.
-    func action(_ action: @escaping () -> Void) -> some View {
+    /// then this will have no effect.
+    func action(perform action: @escaping () -> Void) -> Self {
         var copy = self
         copy.action = action
         return copy

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -39,14 +39,23 @@ public struct Compass: View {
     /// Creates a compass with a heading based on compass directions (0° indicates a direction
     /// toward true North, 90° indicates a direction toward true East, etc.).
     /// - Parameters:
-    ///   - heading: The heading of the compass.
+    ///   - rotation: The rotation whose value determines the heading of the compass.
     ///   - mapViewProxy: The proxy to provide access to map view operations.
+    ///   - action: The action to perform when the compass is tapped.
     init(
-        heading: Double,
-        mapViewProxy: MapViewProxy? = nil
+        rotation: Double?,
+        mapViewProxy: MapViewProxy?,
+        action: (() -> Void)?
     ) {
+        let heading: Double
+        if let rotation {
+            heading = rotation.isZero ? .zero : 360 - rotation
+        } else {
+            heading = .nan
+        }
         self.heading = heading
         self.mapViewProxy = mapViewProxy
+        self.action = action
     }
     
     public var body: some View {
@@ -94,20 +103,24 @@ public extension Compass {
     /// a direction toward true West, etc.).
     /// - Parameters:
     ///   - rotation: The rotation whose value determines the heading of the compass.
-    ///   - mapViewProxy: The proxy to provide access to map view operations. If `mapViewProxy`
-    ///   is non-`nil`, the proxy will be used to set the rotation to `.zero` when the compass is
-    ///   tapped on. Otherwise, the `action` will be called (set using the `action` view modifier).
+    ///   - mapViewProxy: The proxy to provide access to map view operations.
     init(
         rotation: Double?,
-        mapViewProxy: MapViewProxy? = nil
+        mapViewProxy: MapViewProxy
     ) {
-        let heading: Double
-        if let rotation {
-            heading = rotation.isZero ? .zero : 360 - rotation
-        } else {
-            heading = .nan
-        }
-        self.init(heading: heading, mapViewProxy: mapViewProxy)
+        self.init(rotation: rotation, mapViewProxy: mapViewProxy, action: nil)
+    }
+    
+    /// Creates a compass with a rotation (0° indicates a direction toward true North, 90° indicates
+    /// a direction toward true West, etc.).
+    /// - Parameters:
+    ///   - rotation: The rotation whose value determines the heading of the compass.
+    ///   - action: The action to perform when the compass is tapped.
+    init(
+        rotation: Double?,
+        action: @escaping () -> Void
+    ) {
+        self.init(rotation: rotation, mapViewProxy: nil, action: action)
     }
     
     /// Define a custom size for the compass.
@@ -124,14 +137,6 @@ public extension Compass {
     func autoHideDisabled(_ disable: Bool = true) -> Self {
         var copy = self
         copy.autoHide = !disable
-        return copy
-    }
-    
-    /// An action to perform when the compass is tapped. If `mapViewProxy` is non-`nil`,
-    /// then this will have no effect.
-    func action(perform action: @escaping () -> Void) -> Self {
-        var copy = self
-        copy.action = action
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -35,7 +35,7 @@ public struct Compass: View {
     /// An action to perform when the compass is tapped. Note if `mapViewProxy` is non-`nil`
     /// this will not be invoked.
     private var action: (() -> Void)?
-
+    
     /// Creates a compass with a heading based on compass directions (0° indicates a direction
     /// toward true North, 90° indicates a direction toward true East, etc.).
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -32,8 +32,7 @@ public struct Compass: View {
     /// The width and height of the compass.
     private var size: CGFloat = 44
     
-    /// An action to perform when the compass is tapped. Note if `mapViewProxy` is non-`nil`
-    /// this will not be invoked.
+    /// An action to perform when the compass is tapped.
     private var action: (() -> Void)?
     
     /// Creates a compass with a heading based on compass directions (0° indicates a direction

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -21,33 +21,33 @@ final class CompassTests: XCTestCase {
     /// is applied.
     func testHiddenWithAutoHideOff() {
         let compass1Heading = Double.zero
-        let compass1 = Compass(heading: compass1Heading)
-            .autoHideDisabled() as! Compass
+        let compass1 = Compass(rotation: compass1Heading, mapViewProxy: nil, action: nil)
+            .autoHideDisabled()
         XCTAssertFalse(compass1.shouldHide(forHeading: compass1Heading))
         
         let compass2Heading = 45.0
-        let compass2 = Compass(heading: compass2Heading)
-            .autoHideDisabled() as! Compass
+        let compass2 = Compass(rotation: compass2Heading, mapViewProxy: nil, action: nil)
+            .autoHideDisabled()
         XCTAssertFalse(compass2.shouldHide(forHeading: compass2Heading))
         
         let compass3Heading = Double.nan
-        let compass3 = Compass(heading: compass3Heading)
-            .autoHideDisabled() as! Compass
+        let compass3 = Compass(rotation: compass3Heading, mapViewProxy: nil, action: nil)
+            .autoHideDisabled()
         XCTAssertFalse(compass3.shouldHide(forHeading: compass3Heading))
     }
     
     /// Verifies that the compass accurately indicates when it should be hidden.
     func testHiddenWithAutoHideOn() {
         let compass1Heading: Double = .zero
-        let compass1 = Compass(heading: compass1Heading)
+        let compass1 = Compass(rotation: compass1Heading, mapViewProxy: nil, action: nil)
         XCTAssertTrue(compass1.shouldHide(forHeading: compass1Heading))
         
         let compass2Heading = 45.0
-        let compass2 = Compass(heading: compass2Heading)
+        let compass2 = Compass(rotation: compass2Heading, mapViewProxy: nil, action: nil)
         XCTAssertFalse(compass2.shouldHide(forHeading: compass2Heading))
         
         let compass3Heading = Double.nan
-        let compass3 = Compass(heading: compass3Heading)
+        let compass3 = Compass(rotation: compass3Heading, mapViewProxy: nil, action: nil)
         XCTAssertTrue(compass3.shouldHide(forHeading: compass3Heading))
     }
 }


### PR DESCRIPTION
Closes #326 

This PR adds back SceneView support for Compass. Because there is the ability to use `Viewpoint`s or the the different CameraController types to control  SceneView, a custom _action_ is provided via a view modifier. This allows clients to do whatever is best for their implementation of SceneView instead of relying on a default implementation in the Compass.  ~The `mapViewProxy` argument for the initializer is now optional (and defaults to `nil).~

In order to prevent the confusion with behavior if the proxy is nil, there are now two initializers:

```swift
    init(rotation: Double?, mapViewProxy: MapViewProxy)
    init(rotation: Double?, action: @escaping () -> Void)
```

 The usage in a SceneView would be as follows (using the 2nd initializer, the one that takes an `action`):

```swift
@State private var scene = Scene(basemapStyle: .arcGISImagery)

/// Allows for communication between the Compass and MapView or SceneView.
@State private var viewpoint: Viewpoint?

var body: some View {
    SceneViewReader { proxy in
        SceneView(scene: scene)
            .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
            .overlay(alignment: .topTrailing) {
                Compass(rotation: viewpoint?.rotation)
                    .action {
                        if let viewpoint {
                            Task {
                                await proxy.setViewpoint(viewpoint.withRotation(.zero))
                            }
                        }
                    }
                    .padding()
            }
    }
}
```

@laurenwinter Please give this a look and let me know if it works for you.