### PR TITLE
[Search] Improve keyboard focus handling

### DIFF
--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -122,6 +122,9 @@ public struct SearchView: View {
     /// Determines whether the results lists are displayed.
     @State private var isResultListHidden = false
     
+    /// A Boolean value indicating whether the search field is focused or not.
+    @FocusState private var searchFieldIsFocused: Bool
+    
     public var body: some View {
         VStack {
             GeometryReader { geometry in
@@ -131,6 +134,7 @@ public struct SearchView: View {
                         SearchField(
                             query: $viewModel.currentQuery,
                             prompt: prompt,
+                            isFocused: $searchFieldIsFocused,
                             isResultsButtonHidden: !enableResultListView,
                             isResultListHidden: $isResultListHidden
                         )
@@ -187,6 +191,12 @@ public struct SearchView: View {
         .onReceive(viewModel.$currentQuery) { _ in
             onQueryChangedAction?(viewModel.currentQuery)
             viewModel.updateSuggestions()
+        }
+        .onChange(of: viewModel.selectedResult) { _ in
+            searchFieldIsFocused = false
+        }
+        .onChange(of: viewModel.currentSuggestion) { _ in
+            searchFieldIsFocused = false
         }
         .onChange(of: geoViewExtent) { _ in
             viewModel.geoViewExtent = geoViewExtent

--- a/Sources/ArcGISToolkit/Utility/SearchField.swift
+++ b/Sources/ArcGISToolkit/Utility/SearchField.swift
@@ -20,16 +20,19 @@ public struct SearchField: View {
     /// - Parameters:
     ///   - query: The current search query.
     ///   - prompt: The default placeholder displayed when `currentQuery` is empty.
+    ///   - isFocused: A Boolean value indicating whether the text field is focused or not.
     ///   - isResultsButtonHidden: The visibility of the button used to toggle visibility of the results list.
     ///   - isResultListHidden: Binding allowing the user to toggle the visibility of the results list.
     public init(
         query: Binding<String>,
         prompt: String = "",
+        isFocused: FocusState<Bool>.Binding,
         isResultsButtonHidden: Bool = false,
         isResultListHidden: Binding<Bool>? = nil
     ) {
         self.query = query
         self.prompt = prompt
+        self.isFocused = isFocused
         self.isResultsButtonHidden = isResultsButtonHidden
         self.isResultListHidden = isResultListHidden
     }
@@ -39,6 +42,9 @@ public struct SearchField: View {
     
     /// The default placeholder displayed when `currentQuery` is empty.
     private let prompt: String
+    
+    /// A Boolean value indicating whether the text field is focused or not.
+    private var isFocused: FocusState<Bool>.Binding
     
     /// The visibility of the button used to toggle visibility of the results list.
     private let isResultsButtonHidden: Bool
@@ -58,6 +64,7 @@ public struct SearchField: View {
                 text: query,
                 prompt: Text(prompt)
             )
+            .focused(isFocused)
             
             // Delete text button
             if !query.wrappedValue.isEmpty {


### PR DESCRIPTION
Related #7 

When a search suggestion or result is tapped, the keyboard remains focused, leaving less room for the map with pin(s) and signaling to the user more text entry is expected.

A common pattern pattern seems to be that the keyboard is hidden once a result or suggestion is tapped.

This PR changes the search component to follow that latter common pattern.