### PR TITLE
Update basemap gallery code snippet

### DIFF
--- a/Documentation/BasemapGallery/README.md
+++ b/Documentation/BasemapGallery/README.md
@@ -77,7 +77,7 @@ Selecting a basemap with a spatial reference that does not match that of the geo
 ### Basic usage for displaying a `BasemapGallery`.
 
 ```swift
-@StateObject var map = Map(basemapStyle: .arcGISImagery)
+@State var map = Map(basemapStyle: .arcGISImagery)
 
 var body: some View {
     MapView(map: map)

--- a/Documentation/BasemapGallery/README.md
+++ b/Documentation/BasemapGallery/README.md
@@ -77,7 +77,7 @@ Selecting a basemap with a spatial reference that does not match that of the geo
 ### Basic usage for displaying a `BasemapGallery`.
 
 ```swift
-@State var map = Map(basemapStyle: .arcGISImagery)
+@State private var map = Map(basemapStyle: .arcGISImagery)
 
 var body: some View {
     MapView(map: map)


### PR DESCRIPTION
A map property can no longer use the `@StateObject` property wrapper b/c `Map` no longer conforms to `ObservableObject`.

This PR can go into `main` because it applies to the current toolkit code.