### PR TITLE
Use ellipsis character in localized strings

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -76,7 +76,7 @@ public struct PopupView: View {
                     }
                 } else {
                     VStack(alignment: .center) {
-                        Text("Evaluating popup expressions...", bundle: .module)
+                        Text("Evaluating popup expressions…", bundle: .module)
                         ProgressView()
                     }
                     .frame(maxWidth: .infinity)

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -96,7 +96,7 @@
 "Error loading basemap." = "Error loading basemap.";
 
 /* No comment provided by engineer. */
-"Evaluating popup expressions..." = "Evaluating popup expressions...";
+"Evaluating popup expressions…" = "Evaluating popup expressions…";
 
 /* No comment provided by engineer. */
 "Failed to set starting point" = "Failed to set starting point";


### PR DESCRIPTION
The ellipsis character (…) should be used instead of three dots (...) in localized strings.