### PR TITLE
Add custom module property

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -115,13 +115,13 @@ extension CertificateImportError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .invalidData:
-            return String(localized: "The certificate file was invalid.", bundle: .module)
+            return String(localized: "The certificate file was invalid.", bundle: .toolkitModule)
         case .invalidPassword:
-            return String(localized: "The password was invalid.", bundle: .module)
+            return String(localized: "The password was invalid.", bundle: .toolkitModule)
         default:
             return SecCopyErrorMessageString(rawValue, nil) as String? ?? String(
                 localized: "The certificate file or password was invalid.",
-                bundle: .module
+                bundle: .toolkitModule
             )
         }
     }
@@ -131,7 +131,7 @@ extension CertificatePickerViewModel.CertificateError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .couldNotAccessCertificateFile:
-            return String(localized: "Could not access the certificate file.", bundle: .module)
+            return String(localized: "Could not access the certificate file.", bundle: .toolkitModule)
         case .importError(let error):
             return error.localizedDescription
         case .other(let error):
@@ -166,20 +166,20 @@ struct CertificatePickerViewModifier: ViewModifier {
                 isPresented: $viewModel.showPassword,
                 message: String(
                     localized: "Please enter a password for the chosen certificate.",
-                    bundle: .module
+                    bundle: .toolkitModule
                 ),
                 title: String(
                     localized: "Password Required",
-                    bundle: .module
+                    bundle: .toolkitModule
                 ),
                 cancelAction: .init(
-                    title: String(localized: "Cancel", bundle: .module),
+                    title: String(localized: "Cancel", bundle: .toolkitModule),
                     handler: { _, _ in
                         viewModel.cancel()
                     }
                 ),
                 continueAction: .init(
-                    title: String(localized: "OK", bundle: .module),
+                    title: String(localized: "OK", bundle: .toolkitModule),
                     handler: { _, password in
                         viewModel.proceed(withPassword: password)
                     }
@@ -207,24 +207,24 @@ private extension View {
         viewModel: CertificatePickerViewModel
     ) -> some View {
         alert(
-            Text("Certificate Required", bundle: .module),
+            Text("Certificate Required", bundle: .toolkitModule),
             isPresented: isPresented,
             presenting: viewModel.challengingHost
         ) { _ in
             Button {
                 viewModel.proceedFromPrompt()
             } label: {
-                Text("Browse For Certificate", bundle: .module)
+                Text("Browse For Certificate", bundle: .toolkitModule)
             }
             Button(role: .cancel) {
                 viewModel.cancel()
             } label: {
-                Text("Cancel", bundle: .module)
+                Text("Cancel", bundle: .toolkitModule)
             }
         } message: { _ in
             Text(
                 "A certificate is required to access content on \(viewModel.challengingHost).",
-                bundle: .module,
+                bundle: .toolkitModule,
                 comment: """
                          An alert message indicating that a certificate is required to access
                          content on a remote host. The variable is the host that prompted the challenge.
@@ -265,24 +265,24 @@ private extension View {
         viewModel: CertificatePickerViewModel
     ) -> some View {
         alert(
-            Text("Error importing certificate", bundle: .module),
+            Text("Error importing certificate", bundle: .toolkitModule),
             isPresented: isPresented
         ) {
             Button {
                 viewModel.proceedFromPrompt()
             } label: {
-                Text("Try Again", bundle: .module)
+                Text("Try Again", bundle: .toolkitModule)
             }
             Button(role: .cancel) {
                 viewModel.cancel()
             } label: {
-                Text("Cancel", bundle: .module)
+                Text("Cancel", bundle: .toolkitModule)
             }
         } message: {
             Text(
                 viewModel.certificateError?.localizedDescription ?? String(
                     localized: "The certificate file or password was invalid.",
-                    bundle: .module
+                    bundle: .toolkitModule
                  )
             )
         }

--- a/Sources/ArcGISToolkit/Components/Authentication/Login.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Login.swift
@@ -86,21 +86,21 @@ struct LoginViewModifier: ViewModifier {
                 isPresented: $isPresented,
                 message: String(
                     localized: "You must sign in to access '\(viewModel.challengingHost)'",
-                    bundle: .module,
+                    bundle: .toolkitModule,
                     comment: """
                              A label explaining that credentials are required to authenticate with specified host.
                              The host is indicated in the variable.
                              """
                 ),
-                title: String(localized: "Authentication Required", bundle: .module),
+                title: String(localized: "Authentication Required", bundle: .toolkitModule),
                 cancelAction: .init(
-                    title: String(localized: "Cancel", bundle: .module),
+                    title: String(localized: "Cancel", bundle: .toolkitModule),
                     handler: { _, _ in
                         viewModel.cancel()
                     }
                 ),
                 continueAction: .init(
-                    title: String(localized: "Continue", bundle: .module),
+                    title: String(localized: "Continue", bundle: .toolkitModule),
                     handler: { username, password in
                         viewModel.username = username
                         viewModel.password = password

--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -41,7 +41,7 @@ struct TrustHostViewModifier: ViewModifier {
             .alert(
                 Text(
                     "Certificate Trust Warning",
-                    bundle: .module,
+                    bundle: .toolkitModule,
                     comment: "A label indicating that the remote host's certificate is not trusted."
                 ),
                 isPresented: $isPresented,
@@ -52,19 +52,19 @@ struct TrustHostViewModifier: ViewModifier {
                 } label: {
                     Text(
                         "Allow",
-                        bundle: .module,
+                        bundle: .toolkitModule,
                         comment: "A button indicating the user accepts a potentially dangerous action."
                     )
                 }
                 Button(role: .cancel) {
                     challenge.resume(with: .cancel)
                 } label: {
-                    Text("Cancel", bundle: .module)
+                    Text("Cancel", bundle: .toolkitModule)
                 }
             } message: { _ in
                 Text(
                     "Dangerous: The certificate provided by '\(challenge.host)' is not signed by a trusted authority.",
-                    bundle: .module,
+                    bundle: .toolkitModule,
                     comment: "A warning that the host service (challenge.host) is providing a potentially unsafe certificate."
                 )
             }

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
@@ -226,15 +226,15 @@ extension AlertItem {
         
         switch (spatialReferenceMismatchError.basemapSpatialReference, spatialReferenceMismatchError.geoModelSpatialReference) {
         case (.some(_), .some(_)):
-            message = String(localized: "The basemap has a spatial reference that is incompatible with the map.", bundle: .module)
+            message = String(localized: "The basemap has a spatial reference that is incompatible with the map.", bundle: .toolkitModule)
         case (_, .none):
-            message = String(localized: "The map does not have a spatial reference.", bundle: .module)
+            message = String(localized: "The map does not have a spatial reference.", bundle: .toolkitModule)
         case (.none, _):
-            message = String(localized: "The basemap does not have a spatial reference.", bundle: .module)
+            message = String(localized: "The basemap does not have a spatial reference.", bundle: .toolkitModule)
         }
         
         self.init(
-            title: String(localized: "Spatial reference mismatch.", bundle: .module),
+            title: String(localized: "Spatial reference mismatch.", bundle: .toolkitModule),
             message: message
         )
     }
@@ -243,7 +243,7 @@ extension AlertItem {
 private extension String {
     static let basemapFailedToLoadFallbackError = String(
         localized: "The basemap failed to load for an unknown reason.",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: """
                  An error to be displayed when a basemap chosen from the basemap gallery fails to
                  load for an unknown reason.
@@ -252,7 +252,7 @@ private extension String {
     
     static let basemapFailedToLoadTitle = String(
         localized: "Error loading basemap.",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "An error to be displayed when a basemap chosen from the basemap gallery fails to load."
     )
 }

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
@@ -172,6 +172,6 @@ private extension UIImage {
     /// A default thumbnail image.
     /// - Returns: The default thumbnail.
     static func defaultThumbnail() -> UIImage {
-        return UIImage(named: "defaultthumbnail", in: .module, with: nil)!
+        return UIImage(named: "defaultthumbnail", in: .toolkitModule, with: nil)!
     }
 }

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
@@ -34,9 +34,9 @@ struct BookmarksHeader: View {
         HStack(alignment: .top) {
             Image(systemName: "bookmark")
             VStack(alignment: .leading) {
-                Text("Bookmarks", bundle: .module)
+                Text("Bookmarks", bundle: .toolkitModule)
                     .font(.headline)
-                Text("Select a bookmark", bundle: .module)
+                Text("Select a bookmark", bundle: .toolkitModule)
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
@@ -51,7 +51,7 @@ struct BookmarksHeader: View {
                 } label: {
                     Text(
                         "Done",
-                        bundle: .module,
+                        bundle: .toolkitModule,
                         comment: "A button to close the bookmark selection menu."
                     )
                     .fontWeight(.semibold)

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksList.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksList.swift
@@ -39,7 +39,7 @@ struct BookmarksList: View {
         Group {
             if bookmarks.isEmpty {
                 Label {
-                    Text("No bookmarks", bundle: .module)
+                    Text("No bookmarks", bundle: .toolkitModule)
                 } icon: {
                     Image(systemName: "bookmark.slash")
                 }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -85,7 +85,7 @@ public struct Compass: View {
                 .accessibilityLabel(
                     String(
                         localized: "Compass, heading \(Int(heading.rounded())) degrees \(CompassDirection(heading).rawValue)",
-                        bundle: .module,
+                        bundle: .toolkitModule,
                         comment: """
                                  An compass description to be read by a screen reader describing the
                                  current heading. The first variable being a degree value and the

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -102,13 +102,13 @@ struct SiteAndFacilitySelector: View {
                 placement: .navigationBarDrawer(displayMode: .always),
                 prompt: String(
                     localized: "Filter sites",
-                    bundle: .module,
+                    bundle: .toolkitModule,
                     comment: "A search field allowing user to filter a list of sites by name."
                 )
             )
             .keyboardType(.alphabet)
             .disableAutocorrection(true)
-            .navigationTitle(String(localized: "Sites", bundle: .module))
+            .navigationTitle(String(localized: "Sites", bundle: .toolkitModule))
         }
         
         /// The "All sites" button.
@@ -130,7 +130,7 @@ struct SiteAndFacilitySelector: View {
             } label: {
                 Text(
                     "All sites",
-                    bundle: .module,
+                    bundle: .toolkitModule,
                     comment: "A button allowing users to view a list of all sites defined in a floor aware map."
                 )
             }
@@ -232,7 +232,7 @@ struct SiteAndFacilitySelector: View {
                 placement: .navigationBarDrawer(displayMode: .always),
                 prompt: String(
                     localized: "Filter facilities",
-                    bundle: .module,
+                    bundle: .toolkitModule,
                     comment: "A search field allowing user to filter a list of facilities by name."
                 )
             )
@@ -240,8 +240,8 @@ struct SiteAndFacilitySelector: View {
             .disableAutocorrection(true)
             .navigationTitle(
                 usesAllSitesStyling ?
-                String(localized: "All Sites", bundle: .module) :
-                    viewModel.selection?.site?.name ?? String(localized: "Select a facility", bundle: .module)
+                String(localized: "All Sites", bundle: .toolkitModule) :
+                    viewModel.selection?.site?.name ?? String(localized: "Select a facility", bundle: .toolkitModule)
             )
         }
         
@@ -298,7 +298,7 @@ struct SiteAndFacilitySelector: View {
 /// Displays text "No matches found".
 private struct NoMatchesView: View {
     var body: some View {
-        Text("No matches found", bundle: .module)
+        Text("No matches found", bundle: .toolkitModule)
             .frame(maxHeight: .infinity)
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
@@ -92,6 +92,6 @@ struct AttachmentsPopupElementView: View {
 private extension AttachmentsPopupElement {
     /// Provides a default title to display if `title` is empty.
     var displayTitle: String {
-        title.isEmpty ? String(localized: "Attachments", bundle: .module) : title
+        title.isEmpty ? String(localized: "Attachments", bundle: .toolkitModule) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -107,6 +107,6 @@ private struct DisplayField: Hashable, Identifiable {
 private extension FieldsPopupElement {
     /// Provides a default title to display if `title` is empty.
     var displayTitle: String {
-        title.isEmpty ? String(localized: "Fields", bundle: .module) : title
+        title.isEmpty ? String(localized: "Fields", bundle: .toolkitModule) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
@@ -123,6 +123,6 @@ extension PopupMedia: Identifiable {}
 private extension MediaPopupElement {
     /// Provides a default title to display if `title` is empty.
     var displayTitle: String {
-        title.isEmpty ? String(localized: "Media", bundle: .module) : title
+        title.isEmpty ? String(localized: "Media", bundle: .toolkitModule) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageView.swift
@@ -69,7 +69,7 @@ struct AsyncImageView: View {
                         .foregroundColor(.red)
                     Text(
                         "An error occurred loading the image: \(error.localizedDescription).",
-                        bundle: .module
+                        bundle: .toolkitModule
                     )
                 }
                 .padding([.top, .bottom])

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
@@ -109,7 +109,7 @@ extension LoadImageError: LocalizedError {
     public var errorDescription: String? {
         return NSLocalizedString(
             "The URL could not be reached or did not contain image data",
-            bundle: .module,
+            bundle: .toolkitModule,
             comment: "No Data"
         )
     }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
@@ -29,7 +29,7 @@ struct MediaDetailView : View {
                 Button {
                     isShowingDetailView.wrappedValue = false
                 } label: {
-                    Text("Done", bundle: .module)
+                    Text("Done", bundle: .toolkitModule)
                         .fontWeight(.semibold)
                 }
                 .padding([.bottom], 4)
@@ -59,7 +59,7 @@ struct MediaDetailView : View {
                     }
                     if popupMedia.value?.linkURL != nil {
                         HStack {
-                            Text("Tap on the image for more information.", bundle: .module)
+                            Text("Tap on the image for more information.", bundle: .toolkitModule)
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
                             Spacer()

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -67,7 +67,7 @@ public struct PopupView: View {
                     case .failure(let error):
                         Text(
                             "Popup evaluation failed: \(error.localizedDescription)",
-                            bundle: .module,
+                            bundle: .toolkitModule,
                             comment: """
                                      An error message shown when a popup cannot be displayed. The
                                      variable provides additional data.
@@ -76,7 +76,7 @@ public struct PopupView: View {
                     }
                 } else {
                     VStack(alignment: .center) {
-                        Text("Evaluating popup expressions…", bundle: .module)
+                        Text("Evaluating popup expressions…", bundle: .toolkitModule)
                         ProgressView()
                     }
                     .frame(maxWidth: .infinity)

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -88,7 +88,7 @@ public struct SearchView: View {
     /// The string shown in the search view when no user query is entered.
     /// Defaults to "Find a place or address". Note: this is set using the
     /// `prompt` modifier.
-    private var prompt = String(localized: "Find a place or address", bundle: .module)
+    private var prompt = String(localized: "Find a place or address", bundle: .toolkitModule)
     
     /// Determines whether a built-in result view will be shown. Defaults to `true`.
     /// If `false`, the result display/selection list is not shown. Set to false if you want to hide the results
@@ -101,7 +101,7 @@ public struct SearchView: View {
     /// Note: this is set using the `noResultsMessage` modifier.
     private var noResultsMessage = String(
         localized: "No results found",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "A message to show when there are no results or suggestions."
     )
     
@@ -177,7 +177,7 @@ public struct SearchView: View {
                 } label: {
                     Text(
                         "Repeat Search Here",
-                        bundle: .module,
+                        bundle: .toolkitModule,
                         comment: """
                                   A button to show when a user has panned the map away from the
                                   original search location.
@@ -439,7 +439,8 @@ extension ResultRow {
                     Image(
                         uiImage: UIImage(
                             named: "pin",
-                            in: Bundle.module, with: nil
+                            in: .toolkitModule,
+                            with: nil
                         )!
                     )
                 )

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -435,6 +435,6 @@ private extension Symbol {
 
 extension UIImage {
     static var mapPin: UIImage {
-        return UIImage(named: "MapPin", in: Bundle.module, with: nil)!
+        return UIImage(named: "MapPin", in: .toolkitModule, with: nil)!
     }
 }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -247,7 +247,7 @@ public struct UtilityNetworkTrace: View {
                     } label: {
                         Text(
                             "\(viewModel.pendingTrace.startingPoints.count, specifier: "%lld") selected",
-                            bundle: .module,
+                            bundle: .toolkitModule,
                             comment: "A label declaring the number of starting points selected for a utility network trace."
                         )
                     }
@@ -655,7 +655,7 @@ public struct UtilityNetworkTrace: View {
         guard let index = viewModel.selectedTraceIndex else { return "Error" }
         return String(
             localized: "Trace \(index+1, specifier: "%lld") of \(viewModel.completedTraces.count, specifier: "%lld")",
-            bundle: .module,
+            bundle: .toolkitModule,
             comment: "A label indicating the index of the trace being viewed out of the total number of traces completed."
         )
     }
@@ -730,144 +730,144 @@ public struct UtilityNetworkTrace: View {
 private extension String {
     static let addNewButtonLabel = String(
         localized: "Add new",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "A button to add new utility trace starting points."
     )
     
     static let advancedOptionsHeaderLabel = String(
         localized: "Advanced Options",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "A section header for advanced options."
     )
     
     static let attributesSectionTitle = String(
         localized: "Attributes",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let cancelStartingPointSelection = String(
         localized: "Cancel starting point selection",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let clearAllResultsButtonLabel = String(
         localized: "Clear All Results",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let clearAllResultsQuestion = String(
         localized: "Clear all results?",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let clearAllResultsMessage = String(
         localized: "All the trace inputs and results will be lost.",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "A message describing the outcome of clearing all utility network trace results."
     )
     
     static let colorLabel = String(
         localized: "Color",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let deleteButtonLabel = String(
         localized: "Delete",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     /// Title for the feature results section
     static let featureResultsTitle = String(
         localized: "Feature Results",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let fractionAlongEdgeSectionTitle = String(
         localized: "Fraction Along Edge",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let functionResultsSectionTitle = String(
         localized: "Function Results",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let modePickerTitle = String(
         localized: "Mode",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let nameLabel = String(
         localized: "Name",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let networkSectionLabel = String(
         localized: "Network",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let newTraceOptionLabel = String(
         localized: "New trace",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let noConfigurationsAvailable = String(
         localized: "No configurations available",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let noneSelected = String(
         localized: "None selected",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let objectID = String(
         localized: "Object ID",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let resultsOptionLabel = String(
         localized: "Results",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     /// Title for the starting points section
     static let startingPointsTitle = String(
         localized: "Starting Points",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let terminalConfigurationPickerTitle = String(
         localized: "Terminal Configuration",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let traceButtonLabel = String(
         localized: "Trace",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let traceConfigurationSectionLabel = String(
         localized: "Trace Configuration",
-        bundle: .module
+        bundle: .toolkitModule
     )
     
     static let unnamedAssetType = String(
         localized: "Unnamed Asset Type",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "A label to use in place of a utility element asset type name."
     )
     
     static let zoomToButtonLabel = String(
         localized: "Zoom To",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "A button to change the map to the extent of the selected trace."
     )
     
     static let zoomToResult = String(
         localized: "Zoom to result",
-        bundle: .module,
+        bundle: .toolkitModule,
         comment: "A user option specifying that a map should automatically change to show completed trace results."
     )
 }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// A user presentable alert.
 struct UtilityNetworkTraceUserAlert {
     /// Title of the alert.
-    var title: String = String(localized: "Error", bundle: .module)
+    var title: String = String(localized: "Error", bundle: .toolkitModule)
     
     /// Description of the alert.
     var description: String
@@ -30,7 +30,7 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "Please set at least 1 starting location.",
-                bundle: .module
+                bundle: .toolkitModule
             )
         )
     }
@@ -39,7 +39,7 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "Please set at least 2 starting locations.",
-                bundle: .module
+                bundle: .toolkitModule
             )
         )
     }
@@ -48,11 +48,11 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             title: String(
                 localized: "Failed to set starting point",
-                bundle: .module
+                bundle: .toolkitModule
             ),
             description: String(
                 localized: "Duplicate starting points cannot be added.",
-                bundle: .module
+                bundle: .toolkitModule
             )
         )
     }
@@ -61,7 +61,7 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "No trace types found.",
-                bundle: .module
+                bundle: .toolkitModule
             )
         )
     }
@@ -70,7 +70,7 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "No utility networks found.",
-                bundle: .module
+                bundle: .toolkitModule
             )
         )
     }
@@ -79,7 +79,7 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "Element could not be identified.",
-                bundle: .module
+                bundle: .toolkitModule
             )
         )
     }

--- a/Sources/ArcGISToolkit/Extensions/Bundle.swift
+++ b/Sources/ArcGISToolkit/Extensions/Bundle.swift
@@ -1,0 +1,23 @@
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension Bundle {
+    /// The identifier for the ArcGISToolkit module.
+    static var toolkitIdentifier: String { "com.esri.ArcGISToolkit" }
+    
+    /// The toolkit module, which is either the resource bundle or the
+    /// ArcGISToolkit framework, depending on how the toolkit was built.
+    static let toolkitModule = Bundle(identifier: toolkitIdentifier) ?? .module
+}

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -118,7 +118,7 @@ struct CredentialInputView: UIViewControllerRepresentable {
                 )
                 textField.autocapitalizationType = .none
                 textField.autocorrectionType = .no
-                textField.placeholder = String(localized: "Username", bundle: .module)
+                textField.placeholder = String(localized: "Username", bundle: .toolkitModule)
                 textField.returnKeyType = .next
                 textField.textContentType = .username
             }
@@ -140,7 +140,7 @@ struct CredentialInputView: UIViewControllerRepresentable {
             textField.delegate = context.coordinator
             
             textField.isSecureTextEntry = true
-            textField.placeholder = String(localized: "Password", bundle: .module)
+            textField.placeholder = String(localized: "Password", bundle: .toolkitModule)
             textField.returnKeyType = .go
             textField.textContentType = .password
         }


### PR DESCRIPTION
This property first looks for a bundle with the toolkit's identifier. This prevents a crash on accessing a resource when the toolkit has been built into a binary framework.