### PR TITLE
Fix toolkit localization export

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
@@ -110,7 +110,7 @@ extension LoadImageError: LocalizedError {
         return String(
             localized: "The URL could not be reached or did not contain image data",
             bundle: .toolkitModule,
-            comment: "No Data"
+            comment: "Description of error thrown when a remote image could not be loaded."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
@@ -107,8 +107,8 @@ struct LoadImageError: Error {
 
 extension LoadImageError: LocalizedError {
     public var errorDescription: String? {
-        return NSLocalizedString(
-            "The URL could not be reached or did not contain image data",
+        return String(
+            localized: "The URL could not be reached or did not contain image data",
             bundle: .toolkitModule,
             comment: "No Data"
         )


### PR DESCRIPTION
@njarecha discovered that using `NSLocalizedString` here was breaking `xcodebuild -exportLocalizations` and causing that string to be the only one exported.

<img width="943" alt="Screenshot 2023-06-15 at 15 34 34" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/ecc4436f-9666-4e02-bcbc-db4858fe0fd0">