### PR TITLE
Make `content` parameter view builder

### DIFF
--- a/Documentation/FloatingPanel/README.md
+++ b/Documentation/FloatingPanel/README.md
@@ -65,7 +65,7 @@ The floating panel is displayed via a view modifier that allows you to set the c
 MapView(
     map: map
 )
-.floatingPanel() {
+.floatingPanel {
     List(1..<21) { Text("\($0)") }
         .listStyle(.plain)
 }

--- a/Documentation/Popup/README.md
+++ b/Documentation/Popup/README.md
@@ -110,13 +110,11 @@ var body: some View {
                     horizontalAlignment: .leading,
                     isPresented: $showPopup
                 ) {
-                    Group {
-                        if let popup = popup {
-                            PopupView(popup: popup, isPresented: $showPopup)
-                                .showCloseButton(true)
-                        }
+                    if let popup = popup {
+                        PopupView(popup: popup, isPresented: $showPopup)
+                            .showCloseButton(true)
+                            .padding()
                     }
-                    .padding()
                 }
         }
     }

--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -71,13 +71,11 @@ struct PopupExampleView: View {
                         horizontalAlignment: .leading,
                         isPresented: $showPopup
                     ) {
-                        Group {
-                            if let popup = popup {
-                                PopupView(popup: popup, isPresented: $showPopup)
-                                    .showCloseButton(true)
-                            }
+                        if let popup = popup {
+                            PopupView(popup: popup, isPresented: $showPopup)
+                                .showCloseButton(true)
+                                .padding()
                         }
-                        .padding()
                     }
             }
         }

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
@@ -42,7 +42,7 @@ public extension View {
         horizontalAlignment: HorizontalAlignment = .trailing,
         isPresented: Binding<Bool> = .constant(true),
         maxWidth: CGFloat = 400,
-        _ content: @escaping () -> Content
+        @ViewBuilder _ content: () -> Content
     ) -> some View where Content: View {
         modifier(
             FloatingPanelModifier(


### PR DESCRIPTION
Doing so simplifies caller code in some cases. Also, remove the `escaping` attribute since the closure doesn't actually escape.