### PR TITLE
Create t9nmanifest.txt

### DIFF
--- a/t9nmanifest.txt
+++ b/t9nmanifest.txt
@@ -1,0 +1,1 @@
+Sources\ArcGISToolkit\Resources\en.lproj\Localizable.strings


### PR DESCRIPTION
Lists the strings files that need to be translated.
This file is used by the automated jobs managed by the localization team
When we migrate to the new string catalog format in xcode 15, we can update this file to point to that instead