### PR TITLE
[Form] Various improvements

### DIFF
--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -42,13 +42,13 @@ struct FormExampleView: View {
                     feature = nil
                 } content: {
                     if #available(iOS 16.4, *) {
-                        FormView(map: map, feature: feature!)
+                        FormView(feature: feature!)
                             .padding()
                             .presentationBackground(.thinMaterial)
                             .presentationBackgroundInteraction(.enabled(upThrough: .medium))
                             .presentationDetents([.medium])
                     } else {
-                        FormView(map: map, feature: feature!)
+                        FormView(feature: feature!)
                             .padding()
                     }
                     #if targetEnvironment(macCatalyst)
@@ -67,7 +67,7 @@ struct FormExampleView: View {
 //                ) {
 //                    Group {
 //                        if let feature {
-//                            FormView(map: map, feature: feature)
+//                            FormView(feature: feature)
 //                                .padding()
 //                        }
 //                    }

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
@@ -44,14 +44,13 @@ struct MultiLineTextEntry: View {
     ///   - input: A `TextAreaFeatureFormInput` which acts as a configuration.
     init(element: FieldFeatureFormElement, text: String?, input: TextAreaFeatureFormInput) {
         self.element =  element
-        self.text = text ?? ""
         self.input = input
         
         if let text, !text.isEmpty {
-            self.text = text
+            _text = State(initialValue: text)
             isPlaceholder = false
         } else {
-            self.text = element.hint ?? ""
+            _text = State(initialValue: element.hint ?? "")
             isPlaceholder = true
         }
     }

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
@@ -37,8 +37,8 @@ struct SingleLineTextEntry: View {
     ///   - input: A `TextBoxFeatureFormInput` which acts as a configuration.
     init(element: FieldFeatureFormElement, text: String?, input: TextBoxFeatureFormInput) {
         self.element = element
-        self.text = text ?? ""
         self.input = input
+        _text = State(initialValue: text ?? "")
     }
     
     /// - Bug: Focus detection works as of Xcode 14.3.1 but is broken as of Xcode 15 Beta 2.

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -23,9 +23,6 @@ public struct FormView: View {
     /// The structure of the form.
     @State private var formDefinition: FeatureFormDefinition?
     
-    /// Info obtained from the map's JSON which contains the underlying form definition.
-    @State private var mapInfo: MapInfo?
-    
     /// The feature being edited in the form.
     private let feature: ArcGISFeature
     

--- a/Sources/ArcGISToolkit/Components/Form/LengthValidationScheme.swift
+++ b/Sources/ArcGISToolkit/Components/Form/LengthValidationScheme.swift
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// An error that can be encountered while performing length validation.
-enum LengthError {
-    /// The text field was left empty but a value is required.
-    case emptyWhenRequired
-    /// The text field has too few or too many characters.
-    case minOrMaxUnmet
+/// The type of length validation to be performed.
+enum LengthValidationScheme {
+    /// A non-zero identical minimum and maximum have been specified.
+    case exact
+    /// A zero minimum and a non-zero maximum have been specified.
+    case max
+    /// A non-zero non-identical minimum and maximum have been specified.
+    case minAndMax
 }

--- a/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
+++ b/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
@@ -63,11 +63,11 @@ struct TextEntryFooter: View {
         case let input as TextBoxFeatureFormInput:
             self.maxLength = input.maxLength
             self.minLength = input.minLength
-            self.hasPreviouslySatisfiedMinimum = currentLength >= input.minLength
+            _hasPreviouslySatisfiedMinimum = State(initialValue: currentLength >= input.minLength)
         case let input as TextAreaFeatureFormInput:
             self.maxLength = input.maxLength
             self.minLength = input.minLength
-            self.hasPreviouslySatisfiedMinimum = currentLength >= input.minLength
+            _hasPreviouslySatisfiedMinimum = State(initialValue: currentLength >= input.minLength)
         default:
             fatalError("TextEntryFooter can only be used with TextAreaFeatureFormInput or TextBoxFeatureFormInput")
         }

--- a/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
+++ b/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
@@ -131,6 +131,18 @@ extension TextEntryFooter {
         }
     }
     
+    /// Text indicating a field's exact number of allowed characters.
+    /// - Note: This is intended to be used in instances where the character minimum and maximum are
+    /// identical, such as an ID field; the implementation uses `minLength` but it could just as
+    /// well reference `maxLength`.
+    var exactText: Text {
+        Text(
+            "Enter \(minLength) characters",
+            bundle: .toolkitModule,
+            comment: "Text indicating a field's exact number of required characters."
+        )
+    }
+    
     /// Text indicating a field's maximum number of allowed characters.
     var maximumText: Text {
         Text(

--- a/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
+++ b/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
@@ -163,7 +163,7 @@ extension TextEntryFooter {
     /// Text indicating a field's exact number of allowed characters.
     /// - Note: This is intended to be used in instances where the character minimum and maximum are
     /// identical, such as an ID field; the implementation uses `minLength` but it could just as
-    /// well reference `maxLength`.
+    /// well use `maxLength`.
     var exactText: Text {
         Text(
             "Enter \(minLength) characters",

--- a/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
+++ b/Sources/ArcGISToolkit/Components/Form/TextEntryFooter.swift
@@ -17,7 +17,7 @@ import SwiftUI
 /// A view shown at the bottom of each text entry element in a form.
 struct TextEntryFooter: View {
     /// An error that is present when a length constraint is not met.
-    @State private var validationError: LengthError? = nil
+    @State private var validationError: LengthError?
     
     /// A Boolean value indicating whether the text entry field has previously satisfied the minimum
     /// length at any point in time.


### PR DESCRIPTION
This PR is based off of and to be reviewed/merged following #363.

Changes:
  - Switch to parsing data from the feature layer's unsupported JSON 
      - `formInfo` may or may not be saved to a web map, depending on which tool was used to author the form. Over the past week we've found that a feature layer's unsupported JSON is a common place for form editors to save the form definition to. This PR simply switches the current implementation to read the form definition from the feature layer's unsupported JSON rather than the map's JSON. As a result, one can simply now initialize a `FormView` with an `ArcGISFeature` only. A map is no longer needed.
  - Fixes a few `@State` initialization anti-patterns as discussed [here](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/360#discussion_r1248192682).
  - Refactors how the message in the text entry footer is determined. Accounts for design changes in Common Toolkit PR 212.