### PR TITLE
[FormView] Add form view model and support for persisting text field edits

### DIFF
--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -66,10 +66,10 @@ struct FormExampleView: View {
 //                .floatingPanel(
 //                    selectedDetent: .constant(.half),
 //                    horizontalAlignment: .leading,
-//                    isPresented: isPresented
+//                    isPresented: $isPresented
 //                ) {
 //                    Group {
-//                        if let feature {
+//                        if isPresented {
 //                            FormView()
 //                                .padding()
 //                        }

--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -85,6 +85,7 @@ struct FormExampleView: View {
                     ToolbarItem(placement: .navigationBarLeading) {
                         if isPresented {
                             Button("Cancel", role: .cancel) {
+                                formViewModel.undoEdits()
                                 isPresented = false
                             }
                         }
@@ -93,7 +94,10 @@ struct FormExampleView: View {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         if isPresented {
                             Button("Submit") {
-                                formViewModel.submitChanges()
+                                Task {
+                                    await formViewModel.submitChanges()
+                                    isPresented = false
+                                }
                             }
                         }
                     }

--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -19,11 +19,14 @@ struct FormExampleView: View {
     /// The `Map` displayed in the `MapView`.
     @State private var map = Map(url: .sampleData)!
     
-    /// The `ArcGISFeature` to edit in the form.
-    @State private var feature: ArcGISFeature?
-    
     /// The point on the screen the user tapped on to identify a feature.
     @State private var identifyScreenPoint: CGPoint?
+    
+    /// A Boolean value indicating whether or not the form is displayed.
+    @State private var isPresented = false
+    
+    /// The form view model provides a channel of communication between the form view and its host.
+    @StateObject private var formViewModel = FormViewModel()
     
     var body: some View {
         MapViewReader { mapViewProxy in
@@ -32,28 +35,31 @@ struct FormExampleView: View {
                     identifyScreenPoint = screenPoint
                 }
                 .task(id: identifyScreenPoint) {
-                    feature = await identifyFeature(with: mapViewProxy)
+                    if let feature = await identifyFeature(with: mapViewProxy) {
+                        formViewModel.startEditing(feature)
+                        isPresented = true
+                    }
                 }
                 .ignoresSafeArea(.keyboard)
                 
                 // Present a FormView in a native SwiftUI sheet
-                .sheet(isPresented: Binding { feature != nil } set: { _ in }) {
+                .sheet(isPresented: $isPresented) {
                     // Clear the feature on dismiss
-                    feature = nil
+                    formViewModel.didHide()
                 } content: {
                     if #available(iOS 16.4, *) {
-                        FormView(feature: feature!)
+                        FormView()
                             .padding()
                             .presentationBackground(.thinMaterial)
                             .presentationBackgroundInteraction(.enabled(upThrough: .medium))
                             .presentationDetents([.medium])
                     } else {
-                        FormView(feature: feature!)
+                        FormView()
                             .padding()
                     }
                     #if targetEnvironment(macCatalyst)
                     Button("Dismiss") {
-                        feature = nil
+                        isPresented = false
                     }
                     .padding()
                     #endif
@@ -63,15 +69,38 @@ struct FormExampleView: View {
 //                .floatingPanel(
 //                    selectedDetent: .constant(.half),
 //                    horizontalAlignment: .leading,
-//                    isPresented: Binding { feature != nil } set: { _ in }
+//                    isPresented: isPresented
 //                ) {
 //                    Group {
 //                        if let feature {
-//                            FormView(feature: feature)
+//                            FormView()
 //                                .padding()
 //                        }
 //                    }
 //                }
+                
+                .environmentObject(formViewModel)
+                
+                .toolbar {
+                    // Once iOS 16.0 is the minimum supported, the two conditionals to show the
+                    // buttons can be merged and hoisted up as the root content of the toolbar.
+                    
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        if isPresented {
+                            Button("Cancel", role: .cancel) {
+                                isPresented = false
+                            }
+                        }
+                    }
+                    
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        if isPresented {
+                            Button("Submit") {
+                                print("Submit")
+                            }
+                        }
+                    }
+                }
         }
     }
 }

--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -44,9 +44,6 @@ struct FormExampleView: View {
                 
                 // Present a FormView in a native SwiftUI sheet
                 .sheet(isPresented: $isPresented) {
-                    // Clear the feature on dismiss
-                    formViewModel.didHide()
-                } content: {
                     if #available(iOS 16.4, *) {
                         FormView()
                             .padding()

--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -93,7 +93,7 @@ struct FormExampleView: View {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         if isPresented {
                             Button("Submit") {
-                                print("Submit")
+                                formViewModel.submitChanges()
                             }
                         }
                     }

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
@@ -18,6 +18,7 @@ import SwiftUI
 struct MultiLineTextEntry: View {
     @Environment(\.formElementPadding) var elementPadding
     
+    /// The model for the ancestral form view.
     @EnvironmentObject var model: FormViewModel
     
     /// A Boolean value indicating whether or not the field is focused.

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
@@ -18,11 +18,13 @@ import SwiftUI
 struct SingleLineTextEntry: View {
     @Environment(\.formElementPadding) var elementPadding
     
+    @EnvironmentObject var model: FormViewModel
+    
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
     
     /// The current text value.
-    @State private var text: String
+    @State private var text = ""
     
     /// The form element that corresponds to this text field.
     private let element: FieldFeatureFormElement
@@ -33,12 +35,10 @@ struct SingleLineTextEntry: View {
     /// Creates a view for single line text entry.
     /// - Parameters:
     ///   - element: The form element that corresponds to this text field.
-    ///   - text: The current text value.
     ///   - input: A `TextBoxFeatureFormInput` which acts as a configuration.
-    init(element: FieldFeatureFormElement, text: String?, input: TextBoxFeatureFormInput) {
+    init(element: FieldFeatureFormElement, input: TextBoxFeatureFormInput) {
         self.element = element
         self.input = input
-        _text = State(initialValue: text ?? "")
     }
     
     /// - Bug: Focus detection works as of Xcode 14.3.1 but is broken as of Xcode 15 Beta 2.
@@ -62,5 +62,11 @@ struct SingleLineTextEntry: View {
             input: input
         )
         .padding([.bottom], elementPadding)
+        .onAppear {
+            text = model.feature?.attributes[element.fieldName] as? String ?? ""
+        }
+        .onChange(of: text) { newValue in
+            model.feature?.setAttributeValue(newValue, forKey: element.fieldName)
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
@@ -18,6 +18,7 @@ import SwiftUI
 struct SingleLineTextEntry: View {
     @Environment(\.formElementPadding) var elementPadding
     
+    /// The model for the ancestral form view.
     @EnvironmentObject var model: FormViewModel
     
     /// A Boolean value indicating whether or not the field is focused.

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -20,6 +20,7 @@ import SwiftUI
 public struct FormView: View {
     @Environment(\.formElementPadding) var elementPadding
     
+    /// The model for this form view.
     @EnvironmentObject var model: FormViewModel
     
     /// Initializes a form view.

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -20,24 +20,17 @@ import SwiftUI
 public struct FormView: View {
     @Environment(\.formElementPadding) var elementPadding
     
-    /// The structure of the form.
-    @State private var formDefinition: FeatureFormDefinition?
+    @EnvironmentObject var model: FormViewModel
     
-    /// The feature being edited in the form.
-    private let feature: ArcGISFeature
-    
-    /// Creates a `FormView` with the given feature.
-    /// - Parameter feature: The feature to be edited.
-    public init(feature: ArcGISFeature) {
-        self.feature = feature
-    }
+    /// Initializes a form view.
+    public init() {}
     
     public var body: some View {
         ScrollView {
-            FormHeader(title: formDefinition?.title)
+            FormHeader(title: model.formDefinition?.title)
                 .padding([.bottom], elementPadding)
             VStack(alignment: .leading) {
-                ForEach(formDefinition?.formElements ?? [], id: \.element?.label) { container in
+                ForEach(model.formDefinition?.formElements ?? [], id: \.element?.label) { container in
                     if let element = container.element {
                         makeElement(element)
                     }
@@ -50,7 +43,7 @@ public struct FormView: View {
                let formInfoDictionary = layer._unsupportedJSON["formInfo"],
                let jsonData = try? JSONSerialization.data(withJSONObject: formInfoDictionary),
                let formDefinition = try? decoder.decode(FeatureFormDefinition.self, from: jsonData) {
-                self.formDefinition = formDefinition
+                model.formDefinition = formDefinition
             } else {
                 print("Error processing form definition")
             }
@@ -59,6 +52,15 @@ public struct FormView: View {
 }
 
 extension FormView {
+    /// The feature being edited in the form.
+    private var feature: ArcGISFeature {
+        if let feature = model.feature {
+            return feature
+        } else {
+            fatalError("The feature was cleared but the form is still presented.")
+        }
+    }
+    
     /// Makes UI for a form element.
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func makeElement(_ element: FeatureFormElement) -> some View {

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -39,7 +39,7 @@ public struct FormView: View {
         }
         .task {
             let decoder = JSONDecoder()
-            if let layer = feature.table?.layer as? FeatureLayer,
+            if let layer = model.feature?.table?.layer as? FeatureLayer,
                let formInfoDictionary = layer._unsupportedJSON["formInfo"],
                let jsonData = try? JSONSerialization.data(withJSONObject: formInfoDictionary),
                let formDefinition = try? decoder.decode(FeatureFormDefinition.self, from: jsonData) {
@@ -52,15 +52,6 @@ public struct FormView: View {
 }
 
 extension FormView {
-    /// The feature being edited in the form.
-    private var feature: ArcGISFeature {
-        if let feature = model.feature {
-            return feature
-        } else {
-            fatalError("The feature was cleared but the form is still presented.")
-        }
-    }
-    
     /// Makes UI for a form element.
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func makeElement(_ element: FeatureFormElement) -> some View {
@@ -81,13 +72,11 @@ extension FormView {
         case let `input` as TextBoxFeatureFormInput:
             SingleLineTextEntry(
                 element: element,
-                text: feature.attributes[element.fieldName] as? String,
                 input: `input`
             )
         case let `input` as TextAreaFeatureFormInput:
             MultiLineTextEntry(
                 element: element,
-                text: feature.attributes[element.fieldName] as? String,
                 input: `input`
             )
         default:

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -50,6 +50,22 @@ public class FormViewModel: ObservableObject {
     
     /// Submit the changes made to the form.
     public func submitChanges() async {
-        print(#function)
+        guard let table, let feature, let database else {
+            print("A precondition to submit the changes wasn't met.")
+            return
+        }
+        
+        try? await table.update(feature)
+        
+        guard database.hasLocalEdits else {
+            print("No submittable changes found.")
+            return
+        }
+        
+        let results = try? await database.applyEdits()
+        
+        if results?.first?.editResults.first?.didCompleteWithErrors ?? false {
+            print("An error occurred while submitting the changes.")
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -16,11 +16,17 @@ import FormsPlugin
 import SwiftUI
 
 public class FormViewModel: ObservableObject {
-    /// The structure of the form.
-    @Published var formDefinition: FeatureFormDefinition?
+    /// The geodatabase which holds the table and feature being edited in the form.
+    @Published private(set) var database: ServiceGeodatabase?
     
     /// The featured being edited in the form.
     @Published private(set) var feature: ArcGISFeature?
+    
+    /// The structure of the form.
+    @Published var formDefinition: FeatureFormDefinition?
+    
+    /// The service feature table which holds the feature being edited in the form.
+    @Published private(set) var table: ServiceFeatureTable?
     
     /// Initializes a form view model.
     public init() {}
@@ -29,10 +35,21 @@ public class FormViewModel: ObservableObject {
     /// - Parameter feature: The feature to be edited in the form.
     public func startEditing(_ feature: ArcGISFeature) {
         self.feature = feature
+        if let table = feature.table as? ServiceFeatureTable {
+            self.database = table.serviceGeodatabase
+            self.table = table
+        }
+    }
+    
+    /// Undos any local edits that haven't yet been saved to service geodatabase.
+    public func undoEdits() {
+        Task {
+            try? await database?.undoLocalEdits()
+        }
     }
     
     /// Submit the changes made to the form.
-    public func submitChanges() {
+    public func submitChanges() async {
         print(#function)
     }
 }

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -30,11 +30,4 @@ public class FormViewModel: ObservableObject {
     public func startEditing(_ feature: ArcGISFeature) {
         self.feature = feature
     }
-    
-    /// Notifies the model that the form is no longer visible.
-    /// - Note: This should only be called once the form view has been removed from the view
-    /// hierarchy.
-    public func didHide() {
-        feature = nil
-    }
 }

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -30,4 +30,9 @@ public class FormViewModel: ObservableObject {
     public func startEditing(_ feature: ArcGISFeature) {
         self.feature = feature
     }
+    
+    /// Submit the changes made to the form.
+    public func submitChanges() {
+        print(#function)
+    }
 }

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -43,9 +43,7 @@ public class FormViewModel: ObservableObject {
     
     /// Reverts any local edits that haven't yet been saved to service geodatabase.
     public func undoEdits() {
-        Task {
-            try? await database?.undoLocalEdits()
-        }
+        print(#file, #function)
     }
     
     /// Submit the changes made to the form.

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -1,0 +1,40 @@
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArcGIS
+import FormsPlugin
+import SwiftUI
+
+public class FormViewModel: ObservableObject {
+    /// The structure of the form.
+    @Published var formDefinition: FeatureFormDefinition?
+    
+    /// The featured being edited in the form.
+    @Published private(set) var feature: ArcGISFeature?
+    
+    /// Initializes a form view model.
+    public init() {}
+    
+    /// Prepares the feature for editing in the form.
+    /// - Parameter feature: The feature to be edited in the form.
+    public func startEditing(_ feature: ArcGISFeature) {
+        self.feature = feature
+    }
+    
+    /// Notifies the model that the form is no longer visible.
+    /// - Note: This should only be called once the form view has been removed from the view
+    /// hierarchy.
+    public func didHide() {
+        feature = nil
+    }
+}

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -50,7 +50,7 @@ public class FormViewModel: ObservableObject {
     
     /// Submit the changes made to the form.
     public func submitChanges() async {
-        guard let table, let feature, let database else {
+        guard let table, table.isEditable, let feature, let database else {
             print("A precondition to submit the changes wasn't met.")
             return
         }

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 public class FormViewModel: ObservableObject {
     /// The geodatabase which holds the table and feature being edited in the form.
-    @Published private(set) var database: ServiceGeodatabase?
+    @Published private var database: ServiceGeodatabase?
     
     /// The featured being edited in the form.
     @Published private(set) var feature: ArcGISFeature?
@@ -26,7 +26,7 @@ public class FormViewModel: ObservableObject {
     @Published var formDefinition: FeatureFormDefinition?
     
     /// The service feature table which holds the feature being edited in the form.
-    @Published private(set) var table: ServiceFeatureTable?
+    @Published private var table: ServiceFeatureTable?
     
     /// Initializes a form view model.
     public init() {}

--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -41,7 +41,7 @@ public class FormViewModel: ObservableObject {
         }
     }
     
-    /// Undos any local edits that haven't yet been saved to service geodatabase.
+    /// Reverts any local edits that haven't yet been saved to service geodatabase.
     public func undoEdits() {
         Task {
             try? await database?.undoLocalEdits()


### PR DESCRIPTION
- Adds a form view model to provide communication between a `FormView` and its host; adapts the implementation to use the model.
- Adds support to undo and submit local changes via the new model.
- Modifies the example view to make use of the new cancel and submit functionality.