### PR TITLE
added smart card support in authenticator

### DIFF
--- a/AuthenticationExample/AuthenticationExample.xcodeproj/project.pbxproj
+++ b/AuthenticationExample/AuthenticationExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21450B722A4F470B00A81AB8 /* WebMapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21450B712A4F470B00A81AB8 /* WebMapsView.swift */; };
 		88AD13792834355000500B2E /* AuthenticationApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AD13782834355000500B2E /* AuthenticationApp.swift */; };
 		88AD137B2834355000500B2E /* SigninView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AD137A2834355000500B2E /* SigninView.swift */; };
 		88AD137D2834355100500B2E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88AD137C2834355100500B2E /* Assets.xcassets */; };
@@ -15,12 +16,12 @@
 		88AD138E283443F800500B2E /* MapItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AD138D283443F800500B2E /* MapItemView.swift */; };
 		88D24DF0288F062D007A539C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DEF288F062D007A539C /* ProfileView.swift */; };
 		88D24DF2288F2FA1007A539C /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF1288F2FA1007A539C /* HomeView.swift */; };
-		88D24DF4288F4BEB007A539C /* FeaturedMapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF3288F4BEB007A539C /* FeaturedMapsView.swift */; };
 		88D24DF6288F5BAE007A539C /* UserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF5288F5BAE007A539C /* UserView.swift */; };
 		88D24DF8288F6002007A539C /* LoadableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF7288F6002007A539C /* LoadableImageView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		21450B712A4F470B00A81AB8 /* WebMapsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebMapsView.swift; sourceTree = "<group>"; };
 		21B31E8B29EF53BE00A40B10 /* AuthenticationExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AuthenticationExample.entitlements; sourceTree = "<group>"; };
 		88AD13752834355000500B2E /* AuthenticationExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AuthenticationExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		88AD13782834355000500B2E /* AuthenticationApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationApp.swift; sourceTree = "<group>"; };
@@ -32,7 +33,6 @@
 		88AD138D283443F800500B2E /* MapItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapItemView.swift; sourceTree = "<group>"; };
 		88D24DEF288F062D007A539C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		88D24DF1288F2FA1007A539C /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
-		88D24DF3288F4BEB007A539C /* FeaturedMapsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedMapsView.swift; sourceTree = "<group>"; };
 		88D24DF5288F5BAE007A539C /* UserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserView.swift; sourceTree = "<group>"; };
 		88D24DF7288F6002007A539C /* LoadableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableImageView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -75,7 +75,7 @@
 				88AD13782834355000500B2E /* AuthenticationApp.swift */,
 				88D24DF1288F2FA1007A539C /* HomeView.swift */,
 				88D24DF7288F6002007A539C /* LoadableImageView.swift */,
-				88D24DF3288F4BEB007A539C /* FeaturedMapsView.swift */,
+				21450B712A4F470B00A81AB8 /* WebMapsView.swift */,
 				88AD138D283443F800500B2E /* MapItemView.swift */,
 				88AD137A2834355000500B2E /* SigninView.swift */,
 				88D24DEF288F062D007A539C /* ProfileView.swift */,
@@ -176,10 +176,10 @@
 			files = (
 				88AD138E283443F800500B2E /* MapItemView.swift in Sources */,
 				88AD137B2834355000500B2E /* SigninView.swift in Sources */,
-				88D24DF4288F4BEB007A539C /* FeaturedMapsView.swift in Sources */,
 				88D24DF2288F2FA1007A539C /* HomeView.swift in Sources */,
 				88D24DF8288F6002007A539C /* LoadableImageView.swift in Sources */,
 				88D24DF0288F062D007A539C /* ProfileView.swift in Sources */,
+				21450B722A4F470B00A81AB8 /* WebMapsView.swift in Sources */,
 				88AD13792834355000500B2E /* AuthenticationApp.swift in Sources */,
 				88D24DF6288F5BAE007A539C /* UserView.swift in Sources */,
 			);

--- a/AuthenticationExample/AuthenticationExample/AuthenticationExample.entitlements
+++ b/AuthenticationExample/AuthenticationExample/AuthenticationExample.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>com.apple.token</string>
+	</array>
 </dict>
 </plist>

--- a/AuthenticationExample/AuthenticationExample/HomeView.swift
+++ b/AuthenticationExample/AuthenticationExample/HomeView.swift
@@ -25,7 +25,7 @@ struct HomeView: View {
     var body: some View {
         if let portal = portal {
             NavigationView{
-                FeaturedMapsView(portal: portal)
+                WebMapsView(portal: portal)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button {

--- a/AuthenticationExample/AuthenticationExample/SignInView.swift
+++ b/AuthenticationExample/AuthenticationExample/SignInView.swift
@@ -71,6 +71,8 @@ struct SignInView: View {
                             return ""
                         case .serverTrust:
                             return nil
+                        case .smartCard:
+                            return ""
                         @unknown default:
                             fatalError("Unknown NetworkCredential")
                         }

--- a/AuthenticationExample/AuthenticationExample/WebMapsView.swift
+++ b/AuthenticationExample/AuthenticationExample/WebMapsView.swift
@@ -14,23 +14,23 @@
 import SwiftUI
 import ArcGIS
 
-/// A view that displays the featured maps of a portal.
-struct FeaturedMapsView: View {
+/// A view that displays the web maps of a portal.
+struct WebMapsView: View {
     /// The portal from which the featured content can be fetched.
     var portal: Portal
     
     /// A Boolean value indicating whether the featured content is being loaded.
     @State var isLoading = true
     
-    /// The featured items.
-    @State var featuredItems = [PortalItem]()
+    /// The web map portal items.
+    @State var webMapItems = [PortalItem]()
     
     var body: some View {
         VStack {
             if isLoading {
                 ProgressView()
             } else {
-                List(featuredItems, id: \.id) { item in
+                List(webMapItems, id: \.id) { item in
                     NavigationLink {
                         MapItemView(map: Map(item: item))
                     } label: {
@@ -40,10 +40,17 @@ struct FeaturedMapsView: View {
             }
         }
         .task {
-            guard featuredItems.isEmpty else { return }
+            guard webMapItems.isEmpty else { return }
             do {
-                featuredItems = try await portal.featuredItems
+                var items = try await portal.featuredItems
                     .filter { $0.kind == .webMap }
+                if items.isEmpty {
+                    items = try await portal.findItems(
+                        queryParameters: .items(ofKinds: [.webMap])
+                    )
+                    .results
+                }
+                webMapItems = items
             } catch {}
             
             isLoading = false

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -75,7 +75,9 @@ extension Authenticator: NetworkAuthenticationChallengeHandler {
             return .continueWithoutCredential
         }
         
-        // If smart card is connected to the device then continue with smart card network credential.
+        // If smart card is connected to the device then a personal identity verification (PIV) token
+        // is available in the `TKTokenWatcher().tokenIDs`. Create a smart card network credential
+        // with first PIV token and continue with credential.
         if challenge.kind == .clientCertificate,
            let pivToken = TKTokenWatcher().tokenIDs.filter({ $0.localizedCaseInsensitiveContains("pivtoken") }).first,
            let credential = try? NetworkCredential.smartCard(pivToken: pivToken) {


### PR DESCRIPTION
- Adds support for smart card
- Updated `AuthenticationExample` to find the `web maps` if no feature items available.
- Added `keychain-access-groups` with value `com.apple.token` which is required for smart card to work.