### PR TITLE
[FormView] Add "Done" button to keyboard toolbar 

### DIFF
--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
@@ -58,24 +58,25 @@ struct MultiLineTextEntry: View {
             if #available(iOS 16.0, *) {
                 TextEditor(text: $text)
                     .scrollContentBackground(.hidden)
-                    .toolbar {
-                        ToolbarItemGroup(placement: .keyboard) {
-                            Spacer()
-                            
-                            Button { } label: { Image(systemName: "chevron.up") }
-                            
-                            Button { } label: { Image(systemName: "chevron.down") }
-                            
-                            Button("Done") {
-                                isFocused = false
-                            }
-                        }
-                    }
             } else {
                 TextEditor(text: $text)
             }
             if isFocused && !text.isEmpty {
                 ClearButton { text.removeAll() }
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button {
+                    isFocused = false
+                } label: {
+                    Text(
+                        "Done",
+                        bundle: .toolkitModule,
+                        comment: "A label for a button to finish text entry and dismiss the keyboard."
+                    )
+                }
             }
         }
         .background(.clear)

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
@@ -58,6 +58,19 @@ struct MultiLineTextEntry: View {
             if #available(iOS 16.0, *) {
                 TextEditor(text: $text)
                     .scrollContentBackground(.hidden)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            
+                            Button { } label: { Image(systemName: "chevron.up") }
+                            
+                            Button { } label: { Image(systemName: "chevron.down") }
+                            
+                            Button("Done") {
+                                isFocused = false
+                            }
+                        }
+                    }
             } else {
                 TextEditor(text: $text)
             }

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -27,6 +27,9 @@ public struct FormView: View {
     public init() {}
     
     public var body: some View {
+        //  When the `FormView` is hosted within a SwiftUI sheet, any `NavigationView` that may have
+        // been in the hierarchy is detached. A `NavigationView` is needed within the hierarchy to
+        // successfully present a keyboard toolbar (as is done in `MultiLineTextEntry`).
         NavigationView {
             ScrollView {
                 FormHeader(title: model.formDefinition?.title)

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -27,7 +27,7 @@ public struct FormView: View {
     public init() {}
     
     public var body: some View {
-        //  When the `FormView` is hosted within a SwiftUI sheet, any `NavigationView` that may have
+        // When the `FormView` is hosted within a SwiftUI sheet, any `NavigationView` that may have
         // been in the hierarchy is detached. A `NavigationView` is needed within the hierarchy to
         // successfully present a keyboard toolbar (as is done in `MultiLineTextEntry`).
         NavigationView {

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -27,13 +27,15 @@ public struct FormView: View {
     public init() {}
     
     public var body: some View {
-        ScrollView {
-            FormHeader(title: model.formDefinition?.title)
-                .padding([.bottom], elementPadding)
-            VStack(alignment: .leading) {
-                ForEach(model.formDefinition?.formElements ?? [], id: \.element?.label) { container in
-                    if let element = container.element {
-                        makeElement(element)
+        NavigationView {
+            ScrollView {
+                FormHeader(title: model.formDefinition?.title)
+                    .padding([.bottom], elementPadding)
+                VStack(alignment: .leading) {
+                    ForEach(model.formDefinition?.formElements ?? [], id: \.element?.label) { container in
+                        if let element = container.element {
+                            makeElement(element)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When a user has a multiline text entry field focused, the keyboard's main action button adds a new line, making it a bit more difficult for a user to complete their entry once finished. 

This PR adds a "Done" button to the  keyboard's toolbar.

<p align="center">
<img width="50%" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/43b061c0-7d96-4c0d-8e6e-2bbf167db467">
</p>