### PR TITLE
Make Default the preferred action

### DIFF
--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -150,6 +150,7 @@ struct CredentialInputView: UIViewControllerRepresentable {
         
         uiAlertController.addAction(cancelUIAlertAction)
         uiAlertController.addAction(continueUIAlertAction)
+        uiAlertController.preferredAction = continueUIAlertAction
         
         return uiAlertController
     }


### PR DESCRIPTION
This makes the Continue button more prominent, whereas before the Cancel button was more prominent.

Before | After
------ | -----
![Screenshot 2023-07-21 at 3 15 14 PM](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/2257493/4affa683-ed43-450f-9e5f-c6b7aa472bdd) | ![Screenshot 2023-07-21 at 3 15 34 PM](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/2257493/e0c1f80b-f196-47cd-989e-daa565665360)
