### PR TITLE
cancel the challenge if OAuth user credential creation is cancelled

### DIFF
--- a/AuthenticationExample/AuthenticationExample/SignInView.swift
+++ b/AuthenticationExample/AuthenticationExample/SignInView.swift
@@ -132,7 +132,7 @@ private extension Error {
     /// authentication challenge.
     var isChallengeCancellationError: Bool {
         switch self {
-        case is CancellationError:
+        case is ArcGISChallengeCancellationError:
             return true
         case let error as NSError:
             return error.domain == NSURLErrorDomain && error.code == -999

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -53,6 +53,9 @@ extension Authenticator: ArcGISAuthenticationChallengeHandler {
             do {
                 return .continueWithCredential(try await OAuthUserCredential.credential(for: configuration))
             } catch is CancellationError {
+                // If user cancels the creation of OAuth user credential then catch the
+                // cancellation error and cancel the challenge. This will make the request which
+                // issued the challenge fail with `ArcGISChallengeCancellationError`.
                 return .cancel
             }
         } else {

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -50,7 +50,11 @@ extension Authenticator: ArcGISAuthenticationChallengeHandler {
         
         // Create the correct challenge type.
         if let configuration = oAuthUserConfigurations.first(where: { $0.canBeUsed(for: challenge.requestURL) }) {
-            return .continueWithCredential(try await OAuthUserCredential.credential(for: configuration))
+            do {
+                return .continueWithCredential(try await OAuthUserCredential.credential(for: configuration))
+            } catch is CancellationError {
+                return .cancel
+            }
         } else {
             let tokenChallengeContinuation = TokenChallengeContinuation(arcGISChallenge: challenge)
             


### PR DESCRIPTION
Cancelling the challenge will give user a new `ArcGISChallengeCancellationError` with underlying error.