### PR TITLE
Form View - Tweak form controls location in example

### DIFF
--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -93,7 +93,7 @@ struct FormExampleView: View {
 //                }
                 
                 .environmentObject(formViewModel)
-                
+                .navigationBarBackButtonHidden(isPresented)
                 .toolbar {
                     // Once iOS 16.0 is the minimum supported, the two conditionals to show the
                     // buttons can be merged and hoisted up as the root content of the toolbar.


### PR DESCRIPTION
- Slightly tweaks where the cancel and submit buttons are placed in the Forms example.
  - On iPhone the buttons will be in the navigation bar unless in landscape which they'll then be in the full screen cover sheet.
  - On iPad the buttons will always been in the sheet despite the split screen state. Leaving the buttons in the navigation bar would cause them to become dimmed but still tappable which was visually confusing.
  - On macCatalyst the buttons will also always be in the sheet.
  - Hides the navigation bar's back button when the form is displayed.
  
https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/705d4c31-97e4-4121-bbdc-6f1dd28854e6

https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/b1695229-5443-4a3a-835f-24c51064bb32

<img width="1080" alt="macCatalyst" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/94f26a1d-49a3-43ec-a805-143ce58863b5">

