### PR TITLE
Form View - Tweak layout for Floating Panel support

### DIFF
--- a/Examples/Examples/FormExampleView.swift
+++ b/Examples/Examples/FormExampleView.swift
@@ -91,7 +91,7 @@ struct FormExampleView: View {
 //                ) {
 //                    Group {
 //                        if isPresented {
-//                            FormView()
+//                            FormView(featureForm: featureForm)
 //                                .padding()
 //                        }
 //                    }

--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -37,9 +37,9 @@ public struct FormView: View {
         // successfully present a keyboard toolbar (as is done in `MultiLineTextEntry`).
         NavigationView {
             ScrollView {
-                FormHeader(title: featureForm?.title)
-                    .padding([.bottom], elementPadding)
                 VStack(alignment: .leading) {
+                    FormHeader(title: featureForm?.title)
+                        .padding([.bottom], elementPadding)
                     ForEach(featureForm?.elements ?? [], id: \.label) { element in
                         makeElement(element)
                     }


### PR DESCRIPTION
- Slightly tweaks the FormView's inner VStack to include the `FormHeader` so that content is properly displayed when using a Floating Panel.

Currently when using a Floating Panel to display a Form View, the `FormHeader` is placed in the vertical center of the scroll view (often overlapping and obscuring other important form content) rather than at the top of the form where it belongs.

Since this isn't a problem with sheets, I spent some time determining if this is a tweak that's needed with how the Floating Panel handles the content provided to it. I wasn't able to find any conclusive solution so I think the responsibility is on a Floating Panel user to ensure the content passed into it is properly laid out.

<p align="center">Current</p>

| Sheet | Floating Panel |
|---|---|
| <p align="center"><img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/a47c2449-97a9-4fa0-9b77-860342d50ae5"></p> | <p align="center"><img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/4bdbf1a8-347e-4077-b7b9-1939b0569e9c"></p> |

<p align="center">Proposed</p>

| Sheet | Floating Panel |
|---|---|
| <p align="center"><img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/0d5b78ae-0371-4f79-8b0e-3d0991f88e7b"></p> | <p align="center"><img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/d2a6ff77-d9f9-4b79-baef-bc337680e15d"></p> |