### PR TITLE
Remove `anyobject_protocol` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,7 +28,6 @@ disabled_rules:
 
 # Some rules are only opt-in
 opt_in_rules: 
-  - anyobject_protocol
   - array_init
   - attributes
   - closure_end_indentation


### PR DESCRIPTION
The rule [has been deprecated](https://github.com/realm/SwiftLint/releases/tag/0.50.0) and now produces a warning:

![image](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/2257493/5cc51b5c-7315-4edc-bbcc-2e2b8d321639)