### PR TITLE
Repair `FloatingPanel` bottom content padding

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -84,6 +84,7 @@ struct FloatingPanel<Content>: View where Content: View {
                 content
                     .frame(height: height)
                     .clipped()
+                    .padding(.bottom, isCompact ? 25 : 10)
                 if !isCompact && isPresented.wrappedValue {
                     Divider()
                     makeHandleView()


### PR DESCRIPTION
This replaces a line that was erroneously removed in #380. Without it, content towards the bottom of the FloatingPanel can collide with the Home Bar or the panel's handle divider.

First reported by @des12437 during release testing

|   | HomeBar  | Panel Handle Divider |
|---|---|---|
| Padding  |  <img width="50%" alt="homebar" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/ecc3ddae-d048-45ac-b319-a9f02f8efc1b">  | <img width="50%" alt="divider" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/530c773b-34fd-4468-9b5e-285f73c47d00"> |
| No Padding  |  <img width="50%" alt="Screenshot 2023-08-14 at 09 07 03" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/db332bd9-ac8d-4d0c-9f66-251081c91f6d">  |  <img width="50%" alt="Screenshot 2023-08-14 at 09 07 27" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/2c3a5881-439f-4334-8b14-96506a49878e"> |