### PR TITLE
Floating Panel - Presentation/usability improvements

### DIFF
--- a/Examples/Examples/FloatingPanelExampleView.swift
+++ b/Examples/Examples/FloatingPanelExampleView.swift
@@ -39,26 +39,30 @@ struct FloatingPanelExampleView: View {
             viewpoint: initialViewpoint
         )
         .floatingPanel(selectedDetent: $selectedDetent, isPresented: isPresented) {
-            switch demoContent {
+            switch demoContent! {
             case .list:
                 FloatingPanelListDemoContent(selectedDetent: $selectedDetent)
             case .textField:
                 FloatingPanelTextFieldDemoContent(selectedDetent: $selectedDetent)
-            case .none:
-                EmptyView()
             }
         }
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Menu {
-                    Button("List") {
-                        demoContent = .list
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                if demoContent != nil {
+                    Button("Dismiss") {
+                        demoContent = nil
                     }
-                    Button("Text Field") {
-                        demoContent = .textField
+                } else {
+                    Menu {
+                        Button("List") {
+                            demoContent = .list
+                        }
+                        Button("Text Field") {
+                            demoContent = .textField
+                        }
+                    } label: {
+                        Text("Present")
                     }
-                } label: {
-                    Text("Present")
                 }
             }
         }

--- a/Examples/Examples/FloatingPanelExampleView.swift
+++ b/Examples/Examples/FloatingPanelExampleView.swift
@@ -42,6 +42,8 @@ struct FloatingPanelExampleView: View {
             switch demoContent! {
             case .list:
                 FloatingPanelListDemoContent(selectedDetent: $selectedDetent)
+            case .text:
+                FloatingPanelTextContent()
             case .textField:
                 FloatingPanelTextFieldDemoContent(selectedDetent: $selectedDetent)
             }
@@ -56,6 +58,9 @@ struct FloatingPanelExampleView: View {
                     Menu {
                         Button("List") {
                             demoContent = .list
+                        }
+                        Button("Text") {
+                            demoContent = .text
                         }
                         Button("Text Field") {
                             demoContent = .textField
@@ -79,8 +84,9 @@ struct FloatingPanelExampleView: View {
 
 /// The types of content available for demo in the Floating Panel.
 private enum FloatingPanelDemoContent {
-    case textField
     case list
+    case text
+    case textField
 }
 
 /// Demo content consisting of a list with inner sections each containing a set of buttons This
@@ -129,6 +135,14 @@ private struct FloatingPanelListDemoContent: View {
                 .disabled(selectedDetent == .height(200))
             }
         }
+    }
+}
+
+/// Demo content consisting of a single instance of short text which demonstrates the Floating
+/// Panel has a stable width, despite the width of its content.
+private struct FloatingPanelTextContent: View {
+    var body: some View {
+        Text("Hello, world!")
     }
 }
 

--- a/Examples/Examples/FloatingPanelExampleView.swift
+++ b/Examples/Examples/FloatingPanelExampleView.swift
@@ -39,13 +39,15 @@ struct FloatingPanelExampleView: View {
             viewpoint: initialViewpoint
         )
         .floatingPanel(selectedDetent: $selectedDetent, isPresented: isPresented) {
-            switch demoContent! {
+            switch demoContent {
             case .list:
                 FloatingPanelListDemoContent(selectedDetent: $selectedDetent)
             case .text:
                 FloatingPanelTextContent()
             case .textField:
                 FloatingPanelTextFieldDemoContent(selectedDetent: $selectedDetent)
+            case .none:
+                EmptyView()
             }
         }
         .toolbar {

--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -43,41 +43,37 @@ struct PopupExampleView: View {
     
     var body: some View {
         MapViewReader { proxy in
-            VStack {
-                MapView(map: dataModel.map)
-                    .onSingleTapGesture { screenPoint, _ in
-                        identifyScreenPoint = screenPoint
+            MapView(map: dataModel.map)
+                .onSingleTapGesture { screenPoint, _ in
+                    identifyScreenPoint = screenPoint
+                }
+                .task(id: identifyScreenPoint) {
+                    guard let identifyScreenPoint = identifyScreenPoint,
+                          let identifyResult = await Result(awaiting: {
+                              try await proxy.identifyLayers(
+                                screenPoint: identifyScreenPoint,
+                                tolerance: 10,
+                                returnPopupsOnly: true
+                              )
+                          })
+                        .cancellationToNil()
+                    else {
+                        return
                     }
-                    .task(id: identifyScreenPoint) {
-                        guard let identifyScreenPoint = identifyScreenPoint,
-                              let identifyResult = await Result(awaiting: {
-                                  try await proxy.identifyLayers(
-                                    screenPoint: identifyScreenPoint,
-                                    tolerance: 10,
-                                    returnPopupsOnly: true
-                                  )
-                              })
-                            .cancellationToNil()
-                        else {
-                            return
-                        }
-                        
-                        self.identifyScreenPoint = nil
-                        self.popup = try? identifyResult.get().first?.popups.first
-                        self.showPopup = self.popup != nil
-                    }
-                    .floatingPanel(
-                        selectedDetent: $floatingPanelDetent,
-                        horizontalAlignment: .leading,
-                        isPresented: $showPopup
-                    ) {
-                        if let popup = popup {
-                            PopupView(popup: popup, isPresented: $showPopup)
-                                .showCloseButton(true)
-                                .padding()
-                        }
-                    }
-            }
+                    
+                    self.identifyScreenPoint = nil
+                    self.popup = try? identifyResult.get().first?.popups.first
+                    self.showPopup = self.popup != nil
+                }
+                .floatingPanel(
+                    selectedDetent: $floatingPanelDetent,
+                    horizontalAlignment: .leading,
+                    isPresented: $showPopup
+                ) {
+                    PopupView(popup: popup!, isPresented: $showPopup)
+                        .showCloseButton(true)
+                        .padding()
+                }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -106,7 +106,6 @@ struct FloatingPanel<Content>: View where Content: View {
                 height: geometryProxy.size.height,
                 alignment: isCompact ? .bottom : .top
             )
-            .transition(.move(edge: isCompact ? .bottom : .top))
             .animation(.easeInOut, value: isPresented.wrappedValue)
             .onSizeChange {
                 maximumHeight = $0.height
@@ -116,7 +115,12 @@ struct FloatingPanel<Content>: View where Content: View {
             }
             .onAppear {
                 withAnimation {
-                    height = heightFor(detent: selectedDetent.wrappedValue)
+                    height = isPresented.wrappedValue ? heightFor(detent: selectedDetent.wrappedValue) : .zero
+                }
+            }
+            .onChange(of: isPresented.wrappedValue) { isPresented in
+                withAnimation {
+                    height = isPresented ? heightFor(detent: selectedDetent.wrappedValue) : .zero
                 }
             }
             .onChange(of: selectedDetent.wrappedValue) { selectedDetent in

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
@@ -42,7 +42,7 @@ public extension View {
         horizontalAlignment: HorizontalAlignment = .trailing,
         isPresented: Binding<Bool> = .constant(true),
         maxWidth: CGFloat = 400,
-        @ViewBuilder _ content: () -> Content
+        @ViewBuilder _ content: @escaping () -> Content
     ) -> some View where Content: View {
         modifier(
             FloatingPanelModifier(
@@ -51,7 +51,7 @@ public extension View {
                 horizontalAlignment: horizontalAlignment,
                 isPresented: isPresented,
                 maxWidth: maxWidth,
-                panelContent: content()
+                panelContent: content
             )
         )
     }
@@ -83,7 +83,7 @@ private struct FloatingPanelModifier<PanelContent>: ViewModifier where PanelCont
     let maxWidth: CGFloat
     
     /// The content to be displayed within the floating panel.
-    let panelContent: PanelContent
+    let panelContent: () -> PanelContent
     
     func body(content: Content) -> some View {
         content
@@ -91,10 +91,9 @@ private struct FloatingPanelModifier<PanelContent>: ViewModifier where PanelCont
                 FloatingPanel(
                     backgroundColor: backgroundColor,
                     selectedDetent: selectedDetent,
-                    isPresented: isPresented
-                ) {
-                    panelContent
-                }
+                    isPresented: isPresented,
+                    content: panelContent
+                )
                 .ignoresSafeArea(.all, edges: .bottom)
                 .frame(maxWidth: isCompact ? .infinity : maxWidth)
             }


### PR DESCRIPTION
Closes Apollo # 103

- Changes the Floating Panel to lazily evaluate the content only upon presentation. Currently the content will be evaluated as soon as the view containing the Floating Panel is loaded, meaning users have to do odd things like this to prevent content from being evaluated too early:
https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/f75f901995fc3efc74671c896286571df55b980a/Examples/Examples/PopupExampleView.swift#L75-L78
- Simple content such as `Text` that doesn't greedily fill its container width-wise would cause the panel to shrink horizontally when the panel is hiding away. This is also fixed and new demo content has been added to demonstrate the fix.