### PR TITLE
Cleanup `FloatingPanel`

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -24,32 +24,17 @@ import SwiftUI
 /// dedicated search panel. They will also be primarily simple containers
 /// that clients will fill with their own content.
 struct FloatingPanel<Content>: View where Content: View {
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.verticalSizeClass) var verticalSizeClass
-    
     /// The background color of the floating panel.
     let backgroundColor: Color
-    
+    /// A binding to the currently selected detent.
+    @Binding var selectedDetent: FloatingPanelDetent
+    /// A binding to a Boolean value that determines whether the view is presented.
+    @Binding var isPresented: Bool
     /// The content shown in the floating panel.
     let content: () -> Content
     
-    /// Creates a `FloatingPanel`.
-    /// - Parameters:
-    ///   - backgroundColor: The background color of the floating panel.
-    ///   - selectedDetent: Controls the height of the panel.
-    ///   - isPresented: A Boolean value indicating if the view is presented.
-    ///   - content: The view shown in the floating panel.
-    init(
-        backgroundColor: Color,
-        selectedDetent: Binding<FloatingPanelDetent>,
-        isPresented: Binding<Bool>,
-        @ViewBuilder content: @escaping () -> Content
-    ) {
-        self.backgroundColor = backgroundColor
-        self.selectedDetent = selectedDetent
-        self.isPresented = isPresented
-        self.content = content
-    }
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     
     /// The color of the handle.
     @State private var handleColor: Color = .defaultHandleColor
@@ -68,16 +53,10 @@ struct FloatingPanel<Content>: View where Content: View {
         horizontalSizeClass == .compact && verticalSizeClass == .regular
     }
     
-    /// A binding to a Boolean value that determines whether the view is presented.
-    private var isPresented: Binding<Bool>
-    
-    /// A binding to the currently selected detent.
-    private var selectedDetent: Binding<FloatingPanelDetent>
-    
-    public var body: some View {
+    var body: some View {
         GeometryReader { geometryProxy in
             VStack(spacing: 0) {
-                if isPresented.wrappedValue {
+                if isPresented {
                     if isCompact {
                         makeHandleView()
                         Divider()
@@ -106,7 +85,7 @@ struct FloatingPanel<Content>: View where Content: View {
                 height: geometryProxy.size.height,
                 alignment: isCompact ? .bottom : .top
             )
-            .animation(.easeInOut, value: isPresented.wrappedValue)
+            .animation(.easeInOut, value: isPresented)
             .onSizeChange {
                 maximumHeight = $0.height
                 if height > maximumHeight {
@@ -115,15 +94,15 @@ struct FloatingPanel<Content>: View where Content: View {
             }
             .onAppear {
                 withAnimation {
-                    height = isPresented.wrappedValue ? heightFor(detent: selectedDetent.wrappedValue) : .zero
+                    height = isPresented ? heightFor(detent: selectedDetent) : .zero
                 }
             }
-            .onChange(of: isPresented.wrappedValue) { isPresented in
+            .onChange(of: isPresented) { isPresented in
                 withAnimation {
-                    height = isPresented ? heightFor(detent: selectedDetent.wrappedValue) : .zero
+                    height = isPresented ? heightFor(detent: selectedDetent) : .zero
                 }
             }
-            .onChange(of: selectedDetent.wrappedValue) { selectedDetent in
+            .onChange(of: selectedDetent) { selectedDetent in
                 withAnimation {
                     height = heightFor(detent: selectedDetent)
                 }
@@ -135,7 +114,7 @@ struct FloatingPanel<Content>: View where Content: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) { _ in
                 withAnimation {
-                    height = heightFor(detent: selectedDetent.wrappedValue)
+                    height = heightFor(detent: selectedDetent)
                 }
             }
         }
@@ -165,7 +144,7 @@ struct FloatingPanel<Content>: View where Content: View {
                 let travelTime = min(0.35, distanceAhead / speed)
                 
                 withAnimation(.easeOut(duration: travelTime)) {
-                    selectedDetent.wrappedValue = newDetent
+                    selectedDetent = newDetent
                     height = targetHeight
                 }
                 handleColor = .defaultHandleColor
@@ -189,7 +168,7 @@ struct FloatingPanel<Content>: View where Content: View {
         guard speed > lowSpeedThreshold else {
             return allDetents.min {
                 abs(currentHeight - $0.height) < abs(currentHeight - $1.height)
-            }?.detent ?? selectedDetent.wrappedValue
+            }?.detent ?? selectedDetent
         }
         // Generate a new set of detents, filtering out those that would produce a height in the
         // opposite direction of the gesture, and sorting them in order of closest to furthest from
@@ -215,9 +194,9 @@ struct FloatingPanel<Content>: View where Content: View {
         // first candidate detent (the one that would produce the least size difference from the
         // current height).
         if speed >= highSpeedThreshold {
-            return candidateDetents.last?.0 ?? selectedDetent.wrappedValue
+            return candidateDetents.last?.0 ?? selectedDetent
         } else {
-            return candidateDetents.first?.0 ?? selectedDetent.wrappedValue
+            return candidateDetents.first?.0 ?? selectedDetent
         }
     }
     


### PR DESCRIPTION
Changes binding properties to use `Binding` as an attribute, eliminating the need to go through the `wrappedValue` property. That also allows us to use the compiler-generated memberwise initializer, so the handwritten one has been removed. Lastly, removes erroneous `public` attribute from the `body` property.