### PR TITLE
Update `PopupView` example code and tutorial

### DIFF
--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -60,11 +60,6 @@ struct PopupExampleView: View {
                     else {
                         return
                     }
-                    defer {
-                        // `identifyScreenPoint` (a `CGPoint`) doesn't conform to Equatable.
-                        // Manually reset the task identifier to prevent undefined behavior.
-                        self.identifyScreenPoint = nil
-                    }
                     self.popup = try? identifyResult.get().first?.popups.first
                     self.showPopup = self.popup != nil
                 }
@@ -72,7 +67,7 @@ struct PopupExampleView: View {
                     selectedDetent: $floatingPanelDetent,
                     horizontalAlignment: .leading,
                     isPresented: $showPopup
-                ) {
+                ) { [popup] in
                     PopupView(popup: popup!, isPresented: $showPopup)
                         .showCloseButton(true)
                         .padding()

--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -60,8 +60,11 @@ struct PopupExampleView: View {
                     else {
                         return
                     }
-                    
-                    self.identifyScreenPoint = nil
+                    defer {
+                        // `identifyScreenPoint` (a `CGPoint`) doesn't conform to Equatable.
+                        // Manually reset the task identifier to prevent undefined behavior.
+                        self.identifyScreenPoint = nil
+                    }
                     self.popup = try? identifyResult.get().first?.popups.first
                     self.showPopup = self.popup != nil
                 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep3.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep3.swift
@@ -23,9 +23,7 @@ struct PopupExampleView: View {
     
     var body: some View {
         MapViewReader { proxy in
-            VStack {
-                MapView(map: dataModel.map)
-            }
+            MapView(map: dataModel.map)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep4.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep4.swift
@@ -23,12 +23,10 @@ struct PopupExampleView: View {
     
     var body: some View {
         MapViewReader { proxy in
-            VStack {
-                MapView(map: dataModel.map)
-                    .onSingleTapGesture { screenPoint, _ in
-                        identifyScreenPoint = screenPoint
-                    }
-            }
+            MapView(map: dataModel.map)
+                .onSingleTapGesture { screenPoint, _ in
+                    identifyScreenPoint = screenPoint
+                }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep5.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep5.swift
@@ -23,30 +23,28 @@ struct PopupExampleView: View {
     
     var body: some View {
         MapViewReader { proxy in
-            VStack {
-                MapView(map: dataModel.map)
-                    .onSingleTapGesture { screenPoint, _ in
-                        identifyScreenPoint = screenPoint
+            MapView(map: dataModel.map)
+                .onSingleTapGesture { screenPoint, _ in
+                    identifyScreenPoint = screenPoint
+                }
+                .task(id: identifyScreenPoint) {
+                    guard let identifyScreenPoint = identifyScreenPoint,
+                          let identifyResult = await Result(awaiting: {
+                              try await proxy.identifyLayers(
+                                screenPoint: identifyScreenPoint,
+                                tolerance: 10,
+                                returnPopupsOnly: true
+                              )
+                          })
+                        .cancellationToNil()
+                    else {
+                        return
                     }
-                    .task(id: identifyScreenPoint) {
-                        guard let identifyScreenPoint = identifyScreenPoint,
-                              let identifyResult = await Result(awaiting: {
-                                  try await proxy.identifyLayers(
-                                    screenPoint: identifyScreenPoint,
-                                    tolerance: 10,
-                                    returnPopupsOnly: true
-                                  )
-                              })
-                            .cancellationToNil()
-                        else {
-                            return
-                        }
-                        
-                        self.identifyScreenPoint = nil
-                        self.popup = try? identifyResult.get().first?.popups.first
-                        self.showPopup = self.popup != nil
-                    }
-            }
+                    
+                    defer { self.identifyScreenPoint = nil }
+                    self.popup = try? identifyResult.get().first?.popups.first
+                    self.showPopup = self.popup != nil
+                }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep5.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep5.swift
@@ -41,7 +41,6 @@ struct PopupExampleView: View {
                         return
                     }
                     
-                    defer { self.identifyScreenPoint = nil }
                     self.popup = try? identifyResult.get().first?.popups.first
                     self.showPopup = self.popup != nil
                 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
@@ -25,41 +25,39 @@ struct PopupExampleView: View {
     
     var body: some View {
         MapViewReader { proxy in
-            VStack {
-                MapView(map: dataModel.map)
-                    .onSingleTapGesture { screenPoint, _ in
-                        identifyScreenPoint = screenPoint
+            MapView(map: dataModel.map)
+                .onSingleTapGesture { screenPoint, _ in
+                    identifyScreenPoint = screenPoint
+                }
+                .task(id: identifyScreenPoint) {
+                    guard let identifyScreenPoint = identifyScreenPoint,
+                          let identifyResult = await Result(awaiting: {
+                              try await proxy.identifyLayers(
+                                screenPoint: identifyScreenPoint,
+                                tolerance: 10,
+                                returnPopupsOnly: true
+                              )
+                          })
+                        .cancellationToNil()
+                    else {
+                        return
                     }
-                    .task(id: identifyScreenPoint) {
-                        guard let identifyScreenPoint = identifyScreenPoint,
-                              let identifyResult = await Result(awaiting: {
-                                  try await proxy.identifyLayers(
-                                    screenPoint: identifyScreenPoint,
-                                    tolerance: 10,
-                                    returnPopupsOnly: true
-                                  )
-                              })
-                            .cancellationToNil()
-                        else {
-                            return
-                        }
-                        
-                        self.identifyScreenPoint = nil
-                        self.popup = try? identifyResult.get().first?.popups.first
-                        self.showPopup = self.popup != nil
+                    
+                    defer { self.identifyScreenPoint = nil }
+                    self.popup = try? identifyResult.get().first?.popups.first
+                    self.showPopup = self.popup != nil
+                }
+                .floatingPanel(
+                    selectedDetent: $floatingPanelDetent,
+                    horizontalAlignment: .leading,
+                    isPresented: $showPopup
+                ) {
+                    if let popup = popup {
+                        PopupView(popup: popup, isPresented: $showPopup)
+                            .showCloseButton(true)
+                            .padding()
                     }
-                    .floatingPanel(
-                        selectedDetent: $floatingPanelDetent,
-                        horizontalAlignment: .leading,
-                        isPresented: $showPopup
-                    ) {
-                        if let popup = popup {
-                            PopupView(popup: popup, isPresented: $showPopup)
-                                .showCloseButton(true)
-                                .padding()
-                        }
-                    }
-            }
+                }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
@@ -43,7 +43,6 @@ struct PopupExampleView: View {
                         return
                     }
                     
-                    defer { self.identifyScreenPoint = nil }
                     self.popup = try? identifyResult.get().first?.popups.first
                     self.showPopup = self.popup != nil
                 }
@@ -51,12 +50,10 @@ struct PopupExampleView: View {
                     selectedDetent: $floatingPanelDetent,
                     horizontalAlignment: .leading,
                     isPresented: $showPopup
-                ) {
-                    if let popup = popup {
-                        PopupView(popup: popup, isPresented: $showPopup)
-                            .showCloseButton(true)
-                            .padding()
-                    }
+                ) { [popup] in
+                    PopupView(popup: popup, isPresented: $showPopup)
+                        .showCloseButton(true)
+                        .padding()
                 }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
@@ -51,7 +51,7 @@ struct PopupExampleView: View {
                     horizontalAlignment: .leading,
                     isPresented: $showPopup
                 ) { [popup] in
-                    PopupView(popup: popup, isPresented: $showPopup)
+                    PopupView(popup: popup!, isPresented: $showPopup)
                         .showCloseButton(true)
                         .padding()
                 }


### PR DESCRIPTION
- Updates the `PopupView` example code to `defer` the task's id reset.
- This work is [also being changed](https://github.com/Esri/arcgis-maps-sdk-swift-samples/pull/247) in samples so this will keep all of our popup sample code in sync.
- Updates the `PopupView` tutorial to reflect all of the latest usage changes