### PR TITLE
Import only what is needed

### DIFF
--- a/Examples/Utility/MapDataModel.swift
+++ b/Examples/Utility/MapDataModel.swift
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
 
 /// A very basic data model class containing a Map. Since a `Map` is not an observable object,
 /// clients can use `MapDataModel` as an example of how you would store a map in a data model

--- a/Examples/Utility/SceneDataModel.swift
+++ b/Examples/Utility/SceneDataModel.swift
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
 
 /// A very basic data model class containing a Scene. Since a `Scene` is not an observable object,
 /// clients can use `SceneDataModel` as an example of how you would store a scene in a data model

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
 import Combine
 
 /// The `Authenticator` is a configurable object that handles authentication challenges. It will

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ArcGIS
+import Combine
 import SwiftUI
 import UniformTypeIdentifiers
-import ArcGIS
 
 /// An object that provides the business logic for the workflow of prompting the user for a
 /// certificate and a password.

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
-import UIKit.UIImage
 import ArcGIS
+import Combine
+import UIKit
 
 ///  The `BasemapGalleryItem` encompasses an element in a `BasemapGallery`.
 public class BasemapGalleryItem: ObservableObject {

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryViewModel.swift
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
 
 /// Manages the state for a `BasemapGallery`.
 @MainActor class BasemapGalleryViewModel: ObservableObject {

--- a/Sources/ArcGISToolkit/Components/Popups/Attachments/AttachmentModel.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/Attachments/AttachmentModel.swift
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
 import QuickLook
+import SwiftUI
 
 /// A view model representing the combination of a `PopupAttachment` and
 /// an associated `UIImage` used as a thumbnail.

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
@@ -11,8 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
+import Foundation
+import UIKit
 
 /// A view model which performs the work necessary to asynchronously download an image
 /// from a URL and handles refreshing that image at a given time interval.

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarViewModel.swift
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import ArcGIS
+import Combine
 import Foundation
-import SwiftUI
 
 @MainActor
 final class ScalebarViewModel: ObservableObject {

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -11,8 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import Combine
+import SwiftUI
 
 /// Defines how many results to return; one, many, or automatic based on circumstance.
 public enum SearchResultMode {

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import ArcGIS
+import Combine
 import Foundation
 import SwiftUI
 


### PR DESCRIPTION
Imports `Combine` wherever `Published` is used and removes `SwiftUI` imports where not necessary. Addresses the following warning seen with command line builds:

```
warning: 'Published' aliases 'Combine.Published' and cannot be used as property wrapper here because 'Combine' was not imported by this file; this is an error in Swift 6
```