### PR TITLE
updated authenticator to use smart card

### DIFF
--- a/AuthenticationExample/AuthenticationExample.xcodeproj/project.pbxproj
+++ b/AuthenticationExample/AuthenticationExample.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		88AD138E283443F800500B2E /* MapItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AD138D283443F800500B2E /* MapItemView.swift */; };
 		88D24DF0288F062D007A539C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DEF288F062D007A539C /* ProfileView.swift */; };
 		88D24DF2288F2FA1007A539C /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF1288F2FA1007A539C /* HomeView.swift */; };
-		88D24DF4288F4BEB007A539C /* FeaturedMapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF3288F4BEB007A539C /* FeaturedMapsView.swift */; };
+		88D24DF4288F4BEB007A539C /* WebMapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF3288F4BEB007A539C /* WebMapsView.swift */; };
 		88D24DF6288F5BAE007A539C /* UserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF5288F5BAE007A539C /* UserView.swift */; };
 		88D24DF8288F6002007A539C /* LoadableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D24DF7288F6002007A539C /* LoadableImageView.swift */; };
 /* End PBXBuildFile section */
@@ -32,7 +32,7 @@
 		88AD138D283443F800500B2E /* MapItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapItemView.swift; sourceTree = "<group>"; };
 		88D24DEF288F062D007A539C /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		88D24DF1288F2FA1007A539C /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
-		88D24DF3288F4BEB007A539C /* FeaturedMapsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedMapsView.swift; sourceTree = "<group>"; };
+		88D24DF3288F4BEB007A539C /* WebMapsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebMapsView.swift; sourceTree = "<group>"; };
 		88D24DF5288F5BAE007A539C /* UserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserView.swift; sourceTree = "<group>"; };
 		88D24DF7288F6002007A539C /* LoadableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableImageView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -75,7 +75,7 @@
 				88AD13782834355000500B2E /* AuthenticationApp.swift */,
 				88D24DF1288F2FA1007A539C /* HomeView.swift */,
 				88D24DF7288F6002007A539C /* LoadableImageView.swift */,
-				88D24DF3288F4BEB007A539C /* FeaturedMapsView.swift */,
+				88D24DF3288F4BEB007A539C /* WebMapsView.swift */,
 				88AD138D283443F800500B2E /* MapItemView.swift */,
 				88AD137A2834355000500B2E /* SigninView.swift */,
 				88D24DEF288F062D007A539C /* ProfileView.swift */,
@@ -176,7 +176,7 @@
 			files = (
 				88AD138E283443F800500B2E /* MapItemView.swift in Sources */,
 				88AD137B2834355000500B2E /* SigninView.swift in Sources */,
-				88D24DF4288F4BEB007A539C /* FeaturedMapsView.swift in Sources */,
+				88D24DF4288F4BEB007A539C /* WebMapsView.swift in Sources */,
 				88D24DF2288F2FA1007A539C /* HomeView.swift in Sources */,
 				88D24DF8288F6002007A539C /* LoadableImageView.swift in Sources */,
 				88D24DF0288F062D007A539C /* ProfileView.swift in Sources */,

--- a/AuthenticationExample/AuthenticationExample/AuthenticationExample.entitlements
+++ b/AuthenticationExample/AuthenticationExample/AuthenticationExample.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>com.apple.token</string>
+	</array>
 </dict>
 </plist>

--- a/AuthenticationExample/AuthenticationExample/HomeView.swift
+++ b/AuthenticationExample/AuthenticationExample/HomeView.swift
@@ -25,7 +25,7 @@ struct HomeView: View {
     var body: some View {
         if let portal = portal {
             NavigationView{
-                FeaturedMapsView(portal: portal)
+                WebMapsView(portal: portal)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button {

--- a/AuthenticationExample/AuthenticationExample/SignInView.swift
+++ b/AuthenticationExample/AuthenticationExample/SignInView.swift
@@ -67,10 +67,12 @@ struct SignInView: View {
                         switch credential {
                         case .password(let passwordCredential):
                             return passwordCredential.username
-                        case .certificate:
-                            return ""
+                        case .certificate(let certificateCredential):
+                            return certificateCredential.identityName
                         case .serverTrust:
                             return nil
+                        case .smartCard(let smartCardCredential):
+                            return smartCardCredential.identityName
                         @unknown default:
                             fatalError("Unknown NetworkCredential")
                         }

--- a/AuthenticationExample/AuthenticationExample/WebMapsView.swift
+++ b/AuthenticationExample/AuthenticationExample/WebMapsView.swift
@@ -14,23 +14,23 @@
 import SwiftUI
 import ArcGIS
 
-/// A view that displays the featured maps of a portal.
-struct FeaturedMapsView: View {
-    /// The portal from which the featured content can be fetched.
+/// A view that displays the web maps of a portal.
+struct WebMapsView: View {
+    /// The portal from which the web maps can be fetched.
     var portal: Portal
     
     /// A Boolean value indicating whether the featured content is being loaded.
     @State var isLoading = true
     
-    /// The featured items.
-    @State var featuredItems = [PortalItem]()
+    /// The web map portal items.
+    @State var webMapItems = [PortalItem]()
     
     var body: some View {
         VStack {
             if isLoading {
                 ProgressView()
             } else {
-                List(featuredItems, id: \.id) { item in
+                List(webMapItems, id: \.id) { item in
                     NavigationLink {
                         MapItemView(map: Map(item: item))
                     } label: {
@@ -40,15 +40,22 @@ struct FeaturedMapsView: View {
             }
         }
         .task {
-            guard featuredItems.isEmpty else { return }
+            guard webMapItems.isEmpty else { return }
             do {
-                featuredItems = try await portal.featuredItems
+                var items = try await portal.featuredItems
                     .filter { $0.kind == .webMap }
+                if items.isEmpty {
+                    items = try await portal.findItems(
+                        queryParameters: .items(ofKinds: [.webMap])
+                    )
+                    .results
+                }
+                webMapItems = items
             } catch {}
             
             isLoading = false
         }
-        .navigationTitle("Featured Maps")
+        .navigationTitle("Web Maps")
     }
 }
 

--- a/AuthenticationExample/AuthenticationExample/WebMapsView.swift
+++ b/AuthenticationExample/AuthenticationExample/WebMapsView.swift
@@ -42,6 +42,7 @@ struct WebMapsView: View {
         .task {
             guard webMapItems.isEmpty else { return }
             do {
+                // Try to fetch the featured items but if none available then find webmap items.
                 var items = try await portal.featuredItems
                     .filter { $0.kind == .webMap }
                 if items.isEmpty {

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -107,7 +107,7 @@ extension Authenticator: ArcGISAuthenticationChallengeHandler {
 extension Authenticator: NetworkAuthenticationChallengeHandler {
     public func handleNetworkAuthenticationChallenge(
         _ challenge: NetworkAuthenticationChallenge
-    ) async -> NetworkAuthenticationChallenge.Disposition  {
+    ) async -> NetworkAuthenticationChallenge.Disposition {
         // If `promptForUntrustedHosts` is `false` then perform default handling
         // for server trust challenges.
         guard promptForUntrustedHosts || challenge.kind != .serverTrust else {


### PR DESCRIPTION
Changes in this pr,
- Updated authenticator to use the connected smart card when client certificate challenge is issued.
- Added `keychain-access-groups` with value `com.apple.token` which is required for smart card to work.
- Updated authenticator example code to find web maps from portal if featured items not available.