### PR TITLE
Localized string key improvements

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -199,11 +199,7 @@ struct CertificatePickerViewModifier: ViewModifier {
                     comment: "A label indicating that a password is required to proceed with an operation."
                 ),
                 cancelAction: .init(
-                    title: String(
-                        localized: "Cancel",
-                        bundle: .toolkitModule,
-                        comment: "A label for a button to cancel an operation."
-                    ),
+                    title: String.cancel,
                     handler: { _, _ in
                         viewModel.cancel()
                     }
@@ -268,12 +264,8 @@ private extension View {
                         isPresented.wrappedValue = false
                         viewModel.cancel()
                     } label: {
-                        Text(
-                            "Cancel",
-                            bundle: .toolkitModule,
-                            comment: "A label for a button to cancel an operation."
-                        )
-                        .padding(.horizontal)
+                        Text(String.cancel)
+                            .padding(.horizontal)
                     }
                     .buttonStyle(.bordered)
                     Spacer()
@@ -363,12 +355,8 @@ private extension View {
                         isPresented.wrappedValue = false
                         viewModel.cancel()
                     } label: {
-                        Text(
-                            "Cancel",
-                            bundle: .toolkitModule,
-                            comment: "A label for a button to cancel an operation."
-                        )
-                        .padding(.horizontal)
+                        Text(String.cancel)
+                            .padding(.horizontal)
                     }
                     .buttonStyle(.bordered)
                     Spacer()

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -174,7 +174,11 @@ struct CertificatePickerViewModifier: ViewModifier {
                     bundle: .toolkitModule
                 ),
                 cancelAction: .init(
-                    title: String(localized: "Cancel", bundle: .toolkitModule),
+                    title: String(
+                        localized: "Cancel",
+                        bundle: .toolkitModule,
+                        comment: "A label for a button to cancel an operation."
+                    ),
                     handler: { _, _ in
                         viewModel.cancel()
                     }
@@ -215,12 +219,20 @@ private extension View {
             Button {
                 viewModel.proceedFromPrompt()
             } label: {
-                Text("Browse For Certificate", bundle: .toolkitModule)
+                Text(
+                    "Browse For Certificate",
+                    bundle: .toolkitModule,
+                    comment: "A label for a button to open the system file browser."
+                )
             }
             Button(role: .cancel) {
                 viewModel.cancel()
             } label: {
-                Text("Cancel", bundle: .toolkitModule)
+                Text(
+                    "Cancel",
+                    bundle: .toolkitModule,
+                    comment: "A label for a button to cancel an operation."
+                )
             }
         } message: { _ in
             Text(
@@ -277,7 +289,11 @@ private extension View {
             Button(role: .cancel) {
                 viewModel.cancel()
             } label: {
-                Text("Cancel", bundle: .toolkitModule)
+                Text(
+                    "Cancel",
+                    bundle: .toolkitModule,
+                    comment: "A label for a button to cancel an operation."
+                )
             }
         } message: {
             Text(

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -336,7 +336,10 @@ private extension View {
                 Text(
                     "Error importing certificate",
                     bundle: .toolkitModule,
-                    comment: ""
+                    comment: """
+                             A message indicating that some error occurred while importing a chosen
+                             network certificate.
+                             """
                 )
                 .font(.title)
                 .multilineTextAlignment(.center)

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -132,7 +132,11 @@ extension CertificatePickerViewModel.CertificateError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .couldNotAccessCertificateFile:
-            return String(localized: "Could not access the certificate file.", bundle: .toolkitModule)
+            return String(
+                localized: "Could not access the certificate file.",
+                bundle: .toolkitModule,
+                comment: "A label indicating a certificate file was inaccessible."
+            )
         case .importError(let error):
             return error.localizedDescription
         case .other(let error):

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -190,12 +190,13 @@ struct CertificatePickerViewModifier: ViewModifier {
                 fields: .password,
                 message: String(
                     localized: "Please enter a password for the chosen certificate.",
-                    bundle: .toolkitModule
+                    bundle: .toolkitModule,
+                    comment: "A label requesting the password associated with the chosen certificate."
                 ),
                 title: String(
                     localized: "Password Required",
                     bundle: .toolkitModule,
-                    comment: ""
+                    comment: "A label indicating that a password is required to proceed with an operation."
                 ),
                 cancelAction: .init(
                     title: String(
@@ -211,7 +212,7 @@ struct CertificatePickerViewModifier: ViewModifier {
                     title: String(
                         localized: "OK",
                         bundle: .toolkitModule,
-                        comment: ""
+                        comment: "A label for button to proceed with an operation."
                     ),
                     handler: { _, password in
                         viewModel.proceedToUseCertificate(withPassword: password)

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -122,19 +122,19 @@ extension CertificateImportError: LocalizedError {
             return String(
                 localized: "The certificate file was invalid.",
                 bundle: .toolkitModule,
-                comment: ""
+                comment: "A label indicating the chosen file was invalid."
             )
         case .invalidPassword:
             return String(
                 localized: "The password was invalid.",
                 bundle: .toolkitModule,
-                comment: ""
+                comment: "A label indicating the given password was invalid."
             )
         default:
             return SecCopyErrorMessageString(rawValue, nil) as String? ?? String(
                 localized: "The certificate file or password was invalid.",
                 bundle: .toolkitModule,
-                comment: ""
+                comment: "A label indicating the chosen file or given password was invalid."
             )
         }
     }
@@ -350,7 +350,7 @@ private extension View {
                     viewModel.certificateError?.localizedDescription ?? String(
                         localized: "The certificate file or password was invalid.",
                         bundle: .toolkitModule,
-                        comment: ""
+                        comment: "A label indicating the chosen file or given password was invalid."
                     )
                 )
                 .font(.subheadline)
@@ -379,7 +379,7 @@ private extension View {
                         Text(
                             "Try Again",
                             bundle: .toolkitModule,
-                            comment: ""
+                            comment: "A label for a button allowing the user to retry an operation."
                         )
                         .padding(.horizontal)
                     }

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -212,7 +212,11 @@ private extension View {
         viewModel: CertificatePickerViewModel
     ) -> some View {
         alert(
-            Text("Certificate Required", bundle: .toolkitModule),
+            Text(
+                "Certificate Required",
+                bundle: .toolkitModule,
+                comment: "A label indicating that a certificate is required to proceed."
+            ),
             isPresented: isPresented,
             presenting: viewModel.challengingHost
         ) { _ in

--- a/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
@@ -57,7 +57,11 @@ struct LoginViewModifier: ViewModifier {
                     }
                 ),
                 continueAction: .init(
-                    title: String(localized: "Continue", bundle: .toolkitModule),
+                    title: String(
+                        localized: "Continue",
+                        bundle: .toolkitModule,
+                        comment: "A label for a button used to continue the authentication operation."
+                    ),
                     handler: { username, password in
                         let loginCredential = LoginCredential(
                             username: username, password: password

--- a/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
@@ -53,11 +53,7 @@ struct LoginViewModifier: ViewModifier {
                     comment: "A label indicating authentication is required to proceed."
                 ),
                 cancelAction: .init(
-                    title: String(
-                        localized: "Cancel",
-                        bundle: .toolkitModule,
-                        comment: "A label for a button to cancel an operation."
-                    ),
+                    title: String.cancel,
                     handler: { _, _ in
                         onCancel()
                     }

--- a/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
@@ -41,9 +41,17 @@ struct LoginViewModifier: ViewModifier {
                         The host is indicated in the variable.
                         """
                 ),
-                title: String(localized: "Authentication Required", bundle: .toolkitModule),
+                title: String(
+                    localized: "Authentication Required",
+                    bundle: .toolkitModule,
+                    comment: "A label indicating authentication is required to proceed."
+                ),
                 cancelAction: .init(
-                    title: String(localized: "Cancel", bundle: .toolkitModule),
+                    title: String(
+                        localized: "Cancel",
+                        bundle: .toolkitModule,
+                        comment: "A label for a button to cancel an operation."
+                    ),
                     handler: { _, _ in
                         onCancel()
                     }

--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -59,7 +59,11 @@ struct TrustHostViewModifier: ViewModifier {
                 Button(role: .cancel) {
                     challenge.resume(with: .cancel)
                 } label: {
-                    Text("Cancel", bundle: .toolkitModule)
+                    Text(
+                        "Cancel",
+                        bundle: .toolkitModule,
+                        comment: "A label for a button to cancel an operation."
+                    )
                 }
             } message: { _ in
                 Text(

--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -71,12 +71,8 @@ struct TrustHostViewModifier: ViewModifier {
                             isPresented = false
                             challenge.resume(with: .cancel)
                         } label: {
-                            Text(
-                                "Cancel",
-                                bundle: .toolkitModule,
-                                comment: "A label for a button to cancel an operation."
-                            )
-                            .padding(.horizontal)
+                            Text(String.cancel)
+                                .padding(.horizontal)
                         }
                         .buttonStyle(.bordered)
                         Spacer()

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
@@ -263,7 +263,7 @@ extension AlertItem {
                 bundle: .toolkitModule,
                 comment: """
                          A label indicating the spatial reference of the chosen basemap doesn't
-                         match the spatial reference of the geo model.
+                         match the spatial reference of the map.
                          """
             )
         case (_, .none):
@@ -286,7 +286,7 @@ extension AlertItem {
                 bundle: .toolkitModule,
                 comment: """
                          A label indicating the spatial reference of the chosen basemap doesn't
-                         match the spatial reference of the geo model.
+                         match the spatial reference of the map or scene.
                          """
             ),
             message: message

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
@@ -258,15 +258,37 @@ extension AlertItem {
         
         switch (spatialReferenceMismatchError.basemapSpatialReference, spatialReferenceMismatchError.geoModelSpatialReference) {
         case (.some(_), .some(_)):
-            message = String(localized: "The basemap has a spatial reference that is incompatible with the map.", bundle: .toolkitModule)
+            message = String(
+                localized: "The basemap has a spatial reference that is incompatible with the map.",
+                bundle: .toolkitModule,
+                comment: """
+                         A label indicating the spatial reference of the chosen basemap doesn't
+                         match the spatial reference of the geo model.
+                         """
+            )
         case (_, .none):
-            message = String(localized: "The map does not have a spatial reference.", bundle: .toolkitModule)
+            message = String(
+                localized: "The map does not have a spatial reference.",
+                bundle: .toolkitModule,
+                comment: "A label indicating the map doesn't have a spatial reference."
+            )
         case (.none, _):
-            message = String(localized: "The basemap does not have a spatial reference.", bundle: .toolkitModule)
+            message = String(
+                localized: "The basemap does not have a spatial reference.",
+                bundle: .toolkitModule,
+                comment: "A label indicating the chosen basemap doesn't have a spatial reference."
+            )
         }
         
         self.init(
-            title: String(localized: "Spatial reference mismatch.", bundle: .toolkitModule),
+            title: String(
+                localized: "Spatial reference mismatch.",
+                bundle: .toolkitModule,
+                comment: """
+                         A label indicating the spatial reference of the chosen basemap doesn't
+                         match the spatial reference of the geo model.
+                         """
+            ),
             message: message
         )
     }

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
@@ -37,7 +37,7 @@ struct BookmarksHeader: View {
                 Text(
                     "Bookmarks",
                     bundle: .toolkitModule,
-                    comment: "A label in reference to bookmarks contained in a geo model."
+                    comment: "A label in reference to bookmarks contained in a map or scene."
                 )
                 .font(.headline)
                 Text(

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
@@ -40,9 +40,13 @@ struct BookmarksHeader: View {
                     comment: "A label in reference to bookmarks contained in a geo model."
                 )
                 .font(.headline)
-                Text("Select a bookmark", bundle: .toolkitModule)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                Text(
+                    "Select a bookmark",
+                    bundle: .toolkitModule,
+                    comment: "A label prompting the user to make a selection from the available bookmarks."
+                )
+                .font(.subheadline)
+                .foregroundColor(.secondary)
             }
             .frame(
                 maxWidth: .infinity,

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
@@ -34,8 +34,12 @@ struct BookmarksHeader: View {
         HStack(alignment: .top) {
             Image(systemName: "bookmark")
             VStack(alignment: .leading) {
-                Text("Bookmarks", bundle: .toolkitModule)
-                    .font(.headline)
+                Text(
+                    "Bookmarks",
+                    bundle: .toolkitModule,
+                    comment: "A label in reference to bookmarks contained in a geo model."
+                )
+                .font(.headline)
                 Text("Select a bookmark", bundle: .toolkitModule)
                     .font(.subheadline)
                     .foregroundColor(.secondary)

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksList.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksList.swift
@@ -39,7 +39,11 @@ struct BookmarksList: View {
         Group {
             if bookmarks.isEmpty {
                 Label {
-                    Text("No bookmarks", bundle: .toolkitModule)
+                    Text(
+                        "No bookmarks",
+                        bundle: .toolkitModule,
+                        comment: "A label indicating that no bookmarks are available for selection."
+                    )
                 } icon: {
                     Image(systemName: "bookmark.slash")
                 }

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -103,7 +103,7 @@ struct SiteAndFacilitySelector: View {
                 prompt: String(
                     localized: "Filter sites",
                     bundle: .toolkitModule,
-                    comment: "A search field allowing user to filter a list of sites by name."
+                    comment: "A field allowing a user to filter a list of sites by name. A site contains one or more facilities in a floor-aware map or scene."
                 )
             )
             .keyboardType(.alphabet)

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -245,7 +245,14 @@ struct SiteAndFacilitySelector: View {
                     bundle: .toolkitModule,
                     comment: "A reference to all of the sites defined in a floor aware map."
                 ) :
-                viewModel.selection?.site?.name ?? String(localized: "Select a facility", bundle: .toolkitModule)
+                viewModel.selection?.site?.name ?? String(
+                    localized: "Select a facility",
+                    bundle: .toolkitModule,
+                    comment: """
+                             A label directing a user to select a facility. A facility contains one
+                             or more levels in a floor-aware map or scene.
+                             """
+                )
             )
         }
         

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -233,7 +233,7 @@ struct SiteAndFacilitySelector: View {
                 prompt: String(
                     localized: "Filter facilities",
                     bundle: .toolkitModule,
-                    comment: "A search field allowing user to filter a list of facilities by name."
+                    comment: "A field allowing a user to filter a list of facilities by name. A facility contains one or more levels in a floor-aware map or scene."
                 )
             )
             .keyboardType(.alphabet)

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -108,7 +108,11 @@ struct SiteAndFacilitySelector: View {
             )
             .keyboardType(.alphabet)
             .disableAutocorrection(true)
-            .navigationTitle(String(localized: "Sites", bundle: .toolkitModule))
+            .navigationTitle(String(
+                localized: "Sites",
+                bundle: .toolkitModule,
+                comment: "A label in reference to all of the sites in a floor-aware map or scene."
+            ))
         }
         
         /// The "All sites" button.

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -103,7 +103,10 @@ struct SiteAndFacilitySelector: View {
                 prompt: String(
                     localized: "Filter sites",
                     bundle: .toolkitModule,
-                    comment: "A field allowing a user to filter a list of sites by name. A site contains one or more facilities in a floor-aware map or scene."
+                    comment: """
+                             A field allowing the user to filter a list of sites by name. A site
+                             contains one or more facilities in a floor-aware map or scene.
+                             """
                 )
             )
             .keyboardType(.alphabet)
@@ -237,7 +240,10 @@ struct SiteAndFacilitySelector: View {
                 prompt: String(
                     localized: "Filter facilities",
                     bundle: .toolkitModule,
-                    comment: "A field allowing a user to filter a list of facilities by name. A facility contains one or more levels in a floor-aware map or scene."
+                    comment: """
+                             A field allowing the user to filter a list of facilities by name. A
+                             facility contains one or more levels in a floor-aware map or scene.
+                             """
                 )
             )
             .keyboardType(.alphabet)
@@ -253,7 +259,7 @@ struct SiteAndFacilitySelector: View {
                     localized: "Select a facility",
                     bundle: .toolkitModule,
                     comment: """
-                             A label directing a user to select a facility. A facility contains one
+                             A label directing the user to select a facility. A facility contains one
                              or more levels in a floor-aware map or scene.
                              """
                 )

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -302,8 +302,12 @@ struct SiteAndFacilitySelector: View {
 /// Displays text "No matches found".
 private struct NoMatchesView: View {
     var body: some View {
-        Text("No matches found", bundle: .toolkitModule)
-            .frame(maxHeight: .infinity)
+        Text(
+            "No matches found",
+            bundle: .toolkitModule,
+            comment: "A statement that no sites or facilities with names matching a filter phrase were found."
+        )
+        .frame(maxHeight: .infinity)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -320,7 +320,7 @@ struct SiteAndFacilitySelector: View {
 private struct NoMatchesView: View {
     var body: some View {
         Text(
-            "No matches found",
+            "No matches found.",
             bundle: .toolkitModule,
             comment: "A statement that no sites or facilities with names matching a filter phrase were found."
         )

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -131,7 +131,7 @@ struct SiteAndFacilitySelector: View {
                 Text(
                     "All sites",
                     bundle: .toolkitModule,
-                    comment: "A button allowing users to view a list of all sites defined in a floor aware map."
+                    comment: "A reference to all of the sites defined in a floor aware map."
                 )
             }
             .buttonStyle(.bordered)
@@ -240,8 +240,12 @@ struct SiteAndFacilitySelector: View {
             .disableAutocorrection(true)
             .navigationTitle(
                 usesAllSitesStyling ?
-                String(localized: "All Sites", bundle: .toolkitModule) :
-                    viewModel.selection?.site?.name ?? String(localized: "Select a facility", bundle: .toolkitModule)
+                String(
+                    localized: "All sites",
+                    bundle: .toolkitModule,
+                    comment: "A reference to all of the sites defined in a floor aware map."
+                ) :
+                viewModel.selection?.site?.name ?? String(localized: "Select a facility", bundle: .toolkitModule)
             )
         }
         

--- a/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
@@ -95,6 +95,10 @@ struct AttachmentsPopupElementView: View {
 private extension AttachmentsPopupElement {
     /// Provides a default title to display if `title` is empty.
     var displayTitle: String {
-        title.isEmpty ? String(localized: "Attachments", bundle: .toolkitModule) : title
+        title.isEmpty ? String(
+            localized: "Attachments",
+            bundle: .toolkitModule,
+            comment: "A label in reference to attachments in a popup."
+        ) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -91,7 +91,7 @@ private extension FieldsPopupElement {
         title.isEmpty ? String(
             localized: "Fields",
             bundle: .toolkitModule,
-            comment: "A label in reference to fields contained in a chart of data."
+            comment: "A label in reference to fields in a chart of data contained in a popup."
         ) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -91,7 +91,7 @@ private extension FieldsPopupElement {
         title.isEmpty ? String(
             localized: "Fields",
             bundle: .toolkitModule,
-            comment: "A label in reference to fields in a chart of data contained in a popup."
+            comment: "A label in reference to fields in a set of data contained in a popup."
         ) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -88,6 +88,10 @@ private struct DisplayField: Hashable, Identifiable {
 private extension FieldsPopupElement {
     /// Provides a default title to display if `title` is empty.
     var displayTitle: String {
-        title.isEmpty ? String(localized: "Fields", bundle: .toolkitModule) : title
+        title.isEmpty ? String(
+            localized: "Fields",
+            bundle: .toolkitModule,
+            comment: "A label in reference to fields contained in a chart of data."
+        ) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
@@ -118,6 +118,10 @@ extension PopupMedia: Identifiable {}
 private extension MediaPopupElement {
     /// Provides a default title to display if `title` is empty.
     var displayTitle: String {
-        title.isEmpty ? String(localized: "Media", bundle: .toolkitModule) : title
+        title.isEmpty ? String(
+            localized: "Media",
+            bundle: .toolkitModule,
+            comment: "A label referring to media elements contained within a popup."
+        ) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
@@ -121,7 +121,7 @@ private extension MediaPopupElement {
         title.isEmpty ? String(
             localized: "Media",
             bundle: .toolkitModule,
-            comment: "A label referring to media elements contained within a popup."
+            comment: "A label in reference to media elements contained within a popup."
         ) : title
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/BarChart.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/BarChart.swift
@@ -49,14 +49,14 @@ struct BarChart: View {
                 if isColumnChart {
                     // Vertical bars.
                     BarMark(
-                        x: .value("Field", $0.label),
-                        y: .value("Value", $0.value)
+                        x: .value(String.field, $0.label),
+                        y: .value(String.value, $0.value)
                     )
                 } else {
                     // Horizontal bars.
                     BarMark(
-                        x: .value("Value", $0.value),
-                        y: .value("Field", $0.label)
+                        x: .value(String.value, $0.value),
+                        y: .value(String.field, $0.label)
                     )
                 }
             }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/LineChart.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/LineChart.swift
@@ -41,12 +41,12 @@ struct LineChart: View {
 #if canImport(Charts)
             Chart(chartData) {
                 LineMark(
-                    x: .value("Field", $0.label),
-                    y: .value("Value", $0.value)
+                    x: .value(String.field, $0.label),
+                    y: .value(String.value, $0.value)
                 )
                 PointMark(
-                    x: .value("Field", $0.label),
-                    y: .value("Value", $0.value)
+                    x: .value(String.field, $0.label),
+                    y: .value(String.value, $0.value)
                 )
             }
             .chartXAxis {

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageView.swift
@@ -69,7 +69,8 @@ struct AsyncImageView: View {
                         .foregroundColor(.red)
                     Text(
                         "An error occurred loading the image: \(error.localizedDescription).",
-                        bundle: .toolkitModule
+                        bundle: .toolkitModule,
+                        comment: "A fallback message to display when an image cannot be loaded."
                     )
                 }
                 .padding([.top, .bottom])

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/AsyncImageViewModel.swift
@@ -110,7 +110,7 @@ struct LoadImageError: Error {
 extension LoadImageError: LocalizedError {
     public var errorDescription: String? {
         return String(
-            localized: "The URL could not be reached or did not contain image data",
+            localized: "The URL could not be reached or did not contain image data.",
             bundle: .toolkitModule,
             comment: "Description of error thrown when a remote image could not be loaded."
         )

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
@@ -59,9 +59,16 @@ struct MediaDetailView : View {
                     }
                     if popupMedia.value?.linkURL != nil {
                         HStack {
-                            Text("Tap on the image for more information.", bundle: .toolkitModule)
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
+                            Text(
+                                "Tap on the image for more information.",
+                                bundle: .toolkitModule,
+                                comment: """
+                                         A label indicating that tapping an image will reveal
+                                         additional information.
+                                         """
+                            )
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
                             Spacer()
                         }
                     }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -113,8 +113,12 @@ public struct PopupView: View {
                         )
                     }
                 } else {
-                    VStack(alignment: .center) {
-                        Text("Evaluating popup expressions…", bundle: .toolkitModule)
+                    HStack(alignment: .center, spacing: 10) {
+                        Text(
+                            "Evaluating popup expressions",
+                            bundle: .toolkitModule,
+                            comment: "A label indicating popup expressions are being evaluated."
+                        )
                         ProgressView()
                     }
                     .frame(maxWidth: .infinity)

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -128,11 +128,15 @@ public struct SearchView: View {
     
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.verticalSizeClass) var verticalSizeClass
-
+    
     /// The string shown in the search view when no user query is entered.
     /// Defaults to "Find a place or address". Note: this is set using the
     /// `prompt` modifier.
-    private var prompt = String(localized: "Find a place or address", bundle: .toolkitModule)
+    private var prompt = String(
+        localized: "Find a place or address",
+        bundle: .toolkitModule,
+        comment: "A hint as to what a user can search for within a search bar."
+    )
     
     /// Determines whether a built-in result view will be shown. Defaults to `true`.
     /// If `false`, the result display/selection list is not shown. Set to false if you want to hide the results

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -223,8 +223,9 @@ public struct SearchView: View {
                         "Repeat Search Here",
                         bundle: .toolkitModule,
                         comment: """
-                                  A button to show when a user has panned the map away from the
-                                  original search location.
+                                  A label for button to show when a user has panned the map away
+                                  from the original search location. 'Here' is in reference to the
+                                  current visible extent of the map or scene.
                                   """
                     )
                 }

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -135,7 +135,7 @@ public struct SearchView: View {
     private var prompt = String(
         localized: "Find a place or address",
         bundle: .toolkitModule,
-        comment: "A hint as to what a user can search for within a search bar."
+        comment: "A hint as to what the user can search for within a search bar."
     )
     
     /// Determines whether a built-in result view will be shown. Defaults to `true`.
@@ -227,7 +227,7 @@ public struct SearchView: View {
                         "Repeat Search Here",
                         bundle: .toolkitModule,
                         comment: """
-                                  A label for button to show when a user has panned the map away
+                                  A label for button to show when the user has panned the map away
                                   from the original search location. 'Here' is in reference to the
                                   current visible extent of the map or scene.
                                   """

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -135,7 +135,7 @@ public struct SearchView: View {
     private var prompt = String(
         localized: "Find a place or address",
         bundle: .toolkitModule,
-        comment: "A hint for user what to search in a search bar."
+        comment: "A hint for the user on what to search for in a search bar."
     )
     
     /// Determines whether a built-in result view will be shown. Defaults to `true`.

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -228,7 +228,7 @@ public struct SearchView: View {
                         bundle: .toolkitModule,
                         comment: """
                                   A label for button to show when the user has panned the map away
-                                  from the original search location. 'Here' is in reference to the
+                                  from the original search location. 'here' is in reference to the
                                   current visible extent of the map or scene.
                                   """
                     )

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -224,7 +224,7 @@ public struct SearchView: View {
                     viewModel.repeatSearch()
                 } label: {
                     Text(
-                        "Repeat Search Here",
+                        "Repeat search here",
                         bundle: .toolkitModule,
                         comment: """
                                   A label for button to show when the user has panned the map away

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -135,7 +135,7 @@ public struct SearchView: View {
     private var prompt = String(
         localized: "Find a place or address",
         bundle: .toolkitModule,
-        comment: "A hint as to what the user can search for within a search bar."
+        comment: "A hint for user what to search in a search bar."
     )
     
     /// Determines whether a built-in result view will be shown. Defaults to `true`.

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -887,7 +887,7 @@ private extension String {
     )
     
     static let noConfigurationsAvailable = String(
-        localized: "No configurations available",
+        localized: "No configurations available.",
         bundle: .toolkitModule,
         comment: "A statement that no utility trace configurations are available."
     )

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -442,7 +442,7 @@ public struct UtilityNetworkTrace: View {
                                             Text(
                                                 "Not Available",
                                                 bundle: .toolkitModule,
-                                                comment: "A trace function output result is not available."
+                                                comment: "A trace function output result was not provided."
                                             )
                                         }
                                     }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -873,7 +873,8 @@ private extension String {
     
     static let noConfigurationsAvailable = String(
         localized: "No configurations available",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A statement that no utility trace configurations are available."
     )
     
     static let noneSelected = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -842,7 +842,7 @@ private extension String {
         localized: "Feature Results",
         bundle: .toolkitModule,
         comment: """
-                 A label referring to utility elements returned as results of a utility network
+                 A label in reference to utility elements returned as results of a utility network
                  trace operation.
                  """
     )
@@ -850,14 +850,14 @@ private extension String {
     static let fractionAlongEdgeSectionTitle = String(
         localized: "Fraction Along Edge",
         bundle: .toolkitModule,
-        comment: "A label referring to a fractional distance along an edge style utility network element."
+        comment: "A label in reference to a fractional distance along an edge style utility network element."
     )
     
     static let functionResultsSectionTitle = String(
         localized: "Function Results",
         bundle: .toolkitModule,
         comment: """
-                 A label referring to function outputs returned as results of a utility network
+                 A label in reference to function outputs returned as results of a utility network
                  trace operation.
                  """
     )
@@ -871,7 +871,7 @@ private extension String {
     static let nameLabel = String(
         localized: "Name",
         bundle: .toolkitModule,
-        comment: "A label referring to a user defined name given for an individual utility network trace."
+        comment: "A label in reference to the user defined name for an individual utility network trace."
     )
     
     static let networkSectionLabel = String(
@@ -909,7 +909,7 @@ private extension String {
         localized: "Starting Points",
         bundle: .toolkitModule,
         comment: """
-                 A label referring to the utility elements chosen as starting points for a utility
+                 A label in reference to the utility elements chosen as starting points for a utility
                  network trace operation.
                  """
     )

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -900,7 +900,8 @@ private extension String {
     
     static let traceButtonLabel = String(
         localized: "Trace",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label for a button to begin a utility network trace operation."
     )
     
     static let traceConfigurationSectionLabel = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -840,7 +840,11 @@ private extension String {
     /// Title for the feature results section
     static let featureResultsTitle = String(
         localized: "Feature Results",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: """
+                 A label referring to utility elements returned as results of a utility network
+                 trace operation.
+                 """
     )
     
     static let fractionAlongEdgeSectionTitle = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -849,12 +849,17 @@ private extension String {
     
     static let fractionAlongEdgeSectionTitle = String(
         localized: "Fraction Along Edge",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label referring to a fractional distance along an edge style utility network element."
     )
     
     static let functionResultsSectionTitle = String(
         localized: "Function Results",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: """
+                 A label referring to function outputs returned as results of a utility network
+                 trace operation.
+                 """
     )
     
     static let modePickerTitle = String(
@@ -865,7 +870,8 @@ private extension String {
     
     static let nameLabel = String(
         localized: "Name",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label referring to a user defined name given for an individual utility network trace."
     )
     
     static let networkSectionLabel = String(
@@ -876,7 +882,8 @@ private extension String {
     
     static let newTraceOptionLabel = String(
         localized: "New trace",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label for a button to show new utility network trace configuration options."
     )
     
     static let noConfigurationsAvailable = String(
@@ -887,7 +894,8 @@ private extension String {
     
     static let noneSelected = String(
         localized: "None selected",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label indicating that no utility network trace configuration has been selected."
     )
     
     static let resultsOptionLabel = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -809,7 +809,8 @@ private extension String {
     
     static let cancelStartingPointSelection = String(
         localized: "Cancel starting point selection",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label for a button to cancel the starting point selection operation."
     )
     
     static let clearAllResults = String(
@@ -826,12 +827,14 @@ private extension String {
     
     static let colorLabel = String(
         localized: "Color",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label in reference to the color used to display utility trace result graphics."
     )
     
     static let deleteButtonLabel = String(
         localized: "Delete",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label for a button used to delete a utility network trace input component or result."
     )
     
     /// Title for the feature results section

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -803,7 +803,8 @@ private extension String {
     
     static let attributesSectionTitle = String(
         localized: "Attributes",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label in reference to the attributes of a geo element."
     )
     
     static let cancelStartingPointSelection = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -715,7 +715,7 @@ public struct UtilityNetworkTrace: View {
     private var currentTraceLabel: String {
         guard let index = viewModel.selectedTraceIndex else { return "Error" }
         return String(
-            localized: "Trace \(index+1, specifier: "%lld1") of \(viewModel.completedTraces.count, specifier: "%lld2")",
+            localized: "Trace \(index+1, specifier: "%1$lld") of \(viewModel.completedTraces.count, specifier: "%2$lld")",
             bundle: .toolkitModule,
             comment: "A label indicating the index of the trace being viewed out of the total number of traces completed."
         )

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -851,7 +851,8 @@ private extension String {
     
     static let modePickerTitle = String(
         localized: "Mode",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "The mode in which the utility network trace tool is being used (either creating traces or viewing traces)."
     )
     
     static let nameLabel = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -715,7 +715,7 @@ public struct UtilityNetworkTrace: View {
     private var currentTraceLabel: String {
         guard let index = viewModel.selectedTraceIndex else { return "Error" }
         return String(
-            localized: "Trace \(index+1, specifier: "%lld") of \(viewModel.completedTraces.count, specifier: "%lld")",
+            localized: "Trace \(index+1, specifier: "%lld1") of \(viewModel.completedTraces.count, specifier: "%lld2")",
             bundle: .toolkitModule,
             comment: "A label indicating the index of the trace being viewed out of the total number of traces completed."
         )

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -862,7 +862,8 @@ private extension String {
     
     static let networkSectionLabel = String(
         localized: "Network",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label in reference to a specific utility network."
     )
     
     static let newTraceOptionLabel = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -477,15 +477,15 @@ public struct UtilityNetworkTrace: View {
                 }
             }
             .padding([.vertical], 2)
-            Button(String.clearAllResultsButtonLabel, role: .destructive) {
+            Button(String.clearAllResults, role: .destructive) {
                 isShowingClearAllResultsConfirmationDialog = true
             }
             .buttonStyle(.bordered)
             .confirmationDialog(
-                String.clearAllResultsQuestion,
+                String.clearAllResults,
                 isPresented: $isShowingClearAllResultsConfirmationDialog
             ) {
-                Button(String.clearAllResultsButtonLabel, role: .destructive) {
+                Button(String.clearAllResults, role: .destructive) {
                     viewModel.deleteAllTraces()
                     currentActivity = .creatingTrace(nil)
                 }
@@ -811,14 +811,10 @@ private extension String {
         bundle: .toolkitModule
     )
     
-    static let clearAllResultsButtonLabel = String(
-        localized: "Clear All Results",
-        bundle: .toolkitModule
-    )
-    
-    static let clearAllResultsQuestion = String(
-        localized: "Clear all results?",
-        bundle: .toolkitModule
+    static let clearAllResults = String(
+        localized: "Clear all results",
+        bundle: .toolkitModule,
+        comment: "A directive to clear all of the completed utility network traces."
     )
     
     static let clearAllResultsMessage = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -900,18 +900,24 @@ private extension String {
     
     static let resultsOptionLabel = String(
         localized: "Results",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label for a button to show utility network trace results."
     )
     
     /// Title for the starting points section
     static let startingPointsTitle = String(
         localized: "Starting Points",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: """
+                 A label referring to the utility elements chosen as starting points for a utility
+                 network trace operation.
+                 """
     )
     
     static let terminalConfigurationPickerTitle = String(
         localized: "Terminal Configuration",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label in reference to the chosen terminal configuration of a utility network element."
     )
     
     static let traceButtonLabel = String(
@@ -922,7 +928,8 @@ private extension String {
     
     static let traceConfigurationSectionLabel = String(
         localized: "Trace Configuration",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
+        comment: "A label in reference to a utility network trace configuration."
     )
     
     static let unnamedAssetType = String(

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
@@ -18,7 +18,7 @@ struct UtilityNetworkTraceUserAlert {
     /// Title of the alert.
     var title: String = String(
         localized: "Error",
-        bundle: .toolkitModule
+        bundle: .toolkitModule,
         comment: "A label in reference to an error that occurred during a utility network trace."
     )
     

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
@@ -34,7 +34,11 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "Please set at least 1 starting location.",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: """
+                         A label indicating that at least one starting location is required for the
+                         chosen utility network trace configuration.
+                         """
             )
         )
     }
@@ -43,7 +47,11 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "Please set at least 2 starting locations.",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: """
+                         A label indicating that at least two starting locations are required for the
+                         chosen utility network trace configuration.
+                         """
             )
         )
     }
@@ -73,7 +81,8 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "No trace types found.",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: "A label indicating that no utility named trace configurations are available."
             )
         )
     }
@@ -82,7 +91,8 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "No utility networks found.",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: "A label indicating that no utility networks are available."
             )
         )
     }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
@@ -52,11 +52,19 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             title: String(
                 localized: "Failed to set starting point",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: """
+                         A message indicating that the chosen utility network element wasn't able
+                         to be used as a trace starting point.
+                         """
             ),
             description: String(
                 localized: "Duplicate starting points cannot be added.",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: """
+                         A message indicating that the user attempted to use a single utility
+                         network element for more than one trace starting point.
+                         """
             )
         )
     }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceUserAlert.swift
@@ -16,7 +16,11 @@ import SwiftUI
 /// A user presentable alert.
 struct UtilityNetworkTraceUserAlert {
     /// Title of the alert.
-    var title: String = String(localized: "Error", bundle: .toolkitModule)
+    var title: String = String(
+        localized: "Error",
+        bundle: .toolkitModule
+        comment: "A label in reference to an error that occurred during a utility network trace."
+    )
     
     /// Description of the alert.
     var description: String
@@ -79,7 +83,11 @@ extension UtilityNetworkTraceUserAlert {
         .init(
             description: String(
                 localized: "Element could not be identified.",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: """
+                         A label indicating an element could not be identified as a starting point
+                         for a utility network trace.
+                         """
             )
         )
     }

--- a/Sources/ArcGISToolkit/Extensions/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/String.swift
@@ -26,7 +26,7 @@ extension String {
         .init(
             localized: "Value",
             bundle: .toolkitModule,
-            comment: "A value in a set of data contained in a popup."
+            comment: "A value in a chart of data contained in a popup."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/String.swift
@@ -14,6 +14,16 @@
 import Foundation
 
 extension String {
+    /// A localized string for the word "Cancel".
+    static var cancel: Self {
+        .init(
+            localized: "Cancel",
+            bundle: .toolkitModule,
+            comment: "A label for a button to cancel an operation."
+        )
+    }
+    
+    /// A localized string for the word "Field".
     static var field: Self {
         .init(
             localized: "Field",
@@ -22,6 +32,7 @@ extension String {
         )
     }
     
+    /// A localized string for the word "Value".
     static var value: Self {
         .init(
             localized: "Value",

--- a/Sources/ArcGISToolkit/Extensions/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/String.swift
@@ -18,7 +18,7 @@ extension String {
         .init(
             localized: "Field",
             bundle: .toolkitModule,
-            comment: "A field in a chart of data contained in a popup."
+            comment: "A field in a set of data contained in a popup."
         )
     }
     
@@ -26,7 +26,7 @@ extension String {
         .init(
             localized: "Value",
             bundle: .toolkitModule,
-            comment: "A value in a chart of data contained in a popup."
+            comment: "A value in a set of data contained in a popup."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/String.swift
@@ -24,7 +24,7 @@ extension String {
     
     static var value: Self {
         .init(
-            localized: "Field",
+            localized: "Value",
             bundle: .toolkitModule,
             comment: "A value in a set of data contained in a popup."
         )

--- a/Sources/ArcGISToolkit/Extensions/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/String.swift
@@ -1,0 +1,32 @@
+// Copyright 2023 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension String {
+    static var field: Self {
+        .init(
+            localized: "Field",
+            bundle: .toolkitModule,
+            comment: "A field in a chart of data contained in a popup."
+        )
+    }
+    
+    static var value: Self {
+        .init(
+            localized: "Field",
+            bundle: .toolkitModule,
+            comment: "A value in a set of data contained in a popup."
+        )
+    }
+}

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -204,7 +204,7 @@ variable provides additional data. */
  or more levels in a floor-aware map or scene. */
 "Select a facility" = "Select a facility";
 
-/* No comment provided by engineer. */
+/* A label in reference to all of the sites in a floor-aware map or scene. */
 "Sites" = "Sites";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -104,7 +104,7 @@ east, etc.). */
 /* A field in a chart of data contained in a popup. */
 "Field" = "Field";
 
-/* No comment provided by engineer. */
+/* A label in reference to fields contained in a chart of data. */
 "Fields" = "Fields";
 
 /* A search field allowing user to filter a list of facilities by name. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -200,7 +200,8 @@ variable provides additional data. */
 /* No comment provided by engineer. */
 "Select a bookmark" = "Select a bookmark";
 
-/* No comment provided by engineer. */
+/* A label directing a user to select a facility. A facility contains one
+ or more levels in a floor-aware map or scene. */
 "Select a facility" = "Select a facility";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -110,7 +110,7 @@ east, etc.). */
 /* A search field allowing user to filter a list of facilities by name. */
 "Filter facilities" = "Filter facilities";
 
-/* A search field allowing user to filter a list of sites by name. */
+/* A field allowing a user to filter a list of sites by name. A site contains one or more facilities in a floor-aware map or scene. */
 "Filter sites" = "Filter sites";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -118,31 +118,32 @@ network certificate. */
 /* A field allowing a user to filter a list of sites by name. A site contains one or more facilities in a floor-aware map or scene. */
 "Filter sites" = "Filter sites";
 
-/* No comment provided by engineer. */
+/* A hint as to what a user can search for within a search bar. */
 "Find a place or address" = "Find a place or address";
 
-/* No comment provided by engineer. */
+/* A label referring to a fractional distance along an edge style utility network element. */
 "Fraction Along Edge" = "Fraction Along Edge";
 
-/* No comment provided by engineer. */
+/* A label referring to function outputs returned as results of a utility network
+ trace operation. */
 "Function Results" = "Function Results";
 
-/* No comment provided by engineer. */
+/* A label referring to media elements contained within a popup. */
 "Media" = "Media";
 
 /* The mode in which the utility network trace tool is being used (either creating traces or viewing traces). */
 "Mode" = "Mode";
 
-/* No comment provided by engineer. */
+/* A label referring to a user defined name given for an individual utility network trace. */
 "Name" = "Name";
 
 /* A label in reference to a specific utility network. */
 "Network" = "Network";
 
-/* No comment provided by engineer. */
+/* A label for a button to show new utility network trace configuration options. */
 "New trace" = "New trace";
 
-/* No comment provided by engineer. */
+/* A label indicating that no bookmarks are available for selection. */
 "No bookmarks" = "No bookmarks";
 
 /* A statement that no utility trace configurations are available. */
@@ -154,13 +155,13 @@ network certificate. */
 /* A message to show when there are no results or suggestions. */
 "No results found" = "No results found";
 
-/* No comment provided by engineer. */
+/* A label indicating that no utility named trace configurations are available. */
 "No trace types found." = "No trace types found.";
 
-/* No comment provided by engineer. */
+/* A label indicating that no utility networks are available. */
 "No utility networks found." = "No utility networks found.";
 
-/* No comment provided by engineer. */
+/* "A label indicating that no utility network trace configuration has been selected." */
 "None selected" = "None selected";
 
 /* A trace function output result was not provided. */
@@ -169,22 +170,24 @@ network certificate. */
 /* A string identifying a utility network object. */
 "Object ID: %@" = "Object ID: %@";
 
-/* No comment provided by engineer. */
+/* A label for button to proceed with an operation. */
 "OK" = "OK";
 
-/* No comment provided by engineer. */
+/* A label referring to a credential password. */
 "Password" = "Password";
 
-/* No comment provided by engineer. */
+/* A label indicating that a password is required to proceed with an operation. */
 "Password Required" = "Password Required";
 
-/* No comment provided by engineer. */
+/* A label requesting the password associated with the chosen certificate. */
 "Please enter a password for the chosen certificate." = "Please enter a password for the chosen certificate.";
 
-/* No comment provided by engineer. */
+/* A label indicating that at least one starting location is required for the
+ chosen utility network trace configuration. */
 "Please set at least 1 starting location." = "Please set at least 1 starting location.";
 
-/* No comment provided by engineer. */
+/* A label indicating that at least two starting locations are required for the
+ chosen utility network trace configuration. */
 "Please set at least 2 starting locations." = "Please set at least 2 starting locations.";
 
 /* An error message shown when a popup cannot be displayed. The

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -50,11 +50,8 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A label indicating that the remote host's certificate is not trusted. */
 "Certificate Trust Warning" = "Certificate Trust Warning";
 
-/* No comment provided by engineer. */
-"Clear All Results" = "Clear All Results";
-
-/* No comment provided by engineer. */
-"Clear all results?" = "Clear all results?";
+/* A directive to clear all of the completed utility network traces. */
+"Clear all results" = "Clear all results";
 
 /* No comment provided by engineer. */
 "Color" = "Color";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -41,10 +41,10 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A label for a button to cancel an operation. */
 "Cancel" = "Cancel";
 
-/* No comment provided by engineer. */
+/* A label for a button to cancel the starting point selection operation. */
 "Cancel starting point selection" = "Cancel starting point selection";
 
-/* No comment provided by engineer. */
+/* A label indicating that a certificate is required to proceed. */
 "Certificate Required" = "Certificate Required";
 
 /* A label indicating that the remote host's certificate is not trusted. */
@@ -53,7 +53,7 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A directive to clear all of the completed utility network traces. */
 "Clear all results" = "Clear all results";
 
-/* No comment provided by engineer. */
+/* A label in reference to the color used to display utility trace result graphics. */
 "Color" = "Color";
 
 /* An compass description to be read by a screen reader describing the
@@ -62,7 +62,7 @@ second being a corresponding cardinal direction (north, northeast,
 east, etc.). */
 "Compass, heading %lld degrees %@" = "Compass, heading %lld degrees %@";
 
-/* No comment provided by engineer. */
+/* A label for a button used to continue the authentication operation. */
 "Continue" = "Continue";
 
 /* No comment provided by engineer. */
@@ -71,7 +71,7 @@ east, etc.). */
 /* A warning that the host service (challenge.host) is providing a potentially unsafe certificate. */
 "Dangerous: The certificate provided by '%@' is not signed by a trusted authority." = "Dangerous: The certificate provided by '%@' is not signed by a trusted authority.";
 
-/* No comment provided by engineer. */
+/* A label for a button used to delete a utility network trace input component or result. */
 "Delete" = "Delete";
 
 /* A button to close the bookmark selection menu. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -140,7 +140,7 @@ east, etc.). */
 /* No comment provided by engineer. */
 "No bookmarks" = "No bookmarks";
 
-/* No comment provided by engineer. */
+/* A statement that no utility trace configurations are available. */
 "No configurations available" = "No configurations available";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -186,8 +186,9 @@ east, etc.). */
 variable provides additional data. */
 "Popup evaluation failed: %@" = "Popup evaluation failed: %@";
 
-/* A button to show when a user has panned the map away from the
-original search location. */
+/* A label for button to show when a user has panned the map away
+ from the original search location. 'Here' is in reference to the
+ current visible extent of the map or scene. */
 "Repeat Search Here" = "Repeat Search Here";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -242,7 +242,7 @@ load for an unknown reason. */
 "The password was invalid." = "The password was invalid.";
 
 /* Description of error thrown when a remote image could not be loaded. */
-"The URL could not be reached or did not contain image data" = "The URL could not be reached or did not contain image data";
+"The URL could not be reached or did not contain image data." = "The URL could not be reached or did not contain image data.";
 
 /* No comment provided by engineer. */
 "Trace" = "Trace";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -102,7 +102,7 @@ network certificate. */
  to be used as a trace starting point. */
 "Failed to set starting point" = "Failed to set starting point";
 
-/* A label referring to utility elements returned as results of a utility network
+/* A label in reference to utility elements returned as results of a utility network
  trace operation. */
 "Feature Results" = "Feature Results";
 
@@ -112,29 +112,31 @@ network certificate. */
 /* A label in reference to fields contained in a chart of data. */
 "Fields" = "Fields";
 
-/* A field allowing a user to filter a list of facilities by name. A facility contains one or more levels in a floor-aware map or scene. */
+/* A field allowing the user to filter a list of facilities by name. A
+ facility contains one or more levels in a floor-aware map or scene. */
 "Filter facilities" = "Filter facilities";
 
-/* A field allowing a user to filter a list of sites by name. A site contains one or more facilities in a floor-aware map or scene. */
+/* A field allowing the user to filter a list of sites by name. A site
+ contains one or more facilities in a floor-aware map or scene. */
 "Filter sites" = "Filter sites";
 
-/* A hint as to what a user can search for within a search bar. */
+/* A hint as to what the user can search for within a search bar. */
 "Find a place or address" = "Find a place or address";
 
-/* A label referring to a fractional distance along an edge style utility network element. */
+/* A label in reference to a fractional distance along an edge style utility network element. */
 "Fraction Along Edge" = "Fraction Along Edge";
 
-/* A label referring to function outputs returned as results of a utility network
+/* A label in reference to function outputs returned as results of a utility network
  trace operation. */
 "Function Results" = "Function Results";
 
-/* A label referring to media elements contained within a popup. */
+/* A label in reference to media elements contained within a popup. */
 "Media" = "Media";
 
 /* The mode in which the utility network trace tool is being used (either creating traces or viewing traces). */
 "Mode" = "Mode";
 
-/* A label referring to a user defined name given for an individual utility network trace. */
+/* A label in reference to the user defined name for an individual utility network trace. */
 "Name" = "Name";
 
 /* A label in reference to a specific utility network. */
@@ -173,7 +175,7 @@ network certificate. */
 /* A label for button to proceed with an operation. */
 "OK" = "OK";
 
-/* A label referring to a credential password. */
+/* A label in reference to a credential password. */
 "Password" = "Password";
 
 /* A label indicating that a password is required to proceed with an operation. */
@@ -194,7 +196,7 @@ network certificate. */
 variable provides additional data. */
 "Popup evaluation failed: %@" = "Popup evaluation failed: %@";
 
-/* A label for button to show when a user has panned the map away
+/* A label for button to show when the user has panned the map away
  from the original search location. 'Here' is in reference to the
  current visible extent of the map or scene. */
 "Repeat Search Here" = "Repeat Search Here";
@@ -208,7 +210,7 @@ variable provides additional data. */
 /* A label prompting the user to make a selection from the available bookmarks. */
 "Select a bookmark" = "Select a bookmark";
 
-/* A label directing a user to select a facility. A facility contains one
+/* A label directing the user to select a facility. A facility contains one
  or more levels in a floor-aware map or scene. */
 "Select a facility" = "Select a facility";
 
@@ -219,7 +221,7 @@ variable provides additional data. */
  match the spatial reference of the geo model. */
 "Spatial reference mismatch." = "Spatial reference mismatch.";
 
-/* A label referring to the utility elements chosen as starting points for a utility
+/* A label in reference to the utility elements chosen as starting points for a utility
  network trace operation. */
 "Starting Points" = "Starting Points";
 
@@ -271,7 +273,7 @@ load for an unknown reason. */
 /* A label to use in place of a utility element asset type name. */
 "Unnamed Asset Type" = "Unnamed Asset Type";
 
-/* A label referring to a credential username. */
+/* A label in reference to a credential username. */
 "Username" = "Username";
 
 /* A value in a set of data contained in a popup. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -252,7 +252,7 @@ load for an unknown reason. */
 "Trace" = "Trace";
 
 /* A label indicating the index of the trace being viewed out of the total number of traces completed. */
-"Trace %lld of %lld" = "Trace %lld of %lld";
+"Trace %lld1 of %lld2" = "Trace %lld1 of %lld2";
 
 /* No comment provided by engineer. */
 "Trace Configuration" = "Trace Configuration";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -20,7 +20,7 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A button indicating the user accepts a potentially dangerous action. */
 "Allow" = "Allow";
 
-/* No comment provided by engineer. */
+/* A fallback message to display when an image cannot be loaded. */
 "An error occurred loading the image: %@." = "An error occurred loading the image: %@.";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -252,7 +252,7 @@ load for an unknown reason. */
 "Trace" = "Trace";
 
 /* A label indicating the index of the trace being viewed out of the total number of traces completed. */
-"Trace %lld1 of %lld2" = "Trace %lld1 of %lld2";
+"Trace %lld of %lld" = "Trace %lld of %lld";
 
 /* No comment provided by engineer. */
 "Trace Configuration" = "Trace Configuration";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -65,7 +65,7 @@ east, etc.). */
 /* A label for a button used to continue the authentication operation. */
 "Continue" = "Continue";
 
-/* No comment provided by engineer. */
+/* A label indicating a certificate file was inaccessible. */
 "Could not access the certificate file." = "Could not access the certificate file.";
 
 /* A warning that the host service (challenge.host) is providing a potentially unsafe certificate. */
@@ -80,10 +80,11 @@ east, etc.). */
 /* No comment provided by engineer. */
 "Duplicate starting points cannot be added." = "Duplicate starting points cannot be added.";
 
-/* No comment provided by engineer. */
+/* A label indicating an element could not be identified as a starting point
+ for a utility network trace. */
 "Element could not be identified." = "Element could not be identified.";
 
-/* No comment provided by engineer. */
+/* A label in reference to an error that occurred during a utility network trace. */
 "Error" = "Error";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -246,7 +246,7 @@ load for an unknown reason. */
 "Trace" = "Trace";
 
 /* A label indicating the index of the trace being viewed out of the total number of traces completed. */
-"Trace %lld1 of %lld2" = "Trace %lld1 of %lld2";
+"Trace %1$lld of %2$lld" = "Trace %1$lld of %2$lld";
 
 /* No comment provided by engineer. */
 "Trace Configuration" = "Trace Configuration";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -143,7 +143,7 @@ east, etc.). */
 /* A statement that no utility trace configurations are available. */
 "No configurations available" = "No configurations available";
 
-/* No comment provided by engineer. */
+/* A statement that no sites or facilities with names matching a filter phrase were found. */
 "No matches found" = "No matches found";
 
 /* A message to show when there are no results or suggestions. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -244,7 +244,7 @@ load for an unknown reason. */
 /* Description of error thrown when a remote image could not be loaded. */
 "The URL could not be reached or did not contain image data." = "The URL could not be reached or did not contain image data.";
 
-/* No comment provided by engineer. */
+/* A label for a button to begin a utility network trace operation. */
 "Trace" = "Trace";
 
 /* A label indicating the index of the trace being viewed out of the total number of traces completed. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -262,7 +262,7 @@ load for an unknown reason. */
 /* No comment provided by engineer. */
 "Username" = "Username";
 
-/* No comment provided by engineer. */
+/* A value in a set of data contained in a popup. */
 "Value" = "Value";
 
 /* A label explaining that credentials are required to authenticate with specified host.

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -158,7 +158,7 @@ east, etc.). */
 /* No comment provided by engineer. */
 "None selected" = "None selected";
 
-/* A trace function output result is not available. */
+/* A trace function output result was not provided. */
 "Not Available" = "Not Available";
 
 /* A string identifying a utility network object. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -78,11 +78,11 @@ east, etc.). */
 "Done" = "Done";
 
 /* A message indicating that the user attempted to use a single utility
- network element for more than one trace starting point. */
+network element for more than one trace starting point. */
 "Duplicate starting points cannot be added." = "Duplicate starting points cannot be added.";
 
 /* A label indicating an element could not be identified as a starting point
- for a utility network trace. */
+for a utility network trace. */
 "Element could not be identified." = "Element could not be identified.";
 
 /* A label in reference to an error that occurred during a utility network trace. */
@@ -95,39 +95,39 @@ network certificate. */
 /* An error to be displayed when a basemap chosen from the basemap gallery fails to load. */
 "Error loading basemap." = "Error loading basemap.";
 
-/* A label indicating popup expressions are evaluating. */
+/* A label indicating popup expressions are being evaluated. */
 "Evaluating popup expressions" = "Evaluating popup expressions";
 
 /* A message indicating that the chosen utility network element wasn't able
- to be used as a trace starting point. */
+to be used as a trace starting point. */
 "Failed to set starting point" = "Failed to set starting point";
 
 /* A label in reference to utility elements returned as results of a utility network
- trace operation. */
+trace operation. */
 "Feature Results" = "Feature Results";
 
-/* A field in a chart of data contained in a popup. */
+/* A field in a set of data contained in a popup. */
 "Field" = "Field";
 
-/* A label in reference to fields contained in a chart of data. */
+/* A label in reference to fields in a set of data contained in a popup. */
 "Fields" = "Fields";
 
 /* A field allowing the user to filter a list of facilities by name. A
- facility contains one or more levels in a floor-aware map or scene. */
+facility contains one or more levels in a floor-aware map or scene. */
 "Filter facilities" = "Filter facilities";
 
 /* A field allowing the user to filter a list of sites by name. A site
- contains one or more facilities in a floor-aware map or scene. */
+contains one or more facilities in a floor-aware map or scene. */
 "Filter sites" = "Filter sites";
 
-/* A hint as to what the user can search for within a search bar. */
+/* A hint for the user on what to search for in a search bar. */
 "Find a place or address" = "Find a place or address";
 
 /* A label in reference to a fractional distance along an edge style utility network element. */
 "Fraction Along Edge" = "Fraction Along Edge";
 
 /* A label in reference to function outputs returned as results of a utility network
- trace operation. */
+trace operation. */
 "Function Results" = "Function Results";
 
 /* A label in reference to media elements contained within a popup. */
@@ -149,10 +149,10 @@ network certificate. */
 "No bookmarks" = "No bookmarks";
 
 /* A statement that no utility trace configurations are available. */
-"No configurations available" = "No configurations available";
+"No configurations available." = "No configurations available.";
 
 /* A statement that no sites or facilities with names matching a filter phrase were found. */
-"No matches found" = "No matches found";
+"No matches found." = "No matches found.";
 
 /* A message to show when there are no results or suggestions. */
 "No results found" = "No results found";
@@ -163,7 +163,7 @@ network certificate. */
 /* A label indicating that no utility networks are available. */
 "No utility networks found." = "No utility networks found.";
 
-/* "A label indicating that no utility network trace configuration has been selected." */
+/* A label indicating that no utility network trace configuration has been selected. */
 "None selected" = "None selected";
 
 /* A trace function output result was not provided. */
@@ -185,11 +185,11 @@ network certificate. */
 "Please enter a password for the chosen certificate." = "Please enter a password for the chosen certificate.";
 
 /* A label indicating that at least one starting location is required for the
- chosen utility network trace configuration. */
+chosen utility network trace configuration. */
 "Please set at least 1 starting location." = "Please set at least 1 starting location.";
 
 /* A label indicating that at least two starting locations are required for the
- chosen utility network trace configuration. */
+chosen utility network trace configuration. */
 "Please set at least 2 starting locations." = "Please set at least 2 starting locations.";
 
 /* An error message shown when a popup cannot be displayed. The
@@ -197,9 +197,9 @@ variable provides additional data. */
 "Popup evaluation failed: %@" = "Popup evaluation failed: %@";
 
 /* A label for button to show when the user has panned the map away
- from the original search location. 'Here' is in reference to the
- current visible extent of the map or scene. */
-"Repeat Search Here" = "Repeat Search Here";
+from the original search location. 'here' is in reference to the
+current visible extent of the map or scene. */
+"Repeat search here" = "Repeat search here";
 
 /* A label for a button to show utility network trace results. */
 "Results" = "Results";
@@ -211,26 +211,29 @@ variable provides additional data. */
 "Select a bookmark" = "Select a bookmark";
 
 /* A label directing the user to select a facility. A facility contains one
- or more levels in a floor-aware map or scene. */
+or more levels in a floor-aware map or scene. */
 "Select a facility" = "Select a facility";
 
 /* A label in reference to all of the sites in a floor-aware map or scene. */
 "Sites" = "Sites";
 
 /* A label indicating the spatial reference of the chosen basemap doesn't
- match the spatial reference of the map or scene. */
+match the spatial reference of the map or scene. */
 "Spatial reference mismatch." = "Spatial reference mismatch.";
 
 /* A label in reference to the utility elements chosen as starting points for a utility
- network trace operation. */
+network trace operation. */
 "Starting Points" = "Starting Points";
 
 /* A label indicating that tapping an image will reveal
- additional information. */
+additional information. */
 "Tap on the image for more information." = "Tap on the image for more information.";
 
 /* A label in reference to the chosen terminal configuration of a utility network element. */
 "Terminal Configuration" = "Terminal Configuration";
+
+/* A label for development purposes only. This is not user visible. */
+"test" = "test";
 
 /* A label indicating the chosen basemap doesn't have a spatial reference. */
 "The basemap does not have a spatial reference." = "The basemap does not have a spatial reference.";
@@ -240,7 +243,7 @@ load for an unknown reason. */
 "The basemap failed to load for an unknown reason." = "The basemap failed to load for an unknown reason.";
 
 /* A label indicating the spatial reference of the chosen basemap doesn't
- match the spatial reference of the map. */
+match the spatial reference of the map. */
 "The basemap has a spatial reference that is incompatible with the map." = "The basemap has a spatial reference that is incompatible with the map.";
 
 /* A label indicating the chosen file or given password was invalid. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -199,13 +199,13 @@ variable provides additional data. */
  current visible extent of the map or scene. */
 "Repeat Search Here" = "Repeat Search Here";
 
-/* No comment provided by engineer. */
+/* A label for a button to show utility network trace results. */
 "Results" = "Results";
 
-/* No comment provided by engineer. */
+/* A label in reference to a search query entered by the user. */
 "Search Query" = "Search Query";
 
-/* No comment provided by engineer. */
+/* A label prompting the user to make a selection from the available bookmarks. */
 "Select a bookmark" = "Select a bookmark";
 
 /* A label directing a user to select a facility. A facility contains one
@@ -215,38 +215,42 @@ variable provides additional data. */
 /* A label in reference to all of the sites in a floor-aware map or scene. */
 "Sites" = "Sites";
 
-/* No comment provided by engineer. */
+/* A label indicating the spatial reference of the chosen basemap doesn't
+ match the spatial reference of the geo model. */
 "Spatial reference mismatch." = "Spatial reference mismatch.";
 
-/* No comment provided by engineer. */
+/* A label referring to the utility elements chosen as starting points for a utility
+ network trace operation. */
 "Starting Points" = "Starting Points";
 
-/* No comment provided by engineer. */
+/* A label indicating that tapping an image will reveal
+ additional information. */
 "Tap on the image for more information." = "Tap on the image for more information.";
 
-/* No comment provided by engineer. */
+/* A label in reference to the chosen terminal configuration of a utility network element. */
 "Terminal Configuration" = "Terminal Configuration";
 
-/* No comment provided by engineer. */
+/* A label indicating the chosen basemap doesn't have a spatial reference. */
 "The basemap does not have a spatial reference." = "The basemap does not have a spatial reference.";
 
 /* An error to be displayed when a basemap chosen from the basemap gallery fails to
 load for an unknown reason. */
 "The basemap failed to load for an unknown reason." = "The basemap failed to load for an unknown reason.";
 
-/* No comment provided by engineer. */
+/* A label indicating the spatial reference of the chosen basemap doesn't
+ match the spatial reference of the geo model. */
 "The basemap has a spatial reference that is incompatible with the map." = "The basemap has a spatial reference that is incompatible with the map.";
 
-/* No comment provided by engineer. */
+/* A label indicating the chosen file or given password was invalid. */
 "The certificate file or password was invalid." = "The certificate file or password was invalid.";
 
-/* No comment provided by engineer. */
+/* A label indicating the chosen file was invalid. */
 "The certificate file was invalid." = "The certificate file was invalid.";
 
-/* No comment provided by engineer. */
+/* A label indicating the map doesn't have a spatial reference. */
 "The map does not have a spatial reference." = "The map does not have a spatial reference.";
 
-/* No comment provided by engineer. */
+/* A label indicating the given password was invalid. */
 "The password was invalid." = "The password was invalid.";
 
 /* Description of error thrown when a remote image could not be loaded. */
@@ -258,16 +262,16 @@ load for an unknown reason. */
 /* A label indicating the index of the trace being viewed out of the total number of traces completed. */
 "Trace %1$lld of %2$lld" = "Trace %1$lld of %2$lld";
 
-/* No comment provided by engineer. */
+/* A label in reference to a utility network trace configuration. */
 "Trace Configuration" = "Trace Configuration";
 
-/* No comment provided by engineer. */
+/* A label for a button allowing the user to retry an operation. */
 "Try Again" = "Try Again";
 
 /* A label to use in place of a utility element asset type name. */
 "Unnamed Asset Type" = "Unnamed Asset Type";
 
-/* No comment provided by engineer. */
+/* A label referring to a credential username. */
 "Username" = "Username";
 
 /* A value in a set of data contained in a popup. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -107,7 +107,7 @@ east, etc.). */
 /* A label in reference to fields contained in a chart of data. */
 "Fields" = "Fields";
 
-/* A search field allowing user to filter a list of facilities by name. */
+/* A field allowing a user to filter a list of facilities by name. A facility contains one or more levels in a floor-aware map or scene. */
 "Filter facilities" = "Filter facilities";
 
 /* A field allowing a user to filter a list of sites by name. A site contains one or more facilities in a floor-aware map or scene. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -32,7 +32,7 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A label indicating authentication is required to proceed. */
 "Authentication Required" = "Authentication Required";
 
-/* A label in reference to bookmarks contained in a geo model. */
+/* A label in reference to bookmarks contained in a map or scene. */
 "Bookmarks" = "Bookmarks";
 
 /* A label for a button to open the system file browser. */
@@ -218,7 +218,7 @@ variable provides additional data. */
 "Sites" = "Sites";
 
 /* A label indicating the spatial reference of the chosen basemap doesn't
- match the spatial reference of the geo model. */
+ match the spatial reference of the map or scene. */
 "Spatial reference mismatch." = "Spatial reference mismatch.";
 
 /* A label in reference to the utility elements chosen as starting points for a utility
@@ -240,7 +240,7 @@ load for an unknown reason. */
 "The basemap failed to load for an unknown reason." = "The basemap failed to load for an unknown reason.";
 
 /* A label indicating the spatial reference of the chosen basemap doesn't
- match the spatial reference of the geo model. */
+ match the spatial reference of the map. */
 "The basemap has a spatial reference that is incompatible with the map." = "The basemap has a spatial reference that is incompatible with the map.";
 
 /* A label indicating the chosen file or given password was invalid. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -92,8 +92,8 @@ east, etc.). */
 /* An error to be displayed when a basemap chosen from the basemap gallery fails to load. */
 "Error loading basemap." = "Error loading basemap.";
 
-/* No comment provided by engineer. */
-"Evaluating popup expressions…" = "Evaluating popup expressions…";
+/* A label indicating popup expressions are evaluating. */
+"Evaluating popup expressions" = "Evaluating popup expressions";
 
 /* No comment provided by engineer. */
 "Failed to set starting point" = "Failed to set starting point";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -131,7 +131,7 @@ east, etc.). */
 /* No comment provided by engineer. */
 "Name" = "Name";
 
-/* No comment provided by engineer. */
+/* A label in reference to a specific utility network. */
 "Network" = "Network";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -23,22 +23,22 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A fallback message to display when an image cannot be loaded. */
 "An error occurred loading the image: %@." = "An error occurred loading the image: %@.";
 
-/* No comment provided by engineer. */
+/* A label in reference to attachments in a popup. */
 "Attachments" = "Attachments";
 
-/* No comment provided by engineer. */
+/* A label in reference to the attributes of a geo element. */
 "Attributes" = "Attributes";
 
-/* No comment provided by engineer. */
+/* A label indicating authentication is required to proceed. */
 "Authentication Required" = "Authentication Required";
 
-/* No comment provided by engineer. */
+/* A label in reference to bookmarks contained in a geo model. */
 "Bookmarks" = "Bookmarks";
 
-/* No comment provided by engineer. */
+/* A label for a button to open the system file browser. */
 "Browse For Certificate" = "Browse For Certificate";
 
-/* No comment provided by engineer. */
+/* A label for a button to cancel an operation. */
 "Cancel" = "Cancel";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -101,7 +101,7 @@ east, etc.). */
 /* No comment provided by engineer. */
 "Feature Results" = "Feature Results";
 
-/* No comment provided by engineer. */
+/* A field in a chart of data contained in a popup. */
 "Field" = "Field";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -11,11 +11,8 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A section header for advanced options. */
 "Advanced Options" = "Advanced Options";
 
-/* A button allowing users to view a list of all sites defined in a floor aware map. */
+/* A reference to all of the sites defined in a floor aware map. */
 "All sites" = "All sites";
-
-/* No comment provided by engineer. */
-"All Sites" = "All Sites";
 
 /* A message describing the outcome of clearing all utility network trace results. */
 "All the trace inputs and results will be lost." = "All the trace inputs and results will be lost.";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -125,7 +125,7 @@ east, etc.). */
 /* No comment provided by engineer. */
 "Media" = "Media";
 
-/* No comment provided by engineer. */
+/* The mode in which the utility network trace tool is being used (either creating traces or viewing traces). */
 "Mode" = "Mode";
 
 /* No comment provided by engineer. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -77,7 +77,8 @@ east, etc.). */
 /* A button to close the bookmark selection menu. */
 "Done" = "Done";
 
-/* No comment provided by engineer. */
+/* A message indicating that the user attempted to use a single utility
+ network element for more than one trace starting point. */
 "Duplicate starting points cannot be added." = "Duplicate starting points cannot be added.";
 
 /* A label indicating an element could not be identified as a starting point
@@ -87,7 +88,8 @@ east, etc.). */
 /* A label in reference to an error that occurred during a utility network trace. */
 "Error" = "Error";
 
-/* No comment provided by engineer. */
+/* A message indicating that some error occurred while importing a chosen
+network certificate. */
 "Error importing certificate" = "Error importing certificate";
 
 /* An error to be displayed when a basemap chosen from the basemap gallery fails to load. */
@@ -96,10 +98,12 @@ east, etc.). */
 /* A label indicating popup expressions are evaluating. */
 "Evaluating popup expressions" = "Evaluating popup expressions";
 
-/* No comment provided by engineer. */
+/* A message indicating that the chosen utility network element wasn't able
+ to be used as a trace starting point. */
 "Failed to set starting point" = "Failed to set starting point";
 
-/* No comment provided by engineer. */
+/* A label referring to utility elements returned as results of a utility network
+ trace operation. */
 "Feature Results" = "Feature Results";
 
 /* A field in a chart of data contained in a popup. */

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -190,7 +190,8 @@ struct CredentialInputSheetView: View {
         SecureField(
             String(
                 localized: "Password",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: "A label referring to a credential password."
             ),
             text: $password
         )

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -173,7 +173,7 @@ struct CredentialInputSheetView: View {
             String(
                 localized: "Username",
                 bundle: .toolkitModule,
-                comment: "A label referring to a credential username."
+                comment: "A label in reference to a credential username."
             ),
             text: $username
         )
@@ -192,7 +192,7 @@ struct CredentialInputSheetView: View {
             String(
                 localized: "Password",
                 bundle: .toolkitModule,
-                comment: "A label referring to a credential password."
+                comment: "A label in reference to a credential password."
             ),
             text: $password
         )

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -46,23 +46,27 @@ extension View {
 
 struct CredentialInputSheetView_Previews: PreviewProvider {
     static var previews: some View {
-        Text("test")
-            .credentialInput(
-                isPresented: .constant(true),
-                fields: .usernamePassword,
-                message: "You must sign in to access 'arcgis.com'",
-                title: "Authentication Required",
-                cancelAction: .init(
-                    title: "Cancel",
-                    handler: { _, _ in
-                    }
-                ),
-                continueAction: .init(
-                    title: "Continue",
-                    handler: { username, password in
-                    }
-                )
+        Text(
+            "test",
+            bundle: .toolkitModule,
+            comment: "A label for development purposes only. This is not user visible."
+        )
+        .credentialInput(
+            isPresented: .constant(true),
+            fields: .usernamePassword,
+            message: "You must sign in to access 'arcgis.com'",
+            title: "Authentication Required",
+            cancelAction: .init(
+                title: "Cancel",
+                handler: { _, _ in
+                }
+            ),
+            continueAction: .init(
+                title: "Continue",
+                handler: { username, password in
+                }
             )
+        )
     }
 }
 

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -172,7 +172,8 @@ struct CredentialInputSheetView: View {
         TextField(
             String(
                 localized: "Username",
-                bundle: .toolkitModule
+                bundle: .toolkitModule,
+                comment: "A label referring to a credential username."
             ),
             text: $username
         )

--- a/Sources/ArcGISToolkit/Utility/SearchField.swift
+++ b/Sources/ArcGISToolkit/Utility/SearchField.swift
@@ -60,10 +60,15 @@ public struct SearchField: View {
             
             // Search text field
             TextField(
-                "Search Query",
                 text: query,
                 prompt: Text(prompt)
-            )
+            ) {
+                Text(
+                    "Search Query",
+                    bundle: .toolkitModule,
+                    comment: "A label in reference to a search query entered by the user."
+                )
+            }
             .focused(isFocused)
             
             // Delete text button


### PR DESCRIPTION
Related Apollo 119

- Adds comments for the remaining localized string keys missing "engineer comments" resolving ambiguites highlighted by the translations team.

cc @dg0yal 