### PR TITLE
`FormView` - Switch to `FieldFormElement.value` from feature attributes + other minor fixes

### DIFF
--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -63,11 +63,11 @@ struct DateTimeEntry: View {
             if element.value.isEmpty {
                 date = nil
             } else {
-                date = DateFormatter.arcGISDateFormatter.date(from: element.value)
+                date = try? Date(element.value, strategy: Date.ParseStrategy.arcGISDateParseStrategy)
             }
         }
         .onChange(of: date) { newDate in
-            guard let currentDate = DateFormatter.arcGISDateFormatter.date(from: element.value),
+            guard let currentDate = try? Date(element.value, strategy: Date.ParseStrategy.arcGISDateParseStrategy),
                   newDate != currentDate else {
                 return
             }
@@ -208,12 +208,14 @@ struct DateTimeEntry: View {
     }
 }
 
-private extension DateFormatter {
-    static let arcGISDateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        return dateFormatter
-    }()
+private extension Date.ParseStrategy {
+    /// A parse strategy for date/time strings with a yyyy-MM-dd'T'HH:mm:ss format.
+    static var arcGISDateParseStrategy: Self {
+        .fixed(
+            format: "\(year: .defaultDigits)-\(month: .defaultDigits)-\(day: .defaultDigits)T\(hour: .defaultDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .defaultDigits):\(second: .defaultDigits)",
+            timeZone: .current
+        )
+    }
 }
 
 private extension String {

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -60,9 +60,9 @@ struct DateTimeEntry: View {
         }
         .padding([.bottom], elementPadding)
         .onAppear {
-            if let date = featureForm?.feature.attributes[element.fieldName] as? Date {
-                self.date = date
-            }
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            self.date = dateFormatter.date(from: element.value)
         }
         .onChange(of: date) { newDate in
             //TODO: add `required` property to API

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -60,7 +60,11 @@ struct DateTimeEntry: View {
         }
         .padding([.bottom], elementPadding)
         .onAppear {
-            self.date = DateFormatter.arcGISDateFormatter.date(from: element.value)
+            if element.value.isEmpty {
+                date = nil
+            } else {
+                date = DateFormatter.arcGISDateFormatter.date(from: element.value)
+            }
         }
         .onChange(of: date) { newDate in
             //TODO: add `required` property to API

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -67,7 +67,7 @@ struct DateTimeEntry: View {
             }
         }
         .onChange(of: date) { newDate in
-            guard let currentDate = try? Date(element.value, strategy: Date.ParseStrategy.arcGISDateParseStrategy),
+            guard let currentDate = try? Date(element.value, strategy: .arcGISDateParseStrategy),
                   newDate != currentDate else {
                 return
             }

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -63,7 +63,7 @@ struct DateTimeEntry: View {
             if element.value.isEmpty {
                 date = nil
             } else {
-                date = try? Date(element.value, strategy: Date.ParseStrategy.arcGISDateParseStrategy)
+                date = try? Date(element.value, strategy: .arcGISDateParseStrategy)
             }
         }
         .onChange(of: date) { newDate in

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -60,9 +60,7 @@ struct DateTimeEntry: View {
         }
         .padding([.bottom], elementPadding)
         .onAppear {
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            self.date = dateFormatter.date(from: element.value)
+            self.date = DateFormatter.arcGISDateFormatter.date(from: element.value)
         }
         .onChange(of: date) { newDate in
             //TODO: add `required` property to API
@@ -202,6 +200,13 @@ struct DateTimeEntry: View {
     }
 }
 
+private extension DateFormatter {
+    static let arcGISDateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        return dateFormatter
+    }()
+}
 
 private extension String {
     /// A string indicating that no date or time has been set for a date/time field.

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -67,6 +67,10 @@ struct DateTimeEntry: View {
             }
         }
         .onChange(of: date) { newDate in
+            guard let currentDate = DateFormatter.arcGISDateFormatter.date(from: element.value),
+                  newDate != currentDate else {
+                return
+            }
             //TODO: add `required` property to API
             requiredValueMissing = /*element.required && */newDate == nil
             featureForm?.feature.setAttributeValue(newDate, forKey: element.fieldName)

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/DateTimeEntry.swift
@@ -208,7 +208,7 @@ struct DateTimeEntry: View {
     }
 }
 
-private extension Date.ParseStrategy {
+private extension ParseStrategy where Self == Date.ParseStrategy {
     /// A parse strategy for date/time strings with a yyyy-MM-dd'T'HH:mm:ss format.
     static var arcGISDateParseStrategy: Self {
         .fixed(

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
@@ -106,6 +106,9 @@ struct MultiLineTextEntry: View {
         }
         .onChange(of: text) { newValue in
             if !isPlaceholder {
+                guard newValue != element.value else {
+                    return
+                }
                 featureForm?.feature.setAttributeValue(newValue, forKey: element.fieldName)
             }
         }

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/MultiLineTextEntry.swift
@@ -95,11 +95,10 @@ struct MultiLineTextEntry: View {
         )
         .padding([.bottom], elementPadding)
         .onAppear {
-            let text = featureForm?.feature.attributes[element.fieldName] as? String
-            if let text, !text.isEmpty {
+            let text = element.value
+            if !text.isEmpty {
                 isPlaceholder = false
                 self.text = text
-                
             } else {
                 isPlaceholder = true
                 self.text = element.hint

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
@@ -79,6 +79,9 @@ struct SingleLineTextEntry: View {
             }
         }
         .onChange(of: text) { newValue in
+            guard newValue != element.value else {
+                return
+            }
             featureForm?.feature.setAttributeValue(newValue, forKey: element.fieldName)
         }
     }

--- a/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormInputs/SingleLineTextEntry.swift
@@ -54,7 +54,7 @@ struct SingleLineTextEntry: View {
             .padding([.top], elementPadding)
         // Secondary foreground color is used across entry views for consistency.
         HStack {
-            TextField(element.label, text: $text, prompt: Text(element.hint ?? "").foregroundColor(.secondary))
+            TextField(element.label, text: $text, prompt: Text(element.hint).foregroundColor(.secondary))
                 .focused($isFocused)
                 .accessibilityIdentifier("\(element.label) Text Field")
             if !text.isEmpty {
@@ -71,7 +71,7 @@ struct SingleLineTextEntry: View {
         )
         .padding([.bottom], elementPadding)
         .onAppear {
-            text = featureForm?.feature.attributes[element.fieldName] as? String ?? ""
+            text = element.value
         }
         .onChange(of: isFocused) { newFocus in
             if newFocus {

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -549,7 +549,7 @@ final class FormViewTests: XCTestCase {
         
         julyFirstButton.tap()
         
-        let localDate = try? Date("1969-07-01T07:00:00", strategy: .arcGISDateParseStrategy)
+        let localDate = try? Date("1969-07-01T00:00:00", strategy: .arcGISDateParseStrategy)
         
         XCTAssertEqual(
             fieldValue.label,

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -306,7 +306,7 @@ final class FormViewTests: XCTestCase {
         
         XCTAssertEqual(
             footer.label,
-            "Required"
+            "Date Entry is Required"
         )
         
         XCTAssertTrue(

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -367,8 +367,8 @@ final class FormViewTests: XCTestCase {
         )
         
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        let localDate = formatter.date(from: "1969-07-07T20:17:00.000Z")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        let localDate = formatter.date(from: "1969-07-07T20:17:00")
         
         XCTAssertEqual(
             fieldValue.label,

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -366,9 +366,10 @@ final class FormViewTests: XCTestCase {
             "The field title isn't hittable."
         )
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        let localDate = formatter.date(from: "1969-07-07T20:17:00")
+        let localDate = try? Date(
+            "1969-07-07T20:17:00",
+            strategy: Date.ParseStrategy.arcGISDateParseStrategy
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -441,9 +442,10 @@ final class FormViewTests: XCTestCase {
             "The field value isn't hittable."
         )
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        let localDate = formatter.date(from: "2023-07-14")
+        let localDate = try? Date(
+            "2023-07-14T08:53:00",
+            strategy: Date.ParseStrategy.arcGISDateParseStrategy
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -502,9 +504,10 @@ final class FormViewTests: XCTestCase {
             "End date and Time 7/27/1969 12:00:00 AM"
         )
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        let localDate = formatter.date(from: "1969-07-27T07:00:00.000Z")
+        let localDate = try? Date(
+            "1969-07-27T00:00:00",
+            strategy: Date.ParseStrategy.arcGISDateParseStrategy
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -555,9 +558,10 @@ final class FormViewTests: XCTestCase {
         
         julyFirstButton.tap()
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        let localDate = formatter.date(from: "1969-07-01T07:00:00.000Z")
+        let localDate = try? Date(
+            "1969-07-01T07:00:00",
+            strategy: Date.ParseStrategy.arcGISDateParseStrategy
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -605,6 +609,16 @@ final class FormViewTests: XCTestCase {
         XCTAssertEqual(
             fieldValue.label,
             "No Value"
+        )
+    }
+}
+
+private extension Date.ParseStrategy {
+    /// A parse strategy for date/time strings with a yyyy-MM-dd'T'HH:mm:ss format.
+    static var arcGISDateParseStrategy: Self {
+        .fixed(
+            format: "\(year: .defaultDigits)-\(month: .defaultDigits)-\(day: .defaultDigits)T\(hour: .defaultDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .defaultDigits):\(second: .defaultDigits)",
+            timeZone: .current
         )
     }
 }

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -366,7 +366,11 @@ final class FormViewTests: XCTestCase {
             "The field title isn't hittable."
         )
         
-        let localDate = try? Date("1969-07-07T20:17:00", strategy: .arcGISDateParseStrategy)
+        let localDate = Calendar.current.date(
+            from: DateComponents(
+                timeZone: .gmt, year: 1969, month: 7, day: 8, hour: 3, minute: 17
+            )
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -439,7 +443,11 @@ final class FormViewTests: XCTestCase {
             "The field value isn't hittable."
         )
         
-        let localDate = try? Date("2023-07-14T08:53:00", strategy: .arcGISDateParseStrategy)
+        let localDate = Calendar.current.date(
+            from: DateComponents(
+                timeZone: .gmt, year: 2023, month: 7, day: 15, hour: 3, minute: 53
+            )
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -498,7 +506,11 @@ final class FormViewTests: XCTestCase {
             "End date and Time 7/27/1969 12:00:00 AM"
         )
         
-        let localDate = try? Date("1969-07-27T00:00:00", strategy: .arcGISDateParseStrategy)
+        let localDate = Calendar.current.date(
+            from: DateComponents(
+                timeZone: .gmt, year: 1969, month: 7, day: 27, hour: 7
+            )
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -549,7 +561,11 @@ final class FormViewTests: XCTestCase {
         
         julyFirstButton.tap()
         
-        let localDate = try? Date("1969-07-01T00:00:00", strategy: .arcGISDateParseStrategy)
+        let localDate = Calendar.current.date(
+            from: DateComponents(
+                timeZone: .gmt, year: 1969, month: 7, day: 1, hour: 7
+            )
+        )
         
         XCTAssertEqual(
             fieldValue.label,
@@ -597,16 +613,6 @@ final class FormViewTests: XCTestCase {
         XCTAssertEqual(
             fieldValue.label,
             "No Value"
-        )
-    }
-}
-
-private extension ParseStrategy where Self == Date.ParseStrategy {
-    /// A parse strategy for date/time strings with a yyyy-MM-dd'T'HH:mm:ss format.
-    static var arcGISDateParseStrategy: Self {
-        .fixed(
-            format: "\(year: .defaultDigits)-\(month: .defaultDigits)-\(day: .defaultDigits)T\(hour: .defaultDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .defaultDigits):\(second: .defaultDigits)",
-            timeZone: .current
         )
     }
 }

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -310,8 +310,8 @@ final class FormViewTests: XCTestCase {
         )
         
         XCTAssertTrue(
-            calendarImage.isHittable,
-            "The calendar image isn't hittable."
+            calendarImage.exists,
+            "The calendar image doesn't exist."
         )
         
         fieldValue.tap()

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -366,10 +366,7 @@ final class FormViewTests: XCTestCase {
             "The field title isn't hittable."
         )
         
-        let localDate = try? Date(
-            "1969-07-07T20:17:00",
-            strategy: Date.ParseStrategy.arcGISDateParseStrategy
-        )
+        let localDate = try? Date("1969-07-07T20:17:00", strategy: .arcGISDateParseStrategy)
         
         XCTAssertEqual(
             fieldValue.label,
@@ -442,10 +439,7 @@ final class FormViewTests: XCTestCase {
             "The field value isn't hittable."
         )
         
-        let localDate = try? Date(
-            "2023-07-14T08:53:00",
-            strategy: Date.ParseStrategy.arcGISDateParseStrategy
-        )
+        let localDate = try? Date("2023-07-14T08:53:00", strategy: .arcGISDateParseStrategy)
         
         XCTAssertEqual(
             fieldValue.label,
@@ -504,10 +498,7 @@ final class FormViewTests: XCTestCase {
             "End date and Time 7/27/1969 12:00:00 AM"
         )
         
-        let localDate = try? Date(
-            "1969-07-27T00:00:00",
-            strategy: Date.ParseStrategy.arcGISDateParseStrategy
-        )
+        let localDate = try? Date("1969-07-27T00:00:00", strategy: .arcGISDateParseStrategy)
         
         XCTAssertEqual(
             fieldValue.label,
@@ -558,10 +549,7 @@ final class FormViewTests: XCTestCase {
         
         julyFirstButton.tap()
         
-        let localDate = try? Date(
-            "1969-07-01T07:00:00",
-            strategy: Date.ParseStrategy.arcGISDateParseStrategy
-        )
+        let localDate = try? Date("1969-07-01T07:00:00", strategy: .arcGISDateParseStrategy)
         
         XCTAssertEqual(
             fieldValue.label,
@@ -613,7 +601,7 @@ final class FormViewTests: XCTestCase {
     }
 }
 
-private extension Date.ParseStrategy {
+private extension ParseStrategy where Self == Date.ParseStrategy {
     /// A parse strategy for date/time strings with a yyyy-MM-dd'T'HH:mm:ss format.
     static var arcGISDateParseStrategy: Self {
         .fixed(


### PR DESCRIPTION
- Switches the date/time single and multi line form input fields to get their value from `FieldFormElement.value`
- Adds guards in `onAppear` bodies to prevent unnecessarily calling `setAttributeValue` with the value that's already stored.