### PR TITLE
Flyover: update delegate method

### DIFF
--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -15,6 +15,7 @@ import ARKit
 import RealityKit
 import SwiftUI
 
+//typealias ARViewType = RealityKit.ARView
 typealias ARViewType = ARSCNView
 
 /// A SwiftUI version of an AR view.

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// A SwiftUI version of ARSCNView.
 struct ARSwiftUIView {
     /// The closure to call when the ARSCNView renders.
-    private(set) var onAnchorsDidUpdateAction: ((ARSession, [ARAnchor]) -> Void)?
+    private(set) var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
     private(set) var videoFeedIsHidden: Bool = false
     /// The proxy.
     private let proxy: ARSwiftUIViewProxy?
@@ -31,11 +31,11 @@ struct ARSwiftUIView {
     }
     
     /// Sets the closure to call when underlying scene renders.
-    func onAnchorsDidUpdate(
-        perform action: @escaping (ARSession, [ARAnchor]) -> Void
+    func onDidUpdateFrame(
+        perform action: @escaping (ARSession, ARFrame) -> Void
     ) -> Self {
         var view = self
-        view.onAnchorsDidUpdateAction = action
+        view.onDidUpdateFrameAction = action
         return view
     }
     
@@ -56,7 +56,7 @@ extension ARSwiftUIView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: ARView, context: Context) {
-        context.coordinator.onAnchorsDidUpdateAction = onAnchorsDidUpdateAction
+        context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
         uiView.isHidden = videoFeedIsHidden
     }
     
@@ -67,10 +67,10 @@ extension ARSwiftUIView: UIViewRepresentable {
 
 extension ARSwiftUIView {
     class Coordinator: NSObject, ARSessionDelegate {
-        var onAnchorsDidUpdateAction: ((ARSession, [ARAnchor]) -> Void)?
+        var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
         
-        func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
-            onAnchorsDidUpdateAction?(session, anchors)
+        func session(_ session: ARSession, didUpdate frame: ARFrame) {
+            onDidUpdateFrameAction?(session, frame)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -12,10 +12,8 @@
 // limitations under the License.
 
 import ARKit
-import RealityKit
 import SwiftUI
 
-//typealias ARViewType = RealityKit.ARView
 typealias ARViewType = ARSCNView
 
 /// A SwiftUI version of an AR view.
@@ -53,7 +51,6 @@ struct ARSwiftUIView {
 extension ARSwiftUIView: UIViewRepresentable {
     func makeUIView(context: Context) -> ARViewType {
         let arView = ARViewType()
-        //arView.debugOptions.insert(.showStatistics)
         arView.session.delegate = context.coordinator
         proxy?.arView = arView
         return arView

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -50,6 +50,10 @@ struct ARSwiftUIView {
 extension ARSwiftUIView: UIViewRepresentable {
     func makeUIView(context: Context) -> ARView {
         let arView = ARView()
+//        arView.layer.isHidden = true
+        //arView.contentScaleFactor = 0.1
+        //arView.debugOptions.insert(.showStatistics)
+        
         arView.session.delegate = context.coordinator
         proxy?.arView = arView
         return arView
@@ -57,7 +61,7 @@ extension ARSwiftUIView: UIViewRepresentable {
 
     func updateUIView(_ uiView: ARView, context: Context) {
         context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
-        uiView.isHidden = videoFeedIsHidden
+        //uiView.isHidden = videoFeedIsHidden
     }
     
     func makeCoordinator() -> Coordinator {
@@ -84,10 +88,5 @@ class ARSwiftUIViewProxy {
     /// The AR session.
     var session: ARSession? {
         arView?.session
-    }
-    
-    /// The current camera transform of the AR view.
-    var cameraTransform: Transform? {
-        arView?.cameraTransform
     }
 }

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -17,9 +17,9 @@ import SwiftUI
 
 typealias ARViewType = ARSCNView
 
-/// A SwiftUI version of ARSCNView.
+/// A SwiftUI version of an AR view.
 struct ARSwiftUIView {
-    /// The closure to call when the ARSCNView renders.
+    /// The closure to call when the AR view renders.
     private(set) var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
     private(set) var videoFeedIsHidden: Bool = false
     /// The proxy.
@@ -52,10 +52,7 @@ struct ARSwiftUIView {
 extension ARSwiftUIView: UIViewRepresentable {
     func makeUIView(context: Context) -> ARViewType {
         let arView = ARViewType()
-//        arView.layer.isHidden = true
-        //arView.contentScaleFactor = 0.1
         //arView.debugOptions.insert(.showStatistics)
-        
         arView.session.delegate = context.coordinator
         proxy?.arView = arView
         return arView
@@ -83,16 +80,12 @@ extension ARSwiftUIView {
 
 /// A proxy for the ARSwiftUIView.
 class ARSwiftUIViewProxy {
-    /// The underlying ARSCNView.
+    /// The underlying AR view.
     /// This is set by the ARSwiftUIView when it is available.
     fileprivate var arView: ARViewType?
     
     /// The AR session.
     var session: ARSession? {
         arView?.session
-    }
-    
-    var transform: SCNMatrix4? {
-        arView?.pointOfView?.transform
     }
 }

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -61,7 +61,7 @@ extension ARSwiftUIView: UIViewRepresentable {
 
     func updateUIView(_ uiView: ARView, context: Context) {
         context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
-        //uiView.isHidden = videoFeedIsHidden
+        uiView.isHidden = videoFeedIsHidden
     }
     
     func makeCoordinator() -> Coordinator {

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -15,6 +15,8 @@ import ARKit
 import RealityKit
 import SwiftUI
 
+typealias ARViewType = ARSCNView
+
 /// A SwiftUI version of ARSCNView.
 struct ARSwiftUIView {
     /// The closure to call when the ARSCNView renders.
@@ -48,8 +50,8 @@ struct ARSwiftUIView {
 }
 
 extension ARSwiftUIView: UIViewRepresentable {
-    func makeUIView(context: Context) -> ARView {
-        let arView = ARView()
+    func makeUIView(context: Context) -> ARViewType {
+        let arView = ARViewType()
 //        arView.layer.isHidden = true
         //arView.contentScaleFactor = 0.1
         //arView.debugOptions.insert(.showStatistics)
@@ -59,7 +61,7 @@ extension ARSwiftUIView: UIViewRepresentable {
         return arView
     }
 
-    func updateUIView(_ uiView: ARView, context: Context) {
+    func updateUIView(_ uiView: ARViewType, context: Context) {
         context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
         uiView.isHidden = videoFeedIsHidden
     }
@@ -83,10 +85,14 @@ extension ARSwiftUIView {
 class ARSwiftUIViewProxy {
     /// The underlying ARSCNView.
     /// This is set by the ARSwiftUIView when it is available.
-    fileprivate var arView: ARView?
+    fileprivate var arView: ARViewType?
     
     /// The AR session.
     var session: ARSession? {
         arView?.session
+    }
+    
+    var transform: SCNMatrix4? {
+        arView?.pointOfView?.transform
     }
 }

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -101,7 +101,7 @@ extension SceneViewProxy {
     ) {
         let cameraTransform = frame.camera.transform
         
-        // Rotate camera transform 90 degrees in the XY plane.
+        // Rotate camera transform 90 degrees counter-clockwise in the XY plane.
         let transform = simd_float4x4.init(
             cameraTransform.columns.1,
             -cameraTransform.columns.0,

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -100,23 +100,25 @@ extension SceneViewProxy {
         orientation: UIDeviceOrientation
     ) {
         let cameraTransform = frame.camera.transform
-        let povTransform = simd_float4x4.init(
+        
+        // Rotate camera transform 90 degrees in the XY plane.
+        let transform = simd_float4x4.init(
             cameraTransform.columns.1,
             -cameraTransform.columns.0,
             cameraTransform.columns.2,
             cameraTransform.columns.3
         )
         
-        let quaternion = simd_quatf(povTransform)
+        let quaternion = simd_quatf(transform)
         
         let transformationMatrix = TransformationMatrix.normalized(
             quaternionX: Double(quaternion.vector.x),
             quaternionY: Double(quaternion.vector.y),
             quaternionZ: Double(quaternion.vector.z),
             quaternionW: Double(quaternion.vector.w),
-            translationX: Double(povTransform.columns.3.x),
-            translationY: Double(povTransform.columns.3.y),
-            translationZ: Double(povTransform.columns.3.z)
+            translationX: Double(transform.columns.3.x),
+            translationY: Double(transform.columns.3.y),
+            translationZ: Double(transform.columns.3.z)
         )
         
         // Set the matrix on the camera controller.

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -47,7 +47,6 @@ public struct FlyoverSceneView: View {
         
         configuration = ARWorldTrackingConfiguration()
         configuration.worldAlignment = .gravityAndHeading
-        configuration.planeDetection = [.horizontal]
     }
     
     public var body: some View {
@@ -57,7 +56,7 @@ public struct FlyoverSceneView: View {
                     .cameraController(cameraController)
                     .viewDrawingMode(.manual)
                 ARSwiftUIView(proxy: arViewProxy)
-                    .onAnchorsDidUpdate { session, anchors in
+                    .onDidUpdateFrame { _, _ in
                         updateLastGoodDeviceOrientation()
                         sceneViewProxy.draw(
                             for: arViewProxy,

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -62,7 +62,8 @@ public struct FlyoverSceneView: View {
                             frame: frame,
                             for: session,
                             cameraController: cameraController,
-                            orientation: lastGoodDeviceOrientation
+                            orientation: lastGoodDeviceOrientation,
+                            transform: arViewProxy.transform!
                         )
                     }
                     .videoFeedHidden()
@@ -97,20 +98,30 @@ extension SceneViewProxy {
         frame: ARFrame,
         for: ARSession,
         cameraController: TransformationMatrixCameraController,
-        orientation: UIDeviceOrientation
+        orientation: UIDeviceOrientation,
+        transform: SCNMatrix4
     ) {
-        //let cameraMatrix = frame.camera.viewMatrix(for: .portrait)
-        let cameraMatrix = frame.camera.transform
-        let cameraQuat = simd_quatf(cameraMatrix)
+        let cameraTransform = frame.camera.transform
+        let povTransform = simd_float4x4.init(
+            cameraTransform.columns.1,
+            -cameraTransform.columns.0,
+            cameraTransform.columns.2,
+            cameraTransform.columns.3
+        )
+        
+//        print("-- pov: \(transform)")
+//        print("-- cam: \(cameraMatrix)")
+        
+        let quaternion = simd_quatf(povTransform)
         
         let transformationMatrix = TransformationMatrix.normalized(
-            quaternionX: Double(cameraQuat.vector.x),
-            quaternionY: Double(cameraQuat.vector.y),
-            quaternionZ: Double(cameraQuat.vector.z),
-            quaternionW: Double(cameraQuat.vector.w),
-            translationX: Double(cameraMatrix.columns.3.x),
-            translationY: Double(cameraMatrix.columns.3.y),
-            translationZ: Double(cameraMatrix.columns.3.z)
+            quaternionX: Double(quaternion.vector.x),
+            quaternionY: Double(quaternion.vector.y),
+            quaternionZ: Double(quaternion.vector.z),
+            quaternionW: Double(quaternion.vector.w),
+            translationX: Double(povTransform.columns.3.x),
+            translationY: Double(povTransform.columns.3.y),
+            translationZ: Double(povTransform.columns.3.z)
         )
         
         // Set the matrix on the camera controller.

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -56,11 +56,10 @@ public struct FlyoverSceneView: View {
                     .cameraController(cameraController)
                     .viewDrawingMode(.manual)
                 ARSwiftUIView(proxy: arViewProxy)
-                    .onDidUpdateFrame { session, frame in
+                    .onDidUpdateFrame { _, frame in
                         updateLastGoodDeviceOrientation()
                         sceneViewProxy.draw(
                             frame: frame,
-                            for: session,
                             cameraController: cameraController,
                             orientation: lastGoodDeviceOrientation
                         )
@@ -90,12 +89,11 @@ public struct FlyoverSceneView: View {
 extension SceneViewProxy {
     /// Draws the scene view manually and sets the camera for a given augmented reality view.
     /// - Parameters:
-    ///   - arViewProxy: The AR view proxy.
+    ///   - frame: The current AR frame.
     ///   - cameraController: The current camera controller assigned to the scene view.
     ///   - orientation: The device orientation.
     func draw(
         frame: ARFrame,
-        for: ARSession,
         cameraController: TransformationMatrixCameraController,
         orientation: UIDeviceOrientation
     ) {

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -100,7 +100,6 @@ extension SceneViewProxy {
         orientation: UIDeviceOrientation
     ) {
         //let cameraMatrix = frame.camera.viewMatrix(for: .portrait)
-        
         let cameraMatrix = frame.camera.transform
         let cameraQuat = simd_quatf(cameraMatrix)
         

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -87,7 +87,7 @@ public struct FlyoverSceneView: View {
 }
 
 extension SceneViewProxy {
-    /// Draws the scene view manually and sets the camera for a given augmented reality view.
+    /// Draws the scene view manually and sets the camera for a given augmented reality frame.
     /// - Parameters:
     ///   - frame: The current AR frame.
     ///   - cameraController: The current camera controller assigned to the scene view.

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -158,7 +158,7 @@ private extension ARCamera {
             )
         case .portraitUpsideDown:
             return simd_float4x4(
-                transform.columns.1,
+                -transform.columns.1,
                 transform.columns.0,
                 transform.columns.2,
                 transform.columns.3

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -62,8 +62,7 @@ public struct FlyoverSceneView: View {
                             frame: frame,
                             for: session,
                             cameraController: cameraController,
-                            orientation: lastGoodDeviceOrientation,
-                            transform: arViewProxy.transform!
+                            orientation: lastGoodDeviceOrientation
                         )
                     }
                     .videoFeedHidden()
@@ -98,8 +97,7 @@ extension SceneViewProxy {
         frame: ARFrame,
         for: ARSession,
         cameraController: TransformationMatrixCameraController,
-        orientation: UIDeviceOrientation,
-        transform: SCNMatrix4
+        orientation: UIDeviceOrientation
     ) {
         let cameraTransform = frame.camera.transform
         let povTransform = simd_float4x4.init(
@@ -108,9 +106,6 @@ extension SceneViewProxy {
             cameraTransform.columns.2,
             cameraTransform.columns.3
         )
-        
-//        print("-- pov: \(transform)")
-//        print("-- cam: \(cameraMatrix)")
         
         let quaternion = simd_quatf(povTransform)
         
@@ -138,7 +133,7 @@ extension SceneViewProxy {
             yPrincipal: intrinsics[2][1],
             xImageSize: Float(imageResolution.width),
             yImageSize: Float(imageResolution.height),
-            deviceOrientation: .portrait
+            deviceOrientation: orientation
         )
         
         // Render the Scene with the new transformation.


### PR DESCRIPTION
Use new delegate method to update the transformation matrix. 

2 reasons:
This allows us to switch from reality kit to ARKit easily with this code:

```swift
//typealias ARViewType = RealityKit.ARView
typealias ARViewType = ARSCNView
```

And it also allows our draw method to rely on frame state that is passed directly to the delegate method instead of querying it from the session.