### PR TITLE
AR: Add tracking state and help text to TableTop AR

### DIFF
--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -20,6 +20,8 @@ typealias ARViewType = ARSCNView
 struct ARSwiftUIView {
     /// The closure to call when the session's frame updates.
     private(set) var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
+    /// The closure to call when the camera's tracking status changes.
+    private(set) var onCameraTrackingStateChangeAction: ((ARSession, ARCamera) -> Void)?
     /// The closure to call when a node corresponding to a new anchor has been added to the view.
     private(set) var onAddNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
     /// The closure to call when a node has been updated to match it's corresponding anchor.
@@ -41,6 +43,15 @@ struct ARSwiftUIView {
     ) -> Self {
         var view = self
         view.onDidUpdateFrameAction = action
+        return view
+    }
+    
+    /// Sets the closure to call when the camera tracking status changes.
+    func onCameraTrackingStateChange(
+        perform action: @escaping (ARSession, ARCamera) -> Void
+    ) -> Self {
+        var view = self
+        view.onCameraTrackingStateChangeAction = action
         return view
     }
     
@@ -75,6 +86,7 @@ extension ARSwiftUIView: UIViewRepresentable {
     
     func updateUIView(_ uiView: ARViewType, context: Context) {
         context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
+        context.coordinator.onCameraTrackingStateChangeAction = onCameraTrackingStateChangeAction
         context.coordinator.onAddNodeAction = onAddNodeAction
         context.coordinator.onUpdateNodeAction = onUpdateNodeAction
     }
@@ -87,11 +99,16 @@ extension ARSwiftUIView: UIViewRepresentable {
 extension ARSwiftUIView {
     class Coordinator: NSObject, ARSCNViewDelegate, ARSessionDelegate {
         var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
+        var onCameraTrackingStateChangeAction: ((ARSession, ARCamera) -> Void)?
         var onAddNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
         var onUpdateNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
         
         func session(_ session: ARSession, didUpdate frame: ARFrame) {
             onDidUpdateFrameAction?(session, frame)
+        }
+        
+        func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
+            onCameraTrackingStateChangeAction?(session, camera)
         }
         
         func renderer(_ renderer: SCNSceneRenderer, didAdd node: SCNNode, for anchor: ARAnchor) {

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -20,7 +20,7 @@ typealias ARViewType = ARSCNView
 struct ARSwiftUIView {
     /// The closure to call when the session's frame updates.
     private(set) var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
-    /// The closure to call when the camera's tracking status changes.
+    /// The closure to call when the camera tracking status changes.
     private(set) var onCameraTrackingStateChangeAction: ((ARSession, ARCamera) -> Void)?
     /// The closure to call when a node corresponding to a new anchor has been added to the view.
     private(set) var onAddNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -227,7 +227,7 @@ public struct TableTopSceneView: View {
     /// Sets the visibility of the help text.
     /// - Parameter hidden: A Boolean value that indicates whether to hide the
     ///  help text.
-    public func helpTexteHidden(_ hidden: Bool) -> Self {
+    public func helpTextHidden(_ hidden: Bool) -> Self {
         var view = self
         view.isHelpTextHidden = hidden
         return view

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -35,6 +35,8 @@ public struct TableTopSceneView: View {
     private let configuration: ARWorldTrackingConfiguration
     /// A Boolean value indicating that the scene's initial transformation has been set.
     private var initialTransformationIsSet: Bool { initialTransformation != nil }
+    /// A Boolean value that indicates whether to hide the help text.
+    private var isHelpTextHidden: Bool = false
     
     /// Creates a table top scene view.
     /// - Parameters:
@@ -128,7 +130,7 @@ public struct TableTopSceneView: View {
             }
         }
         .overlay(alignment: .top) {
-            if !helpText.isEmpty {
+            if !helpText.isEmpty && !isHelpTextHidden {
                 Text(helpText)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(8)
@@ -220,6 +222,15 @@ public struct TableTopSceneView: View {
                 break
             }
         }
+    }
+    
+    /// Sets the visibility of the help text.
+    /// - Parameter hidden: A Boolean value that indicates whether to hide the
+    ///  help text.
+    public func helpTexteHidden(_ hidden: Bool) -> Self {
+        var view = self
+        view.isHelpTextHidden = hidden
+        return view
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -28,7 +28,7 @@ public struct TableTopSceneView: View {
     /// The current interface orientation.
     @State private var interfaceOrientation: InterfaceOrientation?
     /// The help text to guide the user through an AR experience.
-    @State private var helpText: String?
+    @State private var helpText: String = ""
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
     /// The configuration for the AR session.
@@ -84,7 +84,7 @@ public struct TableTopSceneView: View {
                     )
                 }
                 .onCameraTrackingStateChange { _, camera in
-                    setHelpText(for: camera.trackingState)
+                    updateHelpText(for: camera.trackingState)
                 }
                 .onAddNode { renderer, node, anchor in
                     addPlane(renderer: renderer, node: node, anchor: anchor)
@@ -102,7 +102,7 @@ public struct TableTopSceneView: View {
                         using: screenPoint
                     ) {
                         initialTransformation = transformation
-                        helpText = nil
+                        helpText = ""
                     }
                 }
                 .onAppear {
@@ -128,7 +128,7 @@ public struct TableTopSceneView: View {
             }
         }
         .overlay(alignment: .top) {
-            if let helpText {
+            if !helpText.isEmpty {
                 Text(helpText)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(8)
@@ -191,10 +191,13 @@ public struct TableTopSceneView: View {
         helpText = "Tap a surface to place the scene"
     }
     
-    /// Sets the help text to guide the user through an AR experience using the AR session's camera tracking status.
+    /// Updates the help text to guide the user through an AR experience using the AR session's camera tracking status.
     /// - Parameter trackingState: The camera's tracking status.
-    private func setHelpText(for trackingState: ARCamera.TrackingState) {
-        guard !initialTransformationIsSet else { return }
+    private func updateHelpText(for trackingState: ARCamera.TrackingState) {
+        guard !initialTransformationIsSet else {
+            helpText = ""
+            return
+        }
         
         switch trackingState {
         case .normal:

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -333,50 +333,60 @@ private extension SceneViewProxy {
 }
 
 private extension String {
-    static let planeFound = String(
-        localized: "Tap a surface to place the scene",
-        bundle: .toolkitModule,
-        comment: """
+    static var planeFound: String {
+        String(
+            localized: "Tap a surface to place the scene",
+            bundle: .toolkitModule,
+            comment: """
                  An instruction to the user to tap on a horizontal surface to
                  place an ArcGIS Scene.
                  """
-    )
+        )
+    }
     
-    static let moveDevice = String(
-        localized: "Keep moving your device",
-        bundle: .toolkitModule,
-        comment: """
+    static var moveDevice: String {
+        String(
+            localized: "Keep moving your device",
+            bundle: .toolkitModule,
+            comment: """
                  An instruction to the user to keep moving their device so that
                  horizontal planes can be identified in the AR experience.
                  """
-    )
+        )
+    }
     
-    static let locationUnavailable = String(
-        localized: "Location not available",
-        bundle: .toolkitModule,
-        comment: """
-                 A message to the user to notify them that the location of their 
+    static var locationUnavailable: String {
+        String(
+            localized: "Location not available",
+            bundle: .toolkitModule,
+            comment: """
+                 A message to the user to notify them that the location of their
                  device is unavailable in the AR experience.
                  """
-    )
+        )
+    }
     
-    static let excessiveMotion = String(
-        localized: "Try moving your device more slowly",
-        bundle: .toolkitModule,
-        comment: """
+    static var excessiveMotion: String {
+        String(
+            localized: "Try moving your device more slowly",
+            bundle: .toolkitModule,
+            comment: """
                  An instruction to the user to reduce excessive device motion by
                  moving the device more slowly to improve the AR experience which
                  requires limited device motion.
                 """
-    )
+        )
+    }
     
-    static let insufficentFeatures = String(
-        localized: "Try turning on more lights and moving around",
-        bundle: .toolkitModule,
-        comment: """
+    static var insufficentFeatures: String {
+        String(
+            localized: "Try turning on more lights and moving around",
+            bundle: .toolkitModule,
+            comment: """
                  An instruction to the user to turn on more lights or move towards a
                  light source to improve the AR experience which requires sufficient
                  lighting conditions.
                  """
-    )
+        )
+    }
 }

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -217,8 +217,10 @@ public struct TableTopSceneView: View {
             case .relocalizing:
                 // This case will not occur since the AR session delegate
                 // does not implement relocalization support.
+                helpText = ""
                 break
             default:
+                helpText = ""
                 break
             }
         }

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -36,7 +36,7 @@ public struct TableTopSceneView: View {
     /// A Boolean value indicating that the scene's initial transformation has been set.
     private var initialTransformationIsSet: Bool { initialTransformation != nil }
     /// A Boolean value that indicates whether to hide the help text.
-    private var isHelpTextHidden: Bool = false
+    private var helpTextIsHidden: Bool = false
     
     /// Creates a table top scene view.
     /// - Parameters:
@@ -130,7 +130,7 @@ public struct TableTopSceneView: View {
             }
         }
         .overlay(alignment: .top) {
-            if !helpText.isEmpty && !isHelpTextHidden {
+            if !helpText.isEmpty && !helpTextIsHidden {
                 Text(helpText)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(8)
@@ -168,7 +168,7 @@ public struct TableTopSceneView: View {
         node.addChildNode(planeNode)
         
         // Set help text when plane is visualized.
-        helpText = "Tap a surface to place the scene"
+        helpText = .planeFound
     }
     
     /// Visualizes a node updated in the scene as an AR Plane.
@@ -190,7 +190,7 @@ public struct TableTopSceneView: View {
         planeGeometry.update(from: planeAnchor.geometry)
         
         // Set help text when plane visualization is updated.
-        helpText = "Tap a surface to place the scene"
+        helpText = .planeFound
     }
     
     /// Updates the help text to guide the user through an AR experience using the AR session's camera tracking status.
@@ -229,7 +229,7 @@ public struct TableTopSceneView: View {
     ///  help text.
     public func helpTextHidden(_ hidden: Bool) -> Self {
         var view = self
-        view.isHelpTextHidden = hidden
+        view.helpTextIsHidden = hidden
         return view
     }
 }
@@ -347,7 +347,7 @@ private extension String {
         bundle: .toolkitModule,
         comment: """
                  An instruction to the user to keep moving their device so that
-                 horizontal planes can be identidifed in the AR experience.
+                 horizontal planes can be identified in the AR experience.
                  """
     )
     
@@ -355,8 +355,8 @@ private extension String {
         localized: "Location not available",
         bundle: .toolkitModule,
         comment: """
-                 A message to the user to notify them that the location of their device
-                 is unavailable in the AR experience.
+                 A message to the user to notify them that the location of their 
+                 device is unavailable in the AR experience.
                  """
     )
     
@@ -364,8 +364,8 @@ private extension String {
         localized: "Try moving your device more slowly",
         bundle: .toolkitModule,
         comment: """
-                 An instruction the user to reduce excessive device motion by
-                 moving the device more slowly to imporve the AR experience which
+                 An instruction to the user to reduce excessive device motion by
+                 moving the device more slowly to improve the AR experience which
                  requires limited device motion.
                 """
     )
@@ -374,8 +374,8 @@ private extension String {
         localized: "Try turning on more lights and moving around",
         bundle: .toolkitModule,
         comment: """
-                 An instruction the the user to turn on more lights or move towards a
-                 light source to imporve the AR experience which requires sufficient
+                 An instruction to the user to turn on more lights or move towards a
+                 light source to improve the AR experience which requires sufficient
                  lighting conditions.
                  """
     )

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -203,17 +203,17 @@ public struct TableTopSceneView: View {
         
         switch trackingState {
         case .normal:
-            helpText = "Keep moving your device"
+            helpText = .moveDevice
         case .notAvailable:
-            helpText = "Location not available"
+            helpText = .locationUnavailable
         case .limited(let reason):
             switch reason {
             case .excessiveMotion:
-                helpText = "Try moving your device more slowly"
+                helpText = .excessiveMotion
             case .initializing:
-                helpText = "Keep moving your device"
+                helpText = .moveDevice
             case .insufficientFeatures:
-                helpText = "Try turning on more lights and moving around"
+                helpText = .insufficentFeatures
             case .relocalizing:
                 // This case will not occur since the AR session delegate
                 // does not implement relocalization support.
@@ -330,4 +330,53 @@ private extension SceneViewProxy {
             interfaceOrientation: orientation
         )
     }
+}
+
+private extension String {
+    static let planeFound = String(
+        localized: "Tap a surface to place the scene",
+        bundle: .toolkitModule,
+        comment: """
+                 An instruction to the user to tap on a horizontal surface to
+                 place an ArcGIS Scene.
+                 """
+    )
+    
+    static let moveDevice = String(
+        localized: "Keep moving your device",
+        bundle: .toolkitModule,
+        comment: """
+                 An instruction to the user to keep moving their device so that
+                 horizontal planes can be identidifed in the AR experience.
+                 """
+    )
+    
+    static let locationUnavailable = String(
+        localized: "Location not available",
+        bundle: .toolkitModule,
+        comment: """
+                 A message to the user to notify them that the location of their device
+                 is unavailable in the AR experience.
+                 """
+    )
+    
+    static let excessiveMotion = String(
+        localized: "Try moving your device more slowly",
+        bundle: .toolkitModule,
+        comment: """
+                 An instruction the user to reduce excessive device motion by
+                 moving the device more slowly to imporve the AR experience which
+                 requires limited device motion.
+                """
+    )
+    
+    static let insufficentFeatures = String(
+        localized: "Try turning on more lights and moving around",
+        bundle: .toolkitModule,
+        comment: """
+                 An instruction the the user to turn on more lights or move towards a
+                 light source to imporve the AR experience which requires sufficient
+                 lighting conditions.
+                 """
+    )
 }

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -218,10 +218,8 @@ public struct TableTopSceneView: View {
                 // This case will not occur since the AR session delegate
                 // does not implement relocalization support.
                 helpText = ""
-                break
             default:
                 helpText = ""
-                break
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -27,7 +27,7 @@ public struct TableTopSceneView: View {
     @State private var cameraController: TransformationMatrixCameraController
     /// The current interface orientation.
     @State private var interfaceOrientation: InterfaceOrientation?
-    /// The help text to guide the user through the AR experience.
+    /// The help text to guide the user through an AR experience.
     @State private var helpText: String?
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
@@ -191,7 +191,7 @@ public struct TableTopSceneView: View {
         helpText = "Tap a surface to place the scene"
     }
     
-    /// Sets the help text to guide the user through the AR experience using the AR session's camera tracking status.
+    /// Sets the help text to guide the user through an AR experience using the AR session's camera tracking status.
     /// - Parameter trackingState: The camera's tracking status.
     private func setHelpText(for trackingState: ARCamera.TrackingState) {
         guard !initialTransformationIsSet else { return }

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -130,6 +130,14 @@ contains one or more facilities in a floor-aware map or scene. */
 trace operation. */
 "Function Results" = "Function Results";
 
+/* An instruction to the user to keep moving their device so that
+horizontal planes can be identidifed in the AR experience. */
+"Keep moving your device" = "Keep moving your device";
+
+/* A message to the user to notify them that the location of their device
+is unavailable in the AR experience. */
+"Location not available" = "Location not available";
+
 /* A label in reference to media elements contained within a popup. */
 "Media" = "Media";
 
@@ -225,6 +233,10 @@ match the spatial reference of the map or scene. */
 network trace operation. */
 "Starting Points" = "Starting Points";
 
+/* An instruction to the user to tap on a horizontal surface to
+place an ArcGIS Scene. */
+"Tap a surface to place the scene" = "Tap a surface to place the scene";
+
 /* A label indicating that tapping an image will reveal
 additional information. */
 "Tap on the image for more information." = "Tap on the image for more information.";
@@ -272,6 +284,16 @@ match the spatial reference of the map. */
 
 /* A label for a button allowing the user to retry an operation. */
 "Try Again" = "Try Again";
+
+/*  An instruction the user to reduce excessive device motion by
+ moving the device more slowly to imporve the AR experience which
+ requires limited device motion. */
+"Try moving your device more slowly" = "Try moving your device more slowly";
+
+/* An instruction the the user to turn on more lights or move towards a
+light source to imporve the AR experience which requires sufficient
+lighting conditions. */
+"Try turning on more lights and moving around" = "Try turning on more lights and moving around";
 
 /* A label to use in place of a utility element asset type name. */
 "Unnamed Asset Type" = "Unnamed Asset Type";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -131,11 +131,11 @@ trace operation. */
 "Function Results" = "Function Results";
 
 /* An instruction to the user to keep moving their device so that
-horizontal planes can be identidifed in the AR experience. */
+horizontal planes can be identified in the AR experience. */
 "Keep moving your device" = "Keep moving your device";
 
-/* A message to the user to notify them that the location of their device
-is unavailable in the AR experience. */
+/* A message to the user to notify them that the location of their 
+device is unavailable in the AR experience. */
 "Location not available" = "Location not available";
 
 /* A label in reference to media elements contained within a popup. */
@@ -285,13 +285,13 @@ match the spatial reference of the map. */
 /* A label for a button allowing the user to retry an operation. */
 "Try Again" = "Try Again";
 
-/*  An instruction the user to reduce excessive device motion by
- moving the device more slowly to imporve the AR experience which
+/*  An instruction to the user to reduce excessive device motion by
+ moving the device more slowly to improve the AR experience which
  requires limited device motion. */
 "Try moving your device more slowly" = "Try moving your device more slowly";
 
-/* An instruction the the user to turn on more lights or move towards a
-light source to imporve the AR experience which requires sufficient
+/* An instruction to the user to turn on more lights or move towards a
+light source to improve the AR experience which requires sufficient
 lighting conditions. */
 "Try turning on more lights and moving around" = "Try turning on more lights and moving around";
 

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -134,7 +134,7 @@ trace operation. */
 horizontal planes can be identified in the AR experience. */
 "Keep moving your device" = "Keep moving your device";
 
-/* A message to the user to notify them that the location of their 
+/* A message to the user to notify them that the location of their
 device is unavailable in the AR experience. */
 "Location not available" = "Location not available";
 


### PR DESCRIPTION
This PR adds help text to `TableTopSceneView` to guide the user through an AR experience. The help text follows Apple's human interface [guidelines](https://developer.apple.com/design/human-interface-guidelines/augmented-reality#Communicating-with-people) for communicating with people in AR.