### PR TITLE
Flyover AR: Do not allow user to specify pitch or roll

### DIFF
--- a/Examples/Examples/FlyoverExampleView.swift
+++ b/Examples/Examples/FlyoverExampleView.swift
@@ -22,14 +22,11 @@ struct FlyoverExampleView: View {
             id: PortalItem.ID("7558ee942b2547019f66885c44d4f0b1")!
         )
     )
-    
-    private let initialCamera = Camera(
-        latitude: 51.9244, longitude: 4.4777, altitude: 1_000, heading: 0, pitch: 90, roll: 0
-    )
-    
+
     var body: some View {
         FlyoverSceneView(
-            initialCamera: initialCamera,
+            initialLocation: Point(x: 4.4777, y: 51.9244, z: 1_000, spatialReference: .wgs84),
+            initialHeading: 0,
             translationFactor: 2_000
         ) { proxy in
             SceneView(scene: scene)

--- a/Examples/Examples/FlyoverExampleView.swift
+++ b/Examples/Examples/FlyoverExampleView.swift
@@ -23,58 +23,20 @@ struct FlyoverExampleView: View {
         )
     )
 
-//    var body: some View {
-//        FlyoverSceneView(
-//            initialLocation: Point(x: 4.4777, y: 51.9244, z: 1_000, spatialReference: .wgs84),
-//            initialHeading: 0,
-//            translationFactor: 2_000
-//        ) { proxy in
-//            SceneView(scene: scene)
-//                .onSingleTapGesture { screen, _ in
-//                    print("Identifying...")
-//                    Task.detached {
-//                        let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
-//                        print("\(results.count) identify result(s).")
-//                    }
-//                }
-//        }
-//    }
-    
-    @State var lat = 43.54
-    @State var tf = 2000.0
-    
     var body: some View {
-        VStack {
-            FlyoverSceneView(
-                initialLatitude: lat,
-                initialLongitude: -116.5794293050851,
-                initialAltitude: 3300,
-                initialHeading: 0,
-                translationFactor: tf
-            ) { proxy in
-                SceneView(scene: scene)
-                    .onSingleTapGesture { screen, _ in
-                        print("Identifying...")
-                        Task.detached {
-                            let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
-                            print("\(results.count) identify result(s).")
-                        }
+        FlyoverSceneView(
+            initialLocation: Point(x: 4.4777, y: 51.9244, z: 1_000, spatialReference: .wgs84),
+            initialHeading: 0,
+            translationFactor: 2_000
+        ) { proxy in
+            SceneView(scene: scene)
+                .onSingleTapGesture { screen, _ in
+                    print("Identifying...")
+                    Task.detached {
+                        let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
+                        print("\(results.count) identify result(s).")
                     }
-            }
-            HStack {
-                Button {
-                    lat += 5
-                } label: {
-                    Text("lat")
                 }
-                Spacer()
-                Button {
-                    tf += 1000
-                } label: {
-                    Text("tf")
-                }
-            }
-            .padding()
         }
     }
 }

--- a/Examples/Examples/FlyoverExampleView.swift
+++ b/Examples/Examples/FlyoverExampleView.swift
@@ -23,20 +23,58 @@ struct FlyoverExampleView: View {
         )
     )
 
+//    var body: some View {
+//        FlyoverSceneView(
+//            initialLocation: Point(x: 4.4777, y: 51.9244, z: 1_000, spatialReference: .wgs84),
+//            initialHeading: 0,
+//            translationFactor: 2_000
+//        ) { proxy in
+//            SceneView(scene: scene)
+//                .onSingleTapGesture { screen, _ in
+//                    print("Identifying...")
+//                    Task.detached {
+//                        let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
+//                        print("\(results.count) identify result(s).")
+//                    }
+//                }
+//        }
+//    }
+    
+    @State var lat = 43.54
+    @State var tf = 2000.0
+    
     var body: some View {
-        FlyoverSceneView(
-            initialLocation: Point(x: 4.4777, y: 51.9244, z: 1_000, spatialReference: .wgs84),
-            initialHeading: 0,
-            translationFactor: 2_000
-        ) { proxy in
-            SceneView(scene: scene)
-                .onSingleTapGesture { screen, _ in
-                    print("Identifying...")
-                    Task.detached {
-                        let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
-                        print("\(results.count) identify result(s).")
+        VStack {
+            FlyoverSceneView(
+                initialLatitude: lat,
+                initialLongitude: -116.5794293050851,
+                initialAltitude: 3300,
+                initialHeading: 0,
+                translationFactor: tf
+            ) { proxy in
+                SceneView(scene: scene)
+                    .onSingleTapGesture { screen, _ in
+                        print("Identifying...")
+                        Task.detached {
+                            let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
+                            print("\(results.count) identify result(s).")
+                        }
                     }
+            }
+            HStack {
+                Button {
+                    lat += 5
+                } label: {
+                    Text("lat")
                 }
+                Spacer()
+                Button {
+                    tf += 1000
+                } label: {
+                    Text("tf")
+                }
+            }
+            .padding()
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -19,16 +19,16 @@ import ArcGIS
 public struct FlyoverSceneView: View {
     /// The AR session.
     @StateObject private var session = ObservableARSession()
+    /// The initial camera.
+    private let initialCamera: Camera
+    /// The translation factor.
+    private let translationFactor: Double
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
     /// The camera controller that we will set on the scene view.
     @State private var cameraController: TransformationMatrixCameraController
     /// The current interface orientation.
     @State private var interfaceOrientation: InterfaceOrientation?
-    /// The initial camera.
-    let initialCamera: Camera
-    /// The translation factor.
-    let translationFactor: Double
     
     /// Creates a fly over scene view.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -106,7 +106,6 @@ public struct FlyoverSceneView: View {
                 .onDisappear { session.pause() }
                 .onChange(of: session.currentFrame) { frame in
                     guard let frame, let interfaceOrientation else { return }
-                    
                     sceneViewProxy.updateCamera(
                         frame: frame,
                         cameraController: cameraController,

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -127,11 +127,6 @@ public struct FlyoverSceneView: View {
                 .observingInterfaceOrientation($interfaceOrientation)
         }
     }
-    
-    func updateCameraController() {
-        cameraController = TransformationMatrixCameraController(originCamera: initialCamera)
-        cameraController.translationFactor = translationFactor
-    }
 }
 
 /// An observable object that wraps an `ARSession` and provides the current frame.

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -25,6 +25,10 @@ public struct FlyoverSceneView: View {
     @State private var cameraController: TransformationMatrixCameraController
     /// The current interface orientation.
     @State private var interfaceOrientation: InterfaceOrientation?
+    /// The initial camera.
+    let initialCamera: Camera
+    /// The translation factor.
+    let translationFactor: Double
     
     /// Creates a fly over scene view.
     /// - Parameters:
@@ -92,6 +96,8 @@ public struct FlyoverSceneView: View {
         @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
     ) {
         self.sceneViewBuilder = sceneView
+        self.translationFactor = translationFactor
+        self.initialCamera = initialCamera
         
         let cameraController = TransformationMatrixCameraController(originCamera: initialCamera)
         cameraController.translationFactor = translationFactor
@@ -112,8 +118,19 @@ public struct FlyoverSceneView: View {
                         orientation: interfaceOrientation
                     )
                 }
+                .onChange(of: initialCamera) { initialCamera in
+                    cameraController.originCamera = initialCamera
+                }
+                .onChange(of: translationFactor) { translationFactor in
+                    cameraController.translationFactor = translationFactor
+                }
                 .observingInterfaceOrientation($interfaceOrientation)
         }
+    }
+    
+    func updateCameraController() {
+        cameraController = TransformationMatrixCameraController(originCamera: initialCamera)
+        cameraController.translationFactor = translationFactor
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -28,7 +28,10 @@ public struct FlyoverSceneView: View {
     
     /// Creates a fly over scene view.
     /// - Parameters:
-    ///   - initialCamera: The initial camera.
+    ///   - initialLatitude: The initial latitude of the scene view's camera.
+    ///   - initialLongitude: The initial longitude of the scene view's camera.
+    ///   - initialAltitude: The initial altitude of the scene view's camera.
+    ///   - initialHeading: The initial heading of the scene view's camera.
     ///   - translationFactor: The translation factor that defines how much the scene view translates
     ///   as the device moves.
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
@@ -36,6 +39,54 @@ public struct FlyoverSceneView: View {
     /// - Remark: The provided scene view will have certain properties overridden in order to
     /// be effectively viewed in augmented reality. One such property is the camera controller.
     public init(
+        initialLatitude: Double,
+        initialLongitude: Double,
+        initialAltitude: Double,
+        initialHeading: Double,
+        translationFactor: Double,
+        @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
+    ) {
+        let camera = Camera(
+            latitude: initialLatitude,
+            longitude: initialLongitude,
+            altitude: initialAltitude,
+            heading: initialHeading,
+            pitch: 90,
+            roll: 0
+        )
+        self.init(initialCamera: camera, translationFactor: translationFactor, sceneView: sceneView)
+    }
+    
+    /// Creates a fly over scene view.
+    /// - Parameters:
+    ///   - initialLocation: The initial location of the scene view's camera.
+    ///   - initialHeading: The initial heading of the scene view's camera.
+    ///   - translationFactor: The translation factor that defines how much the scene view translates
+    ///   as the device moves.
+    ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
+    ///   augmented reality video feed.
+    /// - Remark: The provided scene view will have certain properties overridden in order to
+    /// be effectively viewed in augmented reality. One such property is the camera controller.
+    public init(
+        initialLocation: Point,
+        initialHeading: Double,
+        translationFactor: Double,
+        @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
+    ) {
+        let camera = Camera(location: initialLocation, heading: initialHeading, pitch: 90, roll: 0)
+        self.init(initialCamera: camera, translationFactor: translationFactor, sceneView: sceneView)
+    }
+    
+    /// Creates a fly over scene view.
+    /// - Parameters:
+    ///   - initialCamera: The initial camera.
+    ///   - translationFactor: The translation factor that defines how much the scene view translates
+    ///   as the device moves.
+    ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
+    ///   augmented reality video feed.
+    /// - Remark: The provided scene view will have certain properties overridden in order to
+    /// be effectively viewed in augmented reality. One such property is the camera controller.
+    private init(
         initialCamera: Camera,
         translationFactor: Double,
         @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
@@ -55,6 +106,7 @@ public struct FlyoverSceneView: View {
                 .onDisappear { session.pause() }
                 .onChange(of: session.currentFrame) { frame in
                     guard let frame, let interfaceOrientation else { return }
+                    
                     sceneViewProxy.updateCamera(
                         frame: frame,
                         cameraController: cameraController,


### PR DESCRIPTION
- The pitch must be 90 and the roll must be 0 for flyover to work correctly. As such we shouldn't let the user specify those parameters.
- The initial camera needs to respond to changes, this fixes that and allows the initial camera and translation factor to be updated