### PR TITLE
TableTop AR: Add coaching overlay

### DIFF
--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -122,14 +122,14 @@ extension ARSwiftUIView {
 }
 
 /// A proxy for the ARSwiftUIView.
-class ARSwiftUIViewProxy {
+class ARSwiftUIViewProxy: NSObject, ARSessionProviding {
     /// The underlying AR view.
     /// This is set by the ARSwiftUIView when it is available.
-    fileprivate var arView: ARViewType?
+    fileprivate var arView: ARViewType!
     
     /// The AR session.
-    var session: ARSession? {
-        arView?.session
+    @objc dynamic var session: ARSession {
+        arView.session
     }
     
     /// Creates a raycast query that originates from a point on the view, aligned with the center of the camera's field of view.
@@ -143,10 +143,47 @@ class ARSwiftUIViewProxy {
         allowing target: ARRaycastQuery.Target,
         alignment: ARRaycastQuery.TargetAlignment
     ) -> ARRaycastQuery? {
-        return arView?.raycastQuery(
+        return arView.raycastQuery(
             from: point,
             allowing: target,
             alignment: alignment
         )
     }
+}
+
+struct ARCoachinOverlay: UIViewRepresentable {
+    var sessionProvider: ARSessionProviding?
+    var goal: ARCoachingOverlayView.Goal
+    var active: Bool = false
+
+    func active(_ active: Bool) -> Self {
+        var view = self
+        view.active = active
+        return view
+    }
+    
+    func sessionProvider(_ sessionProvider: ARSessionProviding) -> Self {
+        var view = self
+        view.sessionProvider = sessionProvider
+        return view
+    }
+    
+    func makeUIView(context: Context) -> ARCoachingOverlayView {
+        let view = ARCoachingOverlayView()
+        view.delegate = context.coordinator
+        view.activatesAutomatically = false
+        return view
+    }
+    
+    func updateUIView(_ uiView: ARCoachingOverlayView, context: Context) {
+        uiView.sessionProvider = sessionProvider
+        uiView.goal = goal
+        uiView.setActive(active, animated: true)
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+    
+    class Coordinator: NSObject, ARCoachingOverlayViewDelegate {}
 }

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -134,17 +134,27 @@ class ARSwiftUIViewProxy: NSObject, ARSessionProviding {
     }
 }
 
+/// A SwiftUI version of an ARCoachingOverlayView view.
 struct ARCoachingOverlay: UIViewRepresentable {
+    /// The data source for an AR sesison.
     var sessionProvider: ARSessionProviding?
+    /// The goal for the coaching overlay.
     var goal: ARCoachingOverlayView.Goal
+    /// A Boolean value that indicates if coaching is in progress.
     var active: Bool = false
-
+    
+    /// Controls whether the coaching is in progress.
+    /// - Parameter active: A Boolean value indicating if coaching is in progress.
+    /// - Returns: The `ARCoachingOverlay`.
     func active(_ active: Bool) -> Self {
         var view = self
         view.active = active
         return view
     }
     
+    /// Sets the AR session data source for the coaching overlay.
+    /// - Parameter sessionProvider: The AR session data source.
+    /// - Returns: The `ARCoachingOverlay`.
     func sessionProvider(_ sessionProvider: ARSessionProviding) -> Self {
         var view = self
         view.sessionProvider = sessionProvider

--- a/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARSwiftUIView.swift
@@ -20,8 +20,6 @@ typealias ARViewType = ARSCNView
 struct ARSwiftUIView {
     /// The closure to call when the session's frame updates.
     private(set) var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
-    /// The closure to call when the camera tracking status changes.
-    private(set) var onCameraTrackingStateChangeAction: ((ARSession, ARCamera) -> Void)?
     /// The closure to call when a node corresponding to a new anchor has been added to the view.
     private(set) var onAddNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
     /// The closure to call when a node has been updated to match it's corresponding anchor.
@@ -43,15 +41,6 @@ struct ARSwiftUIView {
     ) -> Self {
         var view = self
         view.onDidUpdateFrameAction = action
-        return view
-    }
-    
-    /// Sets the closure to call when the camera tracking status changes.
-    func onCameraTrackingStateChange(
-        perform action: @escaping (ARSession, ARCamera) -> Void
-    ) -> Self {
-        var view = self
-        view.onCameraTrackingStateChangeAction = action
         return view
     }
     
@@ -86,7 +75,6 @@ extension ARSwiftUIView: UIViewRepresentable {
     
     func updateUIView(_ uiView: ARViewType, context: Context) {
         context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
-        context.coordinator.onCameraTrackingStateChangeAction = onCameraTrackingStateChangeAction
         context.coordinator.onAddNodeAction = onAddNodeAction
         context.coordinator.onUpdateNodeAction = onUpdateNodeAction
     }
@@ -99,16 +87,11 @@ extension ARSwiftUIView: UIViewRepresentable {
 extension ARSwiftUIView {
     class Coordinator: NSObject, ARSCNViewDelegate, ARSessionDelegate {
         var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
-        var onCameraTrackingStateChangeAction: ((ARSession, ARCamera) -> Void)?
         var onAddNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
         var onUpdateNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
         
         func session(_ session: ARSession, didUpdate frame: ARFrame) {
             onDidUpdateFrameAction?(session, frame)
-        }
-        
-        func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
-            onCameraTrackingStateChangeAction?(session, camera)
         }
         
         func renderer(_ renderer: SCNSceneRenderer, didAdd node: SCNNode, for anchor: ARAnchor) {
@@ -151,7 +134,7 @@ class ARSwiftUIViewProxy: NSObject, ARSessionProviding {
     }
 }
 
-struct ARCoachinOverlay: UIViewRepresentable {
+struct ARCoachingOverlay: UIViewRepresentable {
     var sessionProvider: ARSessionProviding?
     var goal: ARCoachingOverlayView.Goal
     var active: Bool = false

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -117,11 +117,16 @@ public struct TableTopSceneView: View {
                     }
                 }
                 .onAppear {
-                    arViewProxy.session?.run(configuration)
+                    arViewProxy.session.run(configuration)
                 }
                 .onDisappear {
-                    arViewProxy.session?.pause()
+                    arViewProxy.session.pause()
                 }
+            
+            ARCoachinOverlay(goal: .horizontalPlane)
+                .sessionProvider(arViewProxy)
+                .active(helpText != .planeFound && initialTransformation == nil)
+                .allowsHitTesting(false)
             
             SceneViewReader { proxy in
                 sceneViewBuilder(proxy)
@@ -285,10 +290,10 @@ private extension ARSwiftUIViewProxy {
             alignment: .any
         ) else { return nil }
         
-        let results = session?.raycast(query)
+        let results = session.raycast(query)
         
         // Get the worldTransform from the first result; if there's no worldTransform, return nil.
-        guard let worldTransform = results?.first?.worldTransform else { return nil }
+        guard let worldTransform = results.first?.worldTransform else { return nil }
         
         // Create our hit test matrix based on the worldTransform location.
         // Right now we ignore the orientation of the plane that was hit to find the point

--- a/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/TableTopSceneView.swift
@@ -124,20 +124,21 @@ public struct TableTopSceneView: View {
                     arViewProxy.session.pause()
                 }
             
-            ARCoachingOverlay(goal: .horizontalPlane)
-                .sessionProvider(arViewProxy)
-                .active(coachingOverlayIsActive)
-                .allowsHitTesting(false)
-                .overlay(alignment: .top) {
-                    if !helpText.isEmpty {
-                        Text(helpText)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(8)
-                            .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
-                            .animation(.easeInOut, value: 1)
+            if !coachingOverlayIsHidden {
+                ARCoachingOverlay(goal: .horizontalPlane)
+                    .sessionProvider(arViewProxy)
+                    .active(coachingOverlayIsActive)
+                    .allowsHitTesting(false)
+                    .overlay(alignment: .top) {
+                        if !helpText.isEmpty {
+                            Text(helpText)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(8)
+                                .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
+                                .animation(.easeInOut, value: 1)
+                        }
                     }
-                }
-                .opacity(coachingOverlayIsHidden ? 0 : 1)
+            }
             
             SceneViewReader { proxy in
                 sceneViewBuilder(proxy)

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -130,14 +130,6 @@ contains one or more facilities in a floor-aware map or scene. */
 trace operation. */
 "Function Results" = "Function Results";
 
-/* An instruction to the user to keep moving their device so that
-horizontal planes can be identified in the AR experience. */
-"Keep moving your device" = "Keep moving your device";
-
-/* A message to the user to notify them that the location of their
-device is unavailable in the AR experience. */
-"Location not available" = "Location not available";
-
 /* A label in reference to media elements contained within a popup. */
 "Media" = "Media";
 
@@ -284,16 +276,6 @@ match the spatial reference of the map. */
 
 /* A label for a button allowing the user to retry an operation. */
 "Try Again" = "Try Again";
-
-/*  An instruction to the user to reduce excessive device motion by
- moving the device more slowly to improve the AR experience which
- requires limited device motion. */
-"Try moving your device more slowly" = "Try moving your device more slowly";
-
-/* An instruction to the user to turn on more lights or move towards a
-light source to improve the AR experience which requires sufficient
-lighting conditions. */
-"Try turning on more lights and moving around" = "Try turning on more lights and moving around";
 
 /* A label to use in place of a utility element asset type name. */
 "Unnamed Asset Type" = "Unnamed Asset Type";


### PR DESCRIPTION
This PR adds a coaching overlay which replaces most help text prompts. The coaching overlay and single help text prompt "Tap a surface to place the scene" can be hidden with a view modifier.