### PR TITLE
AR Flyover: Add initial heading parameter

### DIFF
--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -82,8 +82,8 @@ public struct FlyoverSceneView: View {
     /// be effectively viewed in augmented reality. One such property is the camera controller.
     public init(
         initialLocation: Point,
-        initialHeading: Double? = nil,
         translationFactor: Double,
+        initialHeading: Double? = nil,
         @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
     ) {
         let camera = Camera(

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -36,11 +36,11 @@ public struct FlyoverSceneView: View {
     /// - Parameters:
     ///   - initialLatitude: The initial latitude of the scene view's camera.
     ///   - initialLongitude: The initial longitude of the scene view's camera.
-    ///   - initialHeading: The initial heading of the scene view's camera. A value of `nil` means
-    ///   the scene view's heading will be initially oriented to compass heading.
     ///   - initialAltitude: The initial altitude of the scene view's camera.
     ///   - translationFactor: The translation factor that defines how much the scene view translates
     ///   as the device moves.
+    ///   - initialHeading: The initial heading of the scene view's camera. A value of `nil` means
+    ///   the scene view's heading will be initially oriented to compass heading.
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
     ///   augmented reality video feed.
     /// - Remark: The provided scene view will have certain properties overridden in order to
@@ -49,8 +49,8 @@ public struct FlyoverSceneView: View {
         initialLatitude: Double,
         initialLongitude: Double,
         initialAltitude: Double,
-        initialHeading: Double? = nil,
         translationFactor: Double,
+        initialHeading: Double? = nil,
         @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
     ) {
         let camera = Camera(
@@ -63,8 +63,8 @@ public struct FlyoverSceneView: View {
         )
         self.init(
             initialCamera: camera,
-            shouldOrientToCompass: initialHeading == nil,
             translationFactor: translationFactor,
+            shouldOrientToCompass: initialHeading == nil,
             sceneView: sceneView
         )
     }
@@ -72,10 +72,10 @@ public struct FlyoverSceneView: View {
     /// Creates a fly over scene view.
     /// - Parameters:
     ///   - initialLocation: The initial location of the scene view's camera.
-    ///   - initialHeading: The initial heading of the scene view's camera. A value of `nil` means
-    ///   the scene view's heading will be initially oriented to compass heading.
     ///   - translationFactor: The translation factor that defines how much the scene view translates
     ///   as the device moves.
+    ///   - initialHeading: The initial heading of the scene view's camera. A value of `nil` means
+    ///   the scene view's heading will be initially oriented to compass heading.
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
     ///   augmented reality video feed.
     /// - Remark: The provided scene view will have certain properties overridden in order to
@@ -94,8 +94,8 @@ public struct FlyoverSceneView: View {
         )
         self.init(
             initialCamera: camera,
-            shouldOrientToCompass: initialHeading == nil,
             translationFactor: translationFactor,
+            shouldOrientToCompass: initialHeading == nil,
             sceneView: sceneView
         )
     }
@@ -103,23 +103,23 @@ public struct FlyoverSceneView: View {
     /// Creates a fly over scene view.
     /// - Parameters:
     ///   - initialCamera: The initial camera.
-    ///   - shouldOrientToCompass: A Boolean value indicating whether to orient the scene view's
-    ///   initial heading to compass heading.
     ///   - translationFactor: The translation factor that defines how much the scene view translates
     ///   as the device moves.
+    ///   - shouldOrientToCompass: A Boolean value indicating whether to orient the scene view's
+    ///   initial heading to compass heading.
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
     ///   augmented reality video feed.
     /// - Remark: The provided scene view will have certain properties overridden in order to
     /// be effectively viewed in augmented reality. One such property is the camera controller.
     private init(
         initialCamera: Camera,
-        shouldOrientToCompass: Bool,
         translationFactor: Double,
+        shouldOrientToCompass: Bool,
         @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
     ) {
         self.sceneViewBuilder = sceneView
-        self.translationFactor = translationFactor
         self.shouldOrientToCompass = shouldOrientToCompass
+        self.translationFactor = translationFactor
         self.initialCamera = initialCamera
         
         let cameraController = TransformationMatrixCameraController(originCamera: initialCamera)

--- a/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/AR/FlyoverSceneView.swift
@@ -27,8 +27,6 @@ public struct FlyoverSceneView: View {
     private let shouldOrientToCompass: Bool
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
-    /// The configuration used for the AR session.
-    private let configuration: ARConfiguration
     /// The camera controller that we will set on the scene view.
     @State private var cameraController: TransformationMatrixCameraController
     /// The current interface orientation.
@@ -127,11 +125,6 @@ public struct FlyoverSceneView: View {
         let cameraController = TransformationMatrixCameraController(originCamera: initialCamera)
         cameraController.translationFactor = translationFactor
         _cameraController = .init(initialValue: cameraController)
-        
-        configuration = ARPositionalTrackingConfiguration()
-        if shouldOrientToCompass {
-            configuration.worldAlignment = .gravityAndHeading
-        }
     }
     
     public var body: some View {
@@ -139,6 +132,10 @@ public struct FlyoverSceneView: View {
             sceneViewBuilder(sceneViewProxy)
                 .cameraController(cameraController)
                 .onAppear {
+                    let configuration = ARPositionalTrackingConfiguration()
+                    if shouldOrientToCompass {
+                        configuration.worldAlignment = .gravityAndHeading
+                    }
                     session.start(configuration: configuration)
                 }
                 .onDisappear { session.pause() }


### PR DESCRIPTION
## Description

This PR adds an `initialHeading` parameter to the `FlyoverSceneView` initializers to allow the user to initialize the scene view looking a specific point/object just as they could with a `SceneView`. Passing a value of `nil` as the initial heading sets the heading of the scene to compass heading. This parameter is being re-added as it was removed in #468.

## Linked Issue(s)

- `swift/issues/4625`

## How To Test

- **Note**: As of creation, this PR requires `swift-daily` to compile. 