### PR TITLE
Fix typo in `ARCoachingOverlay`

### DIFF
--- a/Sources/ArcGISToolkit/Components/AR/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/AR/ARCoachingOverlay.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 /// A SwiftUI version of an ARCoachingOverlayView view.
 struct ARCoachingOverlay: UIViewRepresentable {
-    /// The data source for an AR sesison.
+    /// The data source for an AR session.
     var sessionProvider: ARSessionProviding?
     /// The goal for the coaching overlay.
     var goal: ARCoachingOverlayView.Goal


### PR DESCRIPTION
Addresses feedback from AR tutorials PR.