### PR TITLE
`FormView` - Example: Identify features from all layers

### DIFF
--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -104,7 +104,14 @@ extension FormViewExampleView {
            })
             .cancellationToNil()?
             .get()
-            .first {
+            .first(where: { result in
+                if let feature = result.geoElements.first as? ArcGISFeature,
+                   let _ = (feature.table?.layer as? FeatureLayer)?.featureFormDefinition {
+                    return true
+                } else {
+                    return false
+                }
+            }) {
             return identifyLayerResult.geoElements.first as? ArcGISFeature
         }
         return nil

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -106,7 +106,7 @@ extension FormViewExampleView {
             .get()
             .first(where: { result in
                 if let feature = result.geoElements.first as? ArcGISFeature,
-                   let _ = (feature.table?.layer as? FeatureLayer)?.featureFormDefinition {
+                   (feature.table?.layer as? FeatureLayer)?.featureFormDefinition != nil {
                     return true
                 } else {
                     return false

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -96,18 +96,16 @@ extension FormViewExampleView {
     /// - Returns: The first identified feature.
     func identifyFeature(with proxy: MapViewProxy) async -> ArcGISFeature? {
         if let screenPoint = identifyScreenPoint,
-           let feature = try? await Result(awaiting: {
-               try await proxy.identify(
-                on: map.operationalLayers.first!,
+           let identifyLayerResult = try? await Result(awaiting: {
+               try await proxy.identifyLayers(
                 screenPoint: screenPoint,
                 tolerance: 10
                )
            })
             .cancellationToNil()?
             .get()
-            .geoElements
-            .first as? ArcGISFeature {
-            return feature
+            .first {
+            return identifyLayerResult.geoElements.first as? ArcGISFeature
         }
         return nil
     }


### PR DESCRIPTION
This is just a small QOL enhancement so that the example identifies features on any layers. 

The identify code no longer needs to be adjusted depending on which operational layer the target feature is on.

Good maps to test this with are "Wind Turbines" ID ending `...2dba` and Redland's water hydrants `...abe4`