### PR TITLE
Reset VisibleElements in model

### DIFF
--- a/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormViewModel.swift
@@ -53,6 +53,7 @@ public class FormViewModel: ObservableObject {
             self.database = table.serviceGeodatabase
             self.table = table
         }
+        visibleElements = []
     }
     
     deinit {


### PR DESCRIPTION
This resets the form view model's visible elements array when startingEditing, so it doesn't contain remnants from the last invocation of FormView.