### PR TITLE
Simplify identify operation for form view example

### DIFF
--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -100,7 +100,8 @@ struct FormViewExampleView: View {
 extension FormViewExampleView {
     /// Identifies features, if any, at the current screen point.
     /// - Parameter proxy: The proxy to use for identification.
-    /// - Returns: The first identified feature.
+    /// - Returns: The first identified feature in a layer with
+    /// a feature form definition.
     func identifyFeature(with proxy: MapViewProxy) async -> ArcGISFeature? {
         guard let identifyScreenPoint else { return nil }
         let identifyResult = try? await proxy.identifyLayers(

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -102,15 +102,11 @@ extension FormViewExampleView {
     /// - Parameter proxy: The proxy to use for identification.
     /// - Returns: The first identified feature.
     func identifyFeature(with proxy: MapViewProxy) async -> ArcGISFeature? {
-        if let screenPoint = identifyScreenPoint,
-           let identifyLayerResult = try? await Result(awaiting: {
-               try await proxy.identifyLayers(
-                screenPoint: screenPoint,
-                tolerance: 10
-               )
-           })
-            .cancellationToNil()?
-            .get()
+        guard let identifyScreenPoint else { return nil }
+        let identifyResult = try? await proxy.identifyLayers(
+            screenPoint: identifyScreenPoint,
+            tolerance: 10
+        )
             .first(where: { result in
                 if let feature = result.geoElements.first as? ArcGISFeature,
                    (feature.table?.layer as? FeatureLayer)?.featureFormDefinition != nil {
@@ -118,10 +114,8 @@ extension FormViewExampleView {
                 } else {
                     return false
                 }
-            }) {
-            return identifyLayerResult.geoElements.first as? ArcGISFeature
-        }
-        return nil
+            })
+        return identifyResult?.geoElements.first as? ArcGISFeature
     }
 }
 


### PR DESCRIPTION
Simplify the forms example identify code based on the recent Popup identify simplification [here](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/488).