### PR TITLE
Deprecate cancellationToNil

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/Swift/Result.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/Result.swift
@@ -26,7 +26,7 @@ public extension Result where Failure == Error {
     /// Converts the result to a `nil` in the case of a user cancelled error.
     /// - Returns: `Self` or `nil` if there was a cancellation error.
     /// - Attention: Deprecated at 200.3.
-    @available(*, deprecated, message: "Check the 'failure' for 'CancellationError' instead.")
+    @available(*, deprecated, message: "Check the 'failure' case for 'CancellationError' instead.")
     func cancellationToNil() -> Self? {
         guard case .failure(_ as CancellationError) = self else {
             return self

--- a/Sources/ArcGISToolkit/Extensions/Swift/Result.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/Result.swift
@@ -25,6 +25,8 @@ public extension Result where Failure == Error {
     
     /// Converts the result to a `nil` in the case of a user cancelled error.
     /// - Returns: `Self` or `nil` if there was a cancellation error.
+    /// - Attention: Deprecated at 200.3.
+    @available(*, deprecated, message: "Check the 'failure' for 'CancellationError' instead.")
     func cancellationToNil() -> Self? {
         guard case .failure(_ as CancellationError) = self else {
             return self

--- a/Tests/ArcGISToolkitTests/ResultTests.swift
+++ b/Tests/ArcGISToolkitTests/ResultTests.swift
@@ -17,6 +17,7 @@ import XCTest
 
 class ResultTests: XCTestCase {
     /// Tests the conversion of a cancellation error result to `nil.`
+    @available(*, deprecated)
     func testCancellationToNil() {
         var result: Result<String, Error> = .success("hello")
         XCTAssertNotNil(result.cancellationToNil())


### PR DESCRIPTION
it's no longer used in our examples so deprecating it.