### PR TITLE
`FormView` Hide dividers for unsupported form inputs

### DIFF
--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -109,7 +109,8 @@ extension FormView {
         default:
             EmptyView()
         }
-        if element.isVisible {
+        // BarcodeScannerFormInput is not currently supported
+        if element.isVisible && !(element.input is BarcodeScannerFormInput) {
             Divider()
         }
     }


### PR DESCRIPTION
Closes Apollo 270

Test map: `Form All Elements_extraLayers` (presently initial expression evaluation needs to be disabled (Apollo 268))