### PR TITLE
Update `SearchViewModel`, fix nullability

### DIFF
--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -116,7 +116,7 @@ public enum SearchOutcome {
             )
             let currentExtentAvg = (lastExtent.width + lastExtent.height) / 2.0
             let threshold = currentExtentAvg * 0.25
-            isEligibleForRequery = (centerDiff ?? 0.0) > threshold
+            isEligibleForRequery = centerDiff > threshold
         }
     }
     


### PR DESCRIPTION
Change nullability of the center diff value. With the recent changes in ~~`swift/pull/4674`~~ `swift/pull/4433` and others to handle the GeometryEngine exception & nullability, the `distance` method no longer return optional value.

![image](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/9660181/a78f88ab-e0d6-4f03-84d1-bfa269fd1c98)
