### PR TITLE
Initial expression evaluation code

### DIFF
--- a/Sources/ArcGISToolkit/Components/Form/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/Form/FormView.swift
@@ -70,11 +70,11 @@ public struct FormView: View {
             do {
                 isEvaluating = true
                 try await featureForm?.evaluateExpressions()
-                isEvaluating = false
-                model.initializeIsVisibleTasks()
             } catch {
                 print("error evaluating expressions: \(error.localizedDescription)")
             }
+            model.initializeIsVisibleTasks()
+            isEvaluating = false
         }
     }
 }


### PR DESCRIPTION
This allows the form display to continue even if there are initial expression evaluation errors.

Apollo 268