### PR TITLE
AR: Fix Issue with tapping a surface to place a scene in Tabletop Mode on iOS 15

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -247,6 +247,8 @@ private extension View {
                 action(screenPoint)
             }
         } else {
+            // Use a drag gesture with a minimum dragging distance of zero so the
+            // gesture is recognized with a single tap.
             return self.gesture(
                 DragGesture(minimumDistance: 0)
                     .onEnded { dragAttributes in

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -248,7 +248,7 @@ private extension View {
             }
         } else {
             return self.gesture(
-                DragGesture()
+                DragGesture(minimumDistance: 0)
                     .onEnded { dragAttributes in
                         action(dragAttributes.location)
                     }


### PR DESCRIPTION
Fixes the tap gesture bug in iOS 15 for TableTop AR by setting the minimum drag distance to zero.