### PR TITLE
`FloatingPanel` - Improve handling of keyboard closure

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
@@ -105,9 +105,6 @@ private struct FloatingPanelModifier<PanelContent>: ViewModifier where PanelCont
                     isPresented: isPresented,
                     content: panelContent
                 )
-                // When the panel is anchored to the bottom of the screen (compact) ignore the
-                // device's bottom safe area.
-                .ignoresSafeArea(.container, edges: isCompact ? .bottom : [])
                 .frame(maxWidth: isCompact ? .infinity : maxWidth)
             }
     }

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -13,6 +13,30 @@
 
 import SwiftUI
 
+/// A modifier which monitors UIResponder keyboard notifications.
+///
+/// This modifier makes it easy to monitor state changes of the device keyboard.
+struct KeyboardStateChangedModifier: ViewModifier {
+    /// The closure to perform when the keyboard state has changed.
+    var action: (KeyboardState, CGFloat) -> Void
+    
+    @ViewBuilder func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) {
+                action(.opening, ($0.userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! CGRect).height)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) {
+                action(.open, ($0.userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! CGRect).height)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                action(.closing, .zero)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) { _ in
+                action(.closed, .zero)
+            }
+    }
+}
+
 /// A modifier which displays a background and shadow for a view. Used to represent a selected view.
 struct SelectedModifier: ViewModifier {
     /// A Boolean value that indicates whether view should display as selected.
@@ -34,6 +58,12 @@ struct SelectedModifier: ViewModifier {
 }
 
 extension View {
+    /// Sets a closure to perform when the keyboard state has changed.
+    /// - Parameter action: The closure to perform when the keyboard state has changed.
+    @ViewBuilder func onKeyboardStateChanged(_ action: @escaping (KeyboardState, CGFloat) -> Void) -> some View {
+        modifier(KeyboardStateChangedModifier(action: action))
+    }
+    
     /// Returns a new `View` that allows a parent `View` to be informed of a child view's size.
     /// - Parameter perform: The closure to be executed when the content size of the receiver
     /// changes.

--- a/Sources/ArcGISToolkit/Utility/KeyboardState.swift
+++ b/Sources/ArcGISToolkit/Utility/KeyboardState.swift
@@ -1,0 +1,25 @@
+// Copyright 2023 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Represents the current state of the device keyboard.
+enum KeyboardState {
+    /// The keyboard will show.
+    case opening
+    /// The keyboard did show.
+    case open
+    /// The keyboard will hide.
+    case closing
+    /// The keyboard did hide.
+    case closed
+}


### PR DESCRIPTION
Closes Apollo 278

Improves handling of keyboard closure. 

Will open a 2nd PR once this has merged to get these changes into `v.next`.

---

This essentially switches the FloatingPanel over from automatic to manual keyboard avoidance. This allows us to maintain a constant height while the keyboard is closing to rid us of the rubber band effect exhibited in Apollo 278.

---

Note: This should be tested on a physical device with rounded corners if possible. Simulators still show a little jump with the predictive text bar but I tested a bit on a physical device with rounded corners and couldn't reproduce it there.

https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/1eba8ad4-5de3-47a8-9ba1-3d7f40eec2ca

