### PR TITLE
`FormView` - Example: Add interface to confirm cancel

### DIFF
--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -73,16 +73,16 @@ struct FormViewExampleView: View {
                     FormView(featureForm: featureForm)
                         .padding([.horizontal])
                 }
-            
-                .alert("Cancel editing?", isPresented: $isCancelConfirmationPresented) {
-                    Button("Cancel editing", role: .destructive) {
-                        formViewModel.undoEdits()
-                        featureForm = nil
-                        isFormPresented = false
-                    }
-                    Button("Continue editing", role: .cancel) { }
+                .alert("Discard edits", isPresented: $isCancelConfirmationPresented) {
+                        Button("Discard edits", role: .destructive) {
+                            formViewModel.undoEdits()
+                            featureForm = nil
+                            isFormPresented = false
+                        }
+                        Button("Continue editing", role: .cancel) { }
+                } message: {
+                    Text("Updates to this feature will be lost.")
                 }
-            
                 .environmentObject(formViewModel)
                 .navigationBarBackButtonHidden(isFormPresented)
                 .toolbar {
@@ -92,8 +92,7 @@ struct FormViewExampleView: View {
                     ToolbarItem(placement: .navigationBarLeading) {
                         if isFormPresented {
                             Button("Cancel", role: .cancel) {
-                                formViewModel.undoEdits()
-                                isFormPresented = false
+                                isCancelConfirmationPresented = true
                             }
                         }
                     }

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct FormViewExampleView: View {
     /// A Boolean value indicating whether the alert confirming the user's intent to cancel is displayed.
-    @State private var cancelConfirmationIsShowing = false
+    @State private var isCancelConfirmationPresented = false
     
     /// The height to present the form at.
     @State private var detent: FloatingPanelDetent = .full

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -16,6 +16,9 @@ import ArcGISToolkit
 import SwiftUI
 
 struct FormViewExampleView: View {
+    /// A Boolean value indicating whether the alert confirming the user's intent to cancel is displayed.
+    @State private var cancelConfirmationIsShowing = false
+    
     /// The height to present the form at.
     @State private var detent: FloatingPanelDetent = .full
     
@@ -44,7 +47,11 @@ struct FormViewExampleView: View {
                     attributionBarHeight = $0
                 }
                 .onSingleTapGesture { screenPoint, _ in
-                    identifyScreenPoint = screenPoint
+                    if isPresented {
+                        cancelConfirmationIsShowing = true
+                    } else {
+                        identifyScreenPoint = screenPoint
+                    }
                 }
                 .task(id: identifyScreenPoint) {
                     if let feature = await identifyFeature(with: mapViewProxy),
@@ -65,6 +72,15 @@ struct FormViewExampleView: View {
                 ) {
                     FormView(featureForm: featureForm)
                         .padding([.horizontal])
+                }
+            
+                .alert("Cancel editing?", isPresented: $cancelConfirmationIsShowing) {
+                    Button("Cancel editing", role: .destructive) {
+                        formViewModel.undoEdits()
+                        featureForm = nil
+                        isPresented = false
+                    }
+                    Button("Continue editing", role: .cancel) { }
                 }
             
                 .environmentObject(formViewModel)

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -104,7 +104,7 @@ struct FormViewExampleView: View {
                             Button("Submit") {
                                 Task {
                                     await formViewModel.submitChanges()
-                                    isFormPresented = false
+                                    featureForm = nil
                                 }
                             }
                         }

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -16,9 +16,6 @@ import ArcGISToolkit
 import SwiftUI
 
 struct FormViewExampleView: View {
-    /// A Boolean value indicating whether the alert confirming the user's intent to cancel is displayed.
-    @State private var isCancelConfirmationPresented = false
-    
     /// The height to present the form at.
     @State private var detent: FloatingPanelDetent = .full
     
@@ -27,6 +24,9 @@ struct FormViewExampleView: View {
     
     /// The point on the screen the user tapped on to identify a feature.
     @State private var identifyScreenPoint: CGPoint?
+    
+    /// A Boolean value indicating whether the alert confirming the user's intent to cancel is displayed.
+    @State private var isCancelConfirmationPresented = false
     
     /// A Boolean value indicating whether or not the form is displayed.
     @State private var isPresented = false
@@ -48,7 +48,7 @@ struct FormViewExampleView: View {
                 }
                 .onSingleTapGesture { screenPoint, _ in
                     if isPresented {
-                        cancelConfirmationIsShowing = true
+                        isCancelConfirmationPresented = true
                     } else {
                         identifyScreenPoint = screenPoint
                     }
@@ -74,7 +74,7 @@ struct FormViewExampleView: View {
                         .padding([.horizontal])
                 }
             
-                .alert("Cancel editing?", isPresented: $cancelConfirmationIsShowing) {
+                .alert("Cancel editing?", isPresented: $isCancelConfirmationPresented) {
                     Button("Cancel editing", role: .destructive) {
                         formViewModel.undoEdits()
                         featureForm = nil

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -35,7 +35,11 @@ struct FormViewExampleView: View {
     @StateObject private var formViewModel = FormViewModel()
     
     /// The form being edited in the form view.
-    @State private var featureForm: FeatureForm?
+    @State private var featureForm: FeatureForm? {
+        didSet {
+            isFormPresented = featureForm != nil
+        }
+    }
     
     /// The height of the map view's attribution bar.
     @State private var attributionBarHeight: CGFloat = 0
@@ -60,7 +64,6 @@ struct FormViewExampleView: View {
                         self.featureForm = featureForm
                         formViewModel.startEditing(feature, featureForm: featureForm)
                     }
-                    isFormPresented = featureForm != nil
                 }
                 .ignoresSafeArea(.keyboard)
             
@@ -77,7 +80,6 @@ struct FormViewExampleView: View {
                         Button("Discard edits", role: .destructive) {
                             formViewModel.undoEdits()
                             featureForm = nil
-                            isFormPresented = false
                         }
                         Button("Continue editing", role: .cancel) { }
                 } message: {

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -29,7 +29,7 @@ struct FormViewExampleView: View {
     @State private var isCancelConfirmationPresented = false
     
     /// A Boolean value indicating whether or not the form is displayed.
-    @State private var isPresented = false
+    @State private var isFormPresented = false
     
     /// The form view model provides a channel of communication between the form view and its host.
     @StateObject private var formViewModel = FormViewModel()
@@ -47,7 +47,7 @@ struct FormViewExampleView: View {
                     attributionBarHeight = $0
                 }
                 .onSingleTapGesture { screenPoint, _ in
-                    if isPresented {
+                    if isFormPresented {
                         isCancelConfirmationPresented = true
                     } else {
                         identifyScreenPoint = screenPoint
@@ -60,7 +60,7 @@ struct FormViewExampleView: View {
                         self.featureForm = featureForm
                         formViewModel.startEditing(feature, featureForm: featureForm)
                     }
-                    isPresented = featureForm != nil
+                    isFormPresented = featureForm != nil
                 }
                 .ignoresSafeArea(.keyboard)
             
@@ -68,7 +68,7 @@ struct FormViewExampleView: View {
                     attributionBarHeight: attributionBarHeight,
                     selectedDetent: $detent,
                     horizontalAlignment: .leading,
-                    isPresented: $isPresented
+                    isPresented: $isFormPresented
                 ) {
                     FormView(featureForm: featureForm)
                         .padding([.horizontal])
@@ -78,32 +78,32 @@ struct FormViewExampleView: View {
                     Button("Cancel editing", role: .destructive) {
                         formViewModel.undoEdits()
                         featureForm = nil
-                        isPresented = false
+                        isFormPresented = false
                     }
                     Button("Continue editing", role: .cancel) { }
                 }
             
                 .environmentObject(formViewModel)
-                .navigationBarBackButtonHidden(isPresented)
+                .navigationBarBackButtonHidden(isFormPresented)
                 .toolbar {
                     // Once iOS 16.0 is the minimum supported, the two conditionals to show the
                     // buttons can be merged and hoisted up as the root content of the toolbar.
                     
                     ToolbarItem(placement: .navigationBarLeading) {
-                        if isPresented {
+                        if isFormPresented {
                             Button("Cancel", role: .cancel) {
                                 formViewModel.undoEdits()
-                                isPresented = false
+                                isFormPresented = false
                             }
                         }
                     }
                     
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        if isPresented {
+                        if isFormPresented {
                             Button("Submit") {
                                 Task {
                                     await formViewModel.submitChanges()
-                                    isPresented = false
+                                    isFormPresented = false
                                 }
                             }
                         }


### PR DESCRIPTION
This slightly adjusts the behavior of the `FormView` example to confirm and close the form when there is a map tap before opening the next form. This takes care of a condition where a new form isn't displayed properly when another form was already open.

| Before  | After  |
|---|---|
| <video src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/1e5ff073-0369-4417-a6d0-1344803eb99e">  | <video src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/60a45da3-386f-44d1-9e04-41d957c03858">  |