### PR TITLE
Update `Menu` & `DisclosureGroup` usage for Mac Catalyst 17.0

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/AttachmentsPopupElementView.swift
@@ -76,6 +76,7 @@ struct AttachmentsPopupElementView: View {
                             title: popupElement.displayTitle,
                             description: popupElement.description
                         )
+                        .catalystPadding(4)
                     }
                 }
             }

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -43,6 +43,7 @@ struct FieldsPopupElementView: View {
                 title: popupElement.displayTitle,
                 description: popupElement.description
             )
+            .catalystPadding(4)
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
@@ -33,6 +33,7 @@ struct MediaPopupElementView: View {
                     title: popupElement.displayTitle,
                     description: popupElement.description
                 )
+                .catalystPadding(4)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -215,6 +215,8 @@ public struct UtilityNetworkTrace: View {
                             }
                         } label: {
                             Text(elements.count, format: .number)
+                                // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                                .padding([.horizontal], 4)
                         }
                     }
                 }
@@ -227,7 +229,7 @@ public struct UtilityNetworkTrace: View {
         if viewModel.configurations.isEmpty {
             Text(String.noConfigurationsAvailable)
         } else {
-            ForEach(viewModel.configurations, id: \.name) { configuration in
+            ForEach(viewModel.configurations.sorted { $0.name < $1.name }, id: \.name) { configuration in
                 Button {
                     viewModel.setPendingTrace(configuration: configuration)
                     currentActivity = .creatingTrace(nil)
@@ -258,27 +260,32 @@ public struct UtilityNetworkTrace: View {
             if viewModel.networks.count > 1 {
                 Section(String.networkSectionLabel) {
                     DisclosureGroup(
-                        viewModel.network?.name ?? .noneSelected,
-                        isExpanded: Binding(
-                            get: { isFocused(traceCreationActivity: .viewingNetworkOptions) },
-                            set: { currentActivity = .creatingTrace($0 ? .viewingNetworkOptions : nil) }
-                        )
-                    ) {
-                        networksList
-                    }
+                        isExpanded: Binding { 
+                            isFocused(traceCreationActivity: .viewingNetworkOptions)
+                        } set: {
+                            currentActivity = .creatingTrace($0 ? .viewingNetworkOptions : nil)
+                        }) {
+                            networksList
+                        } label: {
+                            Text(viewModel.network?.name ?? .noneSelected)
+                                // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                                .padding([.horizontal], 4)
+                        }
                 }
             }
             Section(String.traceConfigurationSectionLabel) {
                 DisclosureGroup(
-                    viewModel.pendingTrace.configuration?.name ?? .noneSelected,
                     isExpanded: Binding {
                         isFocused(traceCreationActivity: .viewingTraceConfigurations)
                     } set: {
                         currentActivity = .creatingTrace($0 ? .viewingTraceConfigurations : nil)
+                    }) {
+                        configurationsList
+                    } label: {
+                        Text(viewModel.pendingTrace.configuration?.name ?? .noneSelected)
+                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                            .padding([.horizontal], 4)
                     }
-                ) {
-                    configurationsList
-                }
             }
             Section(String.startingPointsTitle) {
                 Button(String.addNewButtonLabel) {
@@ -300,12 +307,13 @@ public struct UtilityNetworkTrace: View {
                             bundle: .toolkitModule,
                             comment: "A label declaring the number of starting points selected for a utility network trace."
                         )
+                        // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                        .padding([.horizontal], 4)
                     }
                 }
             }
             Section {
                 DisclosureGroup(
-                    String.advancedOptionsHeaderLabel,
                     isExpanded: Binding {
                         isFocused(traceCreationActivity: .viewingAdvancedOptions)
                     } set: {
@@ -323,6 +331,10 @@ public struct UtilityNetworkTrace: View {
                         }
                         ColorPicker(String.colorLabel, selection: $viewModel.pendingTrace.color)
                         Toggle(String.zoomToResult, isOn: $shouldZoomOnTraceCompletion)
+                    }, label: {
+                        Text(String.advancedOptionsHeaderLabel)
+                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                            .padding([.horizontal], 4)
                     }
                 )
             }
@@ -390,6 +402,8 @@ public struct UtilityNetworkTrace: View {
                 }
             }
             .font(.title3)
+            // Provide horizontal padding for Menus in Catalyst
+            .padding([.horizontal])
         }
         if activeDetent != .summary {
             List {
@@ -417,6 +431,8 @@ public struct UtilityNetworkTrace: View {
                         }
                     } label: {
                         Text(viewModel.selectedTrace?.elementResults.count ?? 0, format: .number)
+                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                            .padding([.horizontal], 4)
                     }
                 }
                 Section(String.functionResultsSectionTitle) {
@@ -451,11 +467,12 @@ public struct UtilityNetworkTrace: View {
                         }
                     } label: {
                         Text(viewModel.selectedTrace?.utilityFunctionTraceResult?.functionOutputs.count ?? 0, format: .number)
+                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                            .padding([.horizontal], 4)
                     }
                 }
                 Section {
                     DisclosureGroup(
-                        String.advancedOptionsHeaderLabel,
                         isExpanded: Binding {
                             isFocused(traceViewingActivity: .viewingAdvancedOptions)
                         } set: {
@@ -473,6 +490,10 @@ public struct UtilityNetworkTrace: View {
                                 }
                             }
                         )
+                    } label: {
+                        Text(String.advancedOptionsHeaderLabel)
+                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                            .padding([.horizontal], 4)
                     }
                 }
             }
@@ -520,6 +541,8 @@ public struct UtilityNetworkTrace: View {
             }
         }
         .font(.title3)
+        // Provide horizontal padding for Menus in Catalyst
+        .padding([.horizontal])
         List {
             if selectedStartingPoint?.utilityElement?.networkSource.kind == .edge {
                 Section(String.fractionAlongEdgeSectionTitle) {

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -260,17 +260,18 @@ public struct UtilityNetworkTrace: View {
             if viewModel.networks.count > 1 {
                 Section(String.networkSectionLabel) {
                     DisclosureGroup(
-                        isExpanded: Binding { 
+                        isExpanded: Binding {
                             isFocused(traceCreationActivity: .viewingNetworkOptions)
                         } set: {
                             currentActivity = .creatingTrace($0 ? .viewingNetworkOptions : nil)
-                        }) {
-                            networksList
-                        } label: {
-                            Text(viewModel.network?.name ?? .noneSelected)
-                                // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                                .padding([.horizontal], 4)
                         }
+                    ) {
+                        networksList
+                    } label: {
+                        Text(viewModel.network?.name ?? .noneSelected)
+                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                            .padding([.horizontal], 4)
+                    }
                 }
             }
             Section(String.traceConfigurationSectionLabel) {
@@ -279,13 +280,14 @@ public struct UtilityNetworkTrace: View {
                         isFocused(traceCreationActivity: .viewingTraceConfigurations)
                     } set: {
                         currentActivity = .creatingTrace($0 ? .viewingTraceConfigurations : nil)
-                    }) {
-                        configurationsList
-                    } label: {
-                        Text(viewModel.pendingTrace.configuration?.name ?? .noneSelected)
-                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                            .padding([.horizontal], 4)
                     }
+                ) {
+                    configurationsList
+                } label: {
+                    Text(viewModel.pendingTrace.configuration?.name ?? .noneSelected)
+                        // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                        .padding([.horizontal], 4)
+                }
             }
             Section(String.startingPointsTitle) {
                 Button(String.addNewButtonLabel) {
@@ -318,25 +320,25 @@ public struct UtilityNetworkTrace: View {
                         isFocused(traceCreationActivity: .viewingAdvancedOptions)
                     } set: {
                         currentActivity = .creatingTrace($0 ? .viewingAdvancedOptions : nil)
-                    }, content: {
-                        HStack {
-                            Text(String.nameLabel)
-                            Spacer()
-                            TextField(String.nameLabel, text: $viewModel.pendingTrace.name)
+                    }
+                ) {
+                    HStack {
+                        Text(String.nameLabel)
+                        Spacer()
+                        TextField(String.nameLabel, text: $viewModel.pendingTrace.name)
                             .onSubmit {
                                 viewModel.pendingTrace.userDidSpecifyName = true
                             }
                             .multilineTextAlignment(.trailing)
                             .foregroundColor(.blue)
-                        }
-                        ColorPicker(String.colorLabel, selection: $viewModel.pendingTrace.color)
-                        Toggle(String.zoomToResult, isOn: $shouldZoomOnTraceCompletion)
-                    }, label: {
-                        Text(String.advancedOptionsHeaderLabel)
-                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                            .padding([.horizontal], 4)
                     }
-                )
+                    ColorPicker(String.colorLabel, selection: $viewModel.pendingTrace.color)
+                    Toggle(String.zoomToResult, isOn: $shouldZoomOnTraceCompletion)
+                } label: {
+                    Text(String.advancedOptionsHeaderLabel)
+                        // Provide horizontal padding to avoid disclosure triangles in Catalyst
+                        .padding([.horizontal], 4)
+                }
             }
         }
         Button(String.traceButtonLabel) {

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -215,7 +215,7 @@ public struct UtilityNetworkTrace: View {
                             }
                         } label: {
                             Text(elements.count, format: .number)
-                                .catalystPadding()
+                                .catalystPadding(4)
                         }
                     }
                 }
@@ -268,7 +268,7 @@ public struct UtilityNetworkTrace: View {
                         networksList
                     } label: {
                         Text(viewModel.network?.name ?? .noneSelected)
-                            .catalystPadding()
+                            .catalystPadding(4)
                     }
                 }
             }
@@ -283,7 +283,7 @@ public struct UtilityNetworkTrace: View {
                     configurationsList
                 } label: {
                     Text(viewModel.pendingTrace.configuration?.name ?? .noneSelected)
-                        .catalystPadding()
+                        .catalystPadding(4)
                 }
             }
             Section(String.startingPointsTitle) {
@@ -306,7 +306,7 @@ public struct UtilityNetworkTrace: View {
                             bundle: .toolkitModule,
                             comment: "A label declaring the number of starting points selected for a utility network trace."
                         )
-                        .catalystPadding()
+                        .catalystPadding(4)
                     }
                 }
             }
@@ -332,7 +332,7 @@ public struct UtilityNetworkTrace: View {
                     Toggle(String.zoomToResult, isOn: $shouldZoomOnTraceCompletion)
                 } label: {
                     Text(String.advancedOptionsHeaderLabel)
-                        .catalystPadding()
+                        .catalystPadding(4)
                 }
             }
         }
@@ -427,7 +427,7 @@ public struct UtilityNetworkTrace: View {
                         }
                     } label: {
                         Text(viewModel.selectedTrace?.elementResults.count ?? 0, format: .number)
-                            .catalystPadding()
+                            .catalystPadding(4)
                     }
                 }
                 Section(String.functionResultsSectionTitle) {
@@ -462,7 +462,7 @@ public struct UtilityNetworkTrace: View {
                         }
                     } label: {
                         Text(viewModel.selectedTrace?.utilityFunctionTraceResult?.functionOutputs.count ?? 0, format: .number)
-                            .catalystPadding()
+                            .catalystPadding(4)
                     }
                 }
                 Section {
@@ -486,7 +486,7 @@ public struct UtilityNetworkTrace: View {
                         )
                     } label: {
                         Text(String.advancedOptionsHeaderLabel)
-                            .catalystPadding()
+                            .catalystPadding(4)
                     }
                 }
             }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -215,8 +215,7 @@ public struct UtilityNetworkTrace: View {
                             }
                         } label: {
                             Text(elements.count, format: .number)
-                                // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                                .padding([.horizontal], 4)
+                                .catalystPadding()
                         }
                     }
                 }
@@ -269,8 +268,7 @@ public struct UtilityNetworkTrace: View {
                         networksList
                     } label: {
                         Text(viewModel.network?.name ?? .noneSelected)
-                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                            .padding([.horizontal], 4)
+                            .catalystPadding()
                     }
                 }
             }
@@ -285,8 +283,7 @@ public struct UtilityNetworkTrace: View {
                     configurationsList
                 } label: {
                     Text(viewModel.pendingTrace.configuration?.name ?? .noneSelected)
-                        // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                        .padding([.horizontal], 4)
+                        .catalystPadding()
                 }
             }
             Section(String.startingPointsTitle) {
@@ -309,8 +306,7 @@ public struct UtilityNetworkTrace: View {
                             bundle: .toolkitModule,
                             comment: "A label declaring the number of starting points selected for a utility network trace."
                         )
-                        // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                        .padding([.horizontal], 4)
+                        .catalystPadding()
                     }
                 }
             }
@@ -336,8 +332,7 @@ public struct UtilityNetworkTrace: View {
                     Toggle(String.zoomToResult, isOn: $shouldZoomOnTraceCompletion)
                 } label: {
                     Text(String.advancedOptionsHeaderLabel)
-                        // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                        .padding([.horizontal], 4)
+                        .catalystPadding()
                 }
             }
         }
@@ -404,8 +399,7 @@ public struct UtilityNetworkTrace: View {
                 }
             }
             .font(.title3)
-            // Provide horizontal padding for Menus in Catalyst
-            .padding([.horizontal])
+            .catalystPadding()
         }
         if activeDetent != .summary {
             List {
@@ -433,8 +427,7 @@ public struct UtilityNetworkTrace: View {
                         }
                     } label: {
                         Text(viewModel.selectedTrace?.elementResults.count ?? 0, format: .number)
-                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                            .padding([.horizontal], 4)
+                            .catalystPadding()
                     }
                 }
                 Section(String.functionResultsSectionTitle) {
@@ -469,8 +462,7 @@ public struct UtilityNetworkTrace: View {
                         }
                     } label: {
                         Text(viewModel.selectedTrace?.utilityFunctionTraceResult?.functionOutputs.count ?? 0, format: .number)
-                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                            .padding([.horizontal], 4)
+                            .catalystPadding()
                     }
                 }
                 Section {
@@ -494,8 +486,7 @@ public struct UtilityNetworkTrace: View {
                         )
                     } label: {
                         Text(String.advancedOptionsHeaderLabel)
-                            // Provide horizontal padding to avoid disclosure triangles in Catalyst
-                            .padding([.horizontal], 4)
+                            .catalystPadding()
                     }
                 }
             }
@@ -543,8 +534,7 @@ public struct UtilityNetworkTrace: View {
             }
         }
         .font(.title3)
-        // Provide horizontal padding for Menus in Catalyst
-        .padding([.horizontal])
+        .catalystPadding()
         List {
             if selectedStartingPoint?.utilityElement?.networkSource.kind == .edge {
                 Section(String.fractionAlongEdgeSectionTitle) {

--- a/Sources/ArcGISToolkit/Extensions/Swift/MacCatalyst.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/MacCatalyst.swift
@@ -1,0 +1,22 @@
+// Copyright 2023 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A Boolean value indicating whether the target environment is Mac Catalyst or not.
+var isMacCatalyst: Bool {
+#if targetEnvironment(macCatalyst)
+    return true
+#else
+    return false
+#endif
+}

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -80,6 +80,12 @@ extension View {
         .onPreferenceChange(SizePreferenceKey.self, perform: perform)
     }
     
+    /// Adds horizontal padding if the target environment is Mac Catalyst.
+    func catalystPadding() -> some View {
+        return self
+            .padding(isMacCatalyst ? [.horizontal] : [])
+    }
+    
     /// View modifier used to denote the view is selected.
     /// - Parameter isSelected: `true` if the view is selected, `false` otherwise.
     /// - Returns: The modified view.

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -80,10 +80,15 @@ extension View {
         .onPreferenceChange(SizePreferenceKey.self, perform: perform)
     }
     
-    /// Adds horizontal padding if the target environment is Mac Catalyst.
-    func catalystPadding() -> some View {
+    /// Adds an equal padding amount to the horizontal edges of this view if the target environment
+    /// is Mac Catalyst.
+    /// - Parameter length: An amount, given in points, to pad this view on the horizontal edges.
+    /// If you set the value to nil, SwiftUI uses a platform-specific default amount.
+    /// The default value of this parameter is nil.
+    /// - Returns: A view that’s padded by the specified amount on the horizontal edges.
+    func catalystPadding(_ length: CGFloat? = nil) -> some View {
         return self
-            .padding(isMacCatalyst ? [.horizontal] : [])
+            .padding(isMacCatalyst ? [.horizontal] : [], length)
     }
     
     /// View modifier used to denote the view is selected.


### PR DESCRIPTION
Closes #521 

As of 17.0, disclosure triangles in Catalyst appear white whereas they used to be much darker, making this issue more visible:

<img width="105" alt="Screenshot 2023-11-30 at 1 38 06 PM" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/26f561db-66e0-4549-81bf-48f1a611017e">

---

|   | Before | After |
|---|---|---|
| iOS (No change) | <img width="320" alt="iPad-before" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/ff57992b-c8b7-4ef9-8eab-7136d91eacc4"> | <img width="320" alt="iPad-after" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/24249560-cd67-4e50-9088-1230b970f31a"> |
| Catalyst | <img width="400" alt="cat-before" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/62457ca0-db12-4f80-a54c-ab195bd6bd8d"> | <img width="400" alt="cat-after" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/b7368533-1d7c-400a-a9e0-d437e26bbdc4"> |
| Popups (Catalyst) | <img width="400" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/8aadf515-3f83-4b70-b2c9-aae5edf22652"> | <img width="400" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/f92290d8-fa31-4e08-8f30-e35a8ab57930"> |