### PR TITLE
`Bookmarks` - Initializer patch

### DIFF
--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -85,7 +85,7 @@ public struct Bookmarks: View {
         viewpoint: Binding<Viewpoint?>? = nil
     ) {
         _isPresented = isPresented
-        self.bookmarks = bookmarks
+        _bookmarks = State(initialValue: bookmarks)
         self.viewpoint = viewpoint
     }
     
@@ -103,7 +103,7 @@ public struct Bookmarks: View {
     ) {
         self.geoModel = geoModel
         self.viewpoint = viewpoint
-        self.bookmarks = []
+        _bookmarks = State(initialValue: [])
         _isPresented = isPresented
     }
     


### PR DESCRIPTION
Related #533 

This repairs a build error introduced in #525 when using a binary of the Swift SDK.