### PR TITLE
Form View model and validation updates.

### DIFF
--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -64,7 +64,7 @@ struct FormViewExampleView: View {
                     isPresented: $model.isFormPresented
                 ) {
                     if let featureForm = model.featureForm {
-                        FormView(feature: featureForm.feature, featureForm: featureForm)
+                        FormView(featureForm: featureForm)
                             .padding([.horizontal])
                     }
                 }

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -129,6 +129,7 @@ extension FormViewExampleView {
 private extension URL {
     static var sampleData: Self {
         .init(string: "<#URL#>")!
+    }
 }
 
 /// The model class for the form example view

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -29,18 +29,8 @@ struct FormViewExampleView: View {
     /// A Boolean value indicating whether the alert confirming the user's intent to cancel is displayed.
     @State private var isCancelConfirmationPresented = false
     
-    /// A Boolean value indicating whether or not the form is displayed.
-    @State private var isFormPresented = false
-    
     /// The form view model provides a channel of communication between the form view and its host.
-    @StateObject private var formViewModel = FormViewModel()
-    
-    /// The form being edited in the form view.
-    @State private var featureForm: FeatureForm? {
-        didSet {
-            isFormPresented = featureForm != nil
-        }
-    }
+    @StateObject private var model = Model()
     
     /// The height of the map view's attribution bar.
     @State private var attributionBarHeight: CGFloat = 0
@@ -52,7 +42,7 @@ struct FormViewExampleView: View {
                     attributionBarHeight = $0
                 }
                 .onSingleTapGesture { screenPoint, _ in
-                    if isFormPresented {
+                    if model.isFormPresented {
                         isCancelConfirmationPresented = true
                     } else {
                         identifyScreenPoint = screenPoint
@@ -62,8 +52,8 @@ struct FormViewExampleView: View {
                     if let feature = await identifyFeature(with: mapViewProxy),
                        let formDefinition = (feature.table?.layer as? FeatureLayer)?.featureFormDefinition,
                        let featureForm = FeatureForm(feature: feature, definition: formDefinition) {
-                        self.featureForm = featureForm
-                        formViewModel.startEditing(feature, featureForm: featureForm)
+                        model.feature = feature
+                        model.featureForm = featureForm
                     }
                 }
                 .ignoresSafeArea(.keyboard)
@@ -72,28 +62,29 @@ struct FormViewExampleView: View {
                     attributionBarHeight: attributionBarHeight,
                     selectedDetent: $detent,
                     horizontalAlignment: .leading,
-                    isPresented: $isFormPresented
+                    isPresented: $model.isFormPresented
                 ) {
-                    FormView(featureForm: featureForm)
-                        .padding([.horizontal])
+                    if let feature = model.feature, let featureForm = model.featureForm {
+                        FormView(feature: feature, featureForm: featureForm)
+                            .padding([.horizontal])
+                    }
                 }
                 .alert("Discard edits", isPresented: $isCancelConfirmationPresented) {
                         Button("Discard edits", role: .destructive) {
-                            formViewModel.undoEdits()
-                            featureForm = nil
+                            model.undoEdits()
+                            model.featureForm = nil
                         }
                         Button("Continue editing", role: .cancel) { }
                 } message: {
                     Text("Updates to this feature will be lost.")
                 }
-                .environmentObject(formViewModel)
-                .navigationBarBackButtonHidden(isFormPresented)
+                .navigationBarBackButtonHidden(model.isFormPresented)
                 .toolbar {
                     // Once iOS 16.0 is the minimum supported, the two conditionals to show the
                     // buttons can be merged and hoisted up as the root content of the toolbar.
                     
                     ToolbarItem(placement: .navigationBarLeading) {
-                        if isFormPresented {
+                        if model.isFormPresented {
                             Button("Cancel", role: .cancel) {
                                 isCancelConfirmationPresented = true
                             }
@@ -101,11 +92,11 @@ struct FormViewExampleView: View {
                     }
                     
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        if isFormPresented {
+                        if model.isFormPresented {
                             Button("Submit") {
                                 Task {
-                                    await formViewModel.submitChanges()
-                                    featureForm = nil
+                                    await model.submitChanges()
+                                    model.featureForm = nil
                                 }
                             }
                         }
@@ -141,5 +132,50 @@ extension FormViewExampleView {
 private extension URL {
     static var sampleData: Self {
         .init(string: "<#URL#>")!
+    }
+}
+
+/// The model class for the form example view
+class Model: ObservableObject {
+    /// The featured being edited in the form.
+    @Published var feature: ArcGISFeature?
+
+    /// The feature form.
+    @Published var featureForm: FeatureForm? {
+        didSet {
+            isFormPresented = featureForm != nil
+        }
+    }
+    
+    /// A Boolean value indicating whether or not the form is displayed.
+    @Published var isFormPresented = false
+    
+    /// Reverts any local edits that haven't yet been saved to service geodatabase.
+    func undoEdits() {
+        featureForm?.discardEdits()
+    }
+    
+    /// Submit the changes made to the form.
+    func submitChanges() async {
+        guard let feature,
+              let table = feature.table as? ServiceFeatureTable,
+              table.isEditable,
+              let database = table.serviceGeodatabase else {
+            print("A precondition to submit the changes wasn't met.")
+            return
+        }
+        
+        try? await table.update(feature)
+        
+        guard database.hasLocalEdits else {
+            print("No submittable changes found.")
+            return
+        }
+        
+        let results = try? await database.applyEdits()
+        
+        if results?.first?.editResults.first?.didCompleteWithErrors ?? false {
+            print("An error occurred while submitting the changes.")
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/ComboBoxInput.swift
@@ -129,7 +129,7 @@ struct ComboBoxInput: View {
         }
         .padding([.bottom], elementPadding)
         .onAppear {
-            codedValues = model.featureForm!.codedValues(fieldName: element.fieldName)
+            codedValues = model.featureForm.codedValues(fieldName: element.fieldName)
             selectedValue = codedValues.first { $0.name == inputModel.formattedValue }
         }
         .onChange(of: selectedValue) { selectedValue in
@@ -142,7 +142,7 @@ struct ComboBoxInput: View {
             model.evaluateExpressions()
         }
         .onChange(of: inputModel.formattedValue) { _ in
-            let codedValues = model.featureForm!.codedValues(fieldName: element.fieldName)
+            let codedValues = model.featureForm.codedValues(fieldName: element.fieldName)
             selectedValue = codedValues.first { $0.name == inputModel.formattedValue }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/FormInputModel.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/FormInputModel.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 /// A model for an input in a form.
 ///
-/// - Since: 200.3
+/// - Since: 200.4
 class FormInputModel: ObservableObject {
     /// A Boolean value indicating whether a value in the input is required.
     @Published var isRequired: Bool

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/RadioButtonsInput.swift
@@ -107,7 +107,7 @@ struct RadioButtonsInput: View {
             }
             .padding([.bottom], elementPadding)
             .onAppear {
-                codedValues = model.featureForm!.codedValues(fieldName: element.fieldName)
+                codedValues = model.featureForm.codedValues(fieldName: element.fieldName)
                 if let selectedValue = codedValues.first(where: { $0.name == element.formattedValue }) {
                     self.selectedValue = selectedValue
                 } else if !element.formattedValue.isEmpty {

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
@@ -131,7 +131,7 @@ private extension TextInput {
     
     /// The field type of the text input.
     var fieldType: FieldType {
-        model.featureForm!.feature.table!.field(named: element.fieldName)!.type!
+        model.featureForm.feature.table!.field(named: element.fieldName)!.type!
     }
     
     /// The body of the text input when the element is editable.

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
@@ -114,7 +114,9 @@ struct TextInput: View {
             } catch {
                 print(error.localizedDescription)
             }
-            model.evaluateExpressions()
+            if element.isEditable {
+                model.evaluateExpressions()
+            }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FormView/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormView.swift
@@ -25,7 +25,7 @@ public struct FormView: View {
     @StateObject private var model: FormViewModel
     
     /// A Boolean value indicating whether the initial expression evaluation is running.
-    @State var isEvaluating = true
+    @State var isEvaluatingInitialExpressions = true
     
     /// Initializes a form view.
     /// - Parameters:
@@ -38,7 +38,7 @@ public struct FormView: View {
     public var body: some View {
         ScrollViewReader { scrollViewProxy in
             ScrollView {
-                if isEvaluating {
+                if isEvaluatingInitialExpressions {
                     ProgressView()
                 } else {
                     VStack(alignment: .leading) {
@@ -63,9 +63,9 @@ public struct FormView: View {
         .environmentObject(model)
         .task {
             // Perform the initial expression evaluation.
-            isEvaluating = true
+            isEvaluatingInitialExpressions = true
             try? await model.initialEvaluation()
-            isEvaluating = false
+            isEvaluatingInitialExpressions = false
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FormView/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormView.swift
@@ -29,10 +29,9 @@ public struct FormView: View {
     
     /// Initializes a form view.
     /// - Parameters:
-    ///   - feature: The feature to edit.
     ///   - featureForm: The feature form defining the editing experience.
-    public init(feature: ArcGISFeature, featureForm: FeatureForm) {
-        _model = StateObject(wrappedValue: FormViewModel(feature: feature, featureForm: featureForm))
+    public init(featureForm: FeatureForm) {
+        _model = StateObject(wrappedValue: FormViewModel(featureForm: featureForm))
     }
     
     public var body: some View {

--- a/Sources/ArcGISToolkit/Components/FormView/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 /// Forms allow users to edit information about GIS features.
 ///
-/// - Since: 200.3
+/// - Since: 200.4
 public struct FormView: View {
     @Environment(\.formElementPadding) var elementPadding
     

--- a/Sources/ArcGISToolkit/Components/FormView/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormView.swift
@@ -22,21 +22,17 @@ public struct FormView: View {
     @Environment(\.formElementPadding) var elementPadding
     
     /// The model for the ancestral form view.
-    @EnvironmentObject var model: FormViewModel
+    @StateObject private var model: FormViewModel
     
-    /// The form's configuration.
-    private let featureForm: FeatureForm?
-    
-    /// A Boolean value indicating whether an evaluation is running.
+    /// A Boolean value indicating whether the initial expression evaluation is running.
     @State var isEvaluating = true
     
-    /// A list of the visible elements in the form.
-    @State var visibleElements = [FormElement]()
-    
     /// Initializes a form view.
-    /// - Parameter featureForm: The form's configuration.
-    public init(featureForm: FeatureForm?) {
-        self.featureForm = featureForm
+    /// - Parameters:
+    ///   - feature: The feature to edit.
+    ///   - featureForm: The feature form defining the editing experience.
+    public init(feature: ArcGISFeature, featureForm: FeatureForm) {
+        _model = StateObject(wrappedValue: FormViewModel(feature: feature, featureForm: featureForm))
     }
     
     public var body: some View {
@@ -46,7 +42,7 @@ public struct FormView: View {
                     ProgressView()
                 } else {
                     VStack(alignment: .leading) {
-                        FormHeader(title: featureForm?.title)
+                        FormHeader(title: model.featureForm.title)
                             .padding([.bottom], elementPadding)
                         ForEach(model.visibleElements, id: \.self) { element in
                             makeElement(element)
@@ -64,17 +60,11 @@ public struct FormView: View {
             // Allow tall multiline text fields to be scrolled
             immediately: (model.focusedElement as? FieldFormElement)?.input is TextAreaFormInput ? false : true
         )
-        .onChange(of: model.visibleElements) { _ in
-            visibleElements = model.visibleElements
-        }
+        .environmentObject(model)
         .task {
-            do {
-                isEvaluating = true
-                try await featureForm?.evaluateExpressions()
-            } catch {
-                print("error evaluating expressions: \(error.localizedDescription)")
-            }
-            model.initializeIsVisibleTasks()
+            // Peform the initial expression evaluation.
+            isEvaluating = true
+            try? await model.initialEvaluation()
             isEvaluating = false
         }
     }

--- a/Sources/ArcGISToolkit/Components/FormView/FormView.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormView.swift
@@ -62,7 +62,6 @@ public struct FormView: View {
         .environmentObject(model)
         .task {
             // Perform the initial expression evaluation.
-            isEvaluatingInitialExpressions = true
             try? await model.initialEvaluation()
             isEvaluatingInitialExpressions = false
         }

--- a/Sources/ArcGISToolkit/Components/FormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormViewModel.swift
@@ -18,9 +18,6 @@ import SwiftUI
 
 /// - Since: 200.4
 public class FormViewModel: ObservableObject {
-    /// The featured being edited in the form.
-    private(set) var feature: ArcGISFeature
-    
     /// The feature form.
     private(set) var featureForm: FeatureForm
     
@@ -43,8 +40,7 @@ public class FormViewModel: ObservableObject {
     @MainActor @Published var isEvaluating = true
 
     /// Initializes a form view model.
-    public init(feature: ArcGISFeature, featureForm: FeatureForm) {
-        self.feature = feature
+    public init(featureForm: FeatureForm) {
         self.featureForm = featureForm
     }
     

--- a/Sources/ArcGISToolkit/Components/FormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormViewModel.swift
@@ -50,6 +50,7 @@ public class FormViewModel: ObservableObject {
         evaluateTask?.cancel()
     }
     
+    /// Kick off tasks to monitor `isVisible` for each element.
     func initializeIsVisibleTasks() {
         clearIsVisibleTasks()
         
@@ -79,12 +80,14 @@ public class FormViewModel: ObservableObject {
         isVisibleTasks.removeAll()
     }
     
+    /// Performs an initial evaluation of all form expressions.
     @MainActor func initialEvaluation() async throws {
         let evaluationErrors = try? await featureForm.evaluateExpressions()
         expressionEvaluationErrors = evaluationErrors ?? []
         initializeIsVisibleTasks()
     }
 
+    /// Performs an evaluation of all form expressions.
     @MainActor func evaluateExpressions() {
         evaluateTask?.cancel()
         isEvaluating = true

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/FormElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/FormElement.swift
@@ -15,19 +15,6 @@
 import SwiftUI
 import ArcGIS
 
-extension FormElement: Equatable {
-    public static func == (lhs: ArcGIS.FormElement, rhs: ArcGIS.FormElement) -> Bool {
-        lhs === rhs
-    }
-}
-
-extension FormElement: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(description)
-        hasher.combine(label)
-    }
-}
-
 extension FormElement {
     /// The id of the element.
     public var id: ObjectIdentifier {


### PR DESCRIPTION
This splits the original `FormViewModel` used by both the `FormViewExampleView` and `FormView` into two models, so the `FormView` has its own internal model. The `FormViewModel` now has all of the expression evaluation code.

It also simplifies both the example and the form view. 

This will be merged into the `mhd/NewValidationAPI` branch, which will remain until the new Validation API and implementation is complete.