### PR TITLE
`FloatingPanel` - Fix locked detent

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
@@ -41,7 +41,7 @@ public extension View {
     func floatingPanel<Content>(
         attributionBarHeight: CGFloat = 0,
         backgroundColor: Color = Color(uiColor: .systemBackground),
-        selectedDetent: Binding<FloatingPanelDetent> = .constant(.half),
+        selectedDetent: Binding<FloatingPanelDetent>? = nil,
         horizontalAlignment: HorizontalAlignment = .trailing,
         isPresented: Binding<Bool> = .constant(true),
         maxWidth: CGFloat = 400,
@@ -51,7 +51,7 @@ public extension View {
             FloatingPanelModifier(
                 attributionBarHeight: attributionBarHeight,
                 backgroundColor: backgroundColor,
-                selectedDetent: selectedDetent,
+                boundDetent: selectedDetent,
                 horizontalAlignment: horizontalAlignment,
                 isPresented: isPresented,
                 maxWidth: maxWidth,
@@ -75,8 +75,11 @@ private struct FloatingPanelModifier<PanelContent>: ViewModifier where PanelCont
     /// The background color of the floating panel.
     let backgroundColor: Color
     
-    /// A binding to the currently selected detent.
-    let selectedDetent: Binding<FloatingPanelDetent>
+    /// A user provided detent.
+    let boundDetent: Binding<FloatingPanelDetent>?
+    
+    /// A managed detent when a user bound one isn't provided.
+    @State private var managedDetent: FloatingPanelDetent = .half
     
     /// The horizontal alignment of the floating panel.
     let horizontalAlignment: HorizontalAlignment
@@ -96,7 +99,7 @@ private struct FloatingPanelModifier<PanelContent>: ViewModifier where PanelCont
                 FloatingPanel(
                     attributionBarHeight: attributionBarHeight,
                     backgroundColor: backgroundColor,
-                    selectedDetent: selectedDetent,
+                    selectedDetent: boundDetent ?? $managedDetent,
                     isPresented: isPresented,
                     content: panelContent
                 )


### PR DESCRIPTION
I noticed that if no detent binding is provided to the floating panel modifier, the panel will just snap back to half size when the handle is released. This is because we're using a constant binding as the fallback.

<p align="center">
<img width="30%" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/61a07018-04cd-4e2e-8a76-2d51b2313ed2">
</p>