### PR TITLE
State variable updates for events

### DIFF
--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -70,7 +70,7 @@ struct FormViewExampleView: View {
                 }
                 .alert("Discard edits", isPresented: $isCancelConfirmationPresented) {
                         Button("Discard edits", role: .destructive) {
-                            model.undoEdits()
+                            model.discardEdits()
                         }
                         Button("Continue editing", role: .cancel) { }
                 } message: {
@@ -145,7 +145,7 @@ class Model: ObservableObject {
     @Published var isFormPresented = false
     
     /// Reverts any local edits that haven't yet been saved to service geodatabase.
-    func undoEdits() {
+    func discardEdits() {
         featureForm?.discardEdits()
         featureForm = nil
     }

--- a/Examples/Examples/FormViewExampleView.swift
+++ b/Examples/Examples/FormViewExampleView.swift
@@ -133,7 +133,7 @@ private extension URL {
 }
 
 /// The model class for the form example view
-class Model: ObservableObject {
+@MainActor class Model: ObservableObject {
     /// The feature form.
     @Published var featureForm: FeatureForm? {
         didSet {

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/ComboBoxInput.swift
@@ -24,11 +24,12 @@ struct ComboBoxInput: View {
     /// The model for the ancestral form view.
     @EnvironmentObject var model: FormViewModel
     
-    /// State properties for element events.
-    @State var isRequired: Bool = false
-    @State var isEditable: Bool = false
-    @State var value: Any?
-    @State var formattedValue: String = ""
+    // State properties for element events.
+    
+    @State private var isRequired: Bool = false
+    @State private var isEditable: Bool = false
+    @State private var value: Any?
+    @State private var formattedValue: String = ""
 
     /// The set of options in the combo box.
     @State private var codedValues = [CodedValue]()
@@ -77,11 +78,6 @@ struct ComboBoxInput: View {
         let input = element.input as! ComboBoxFormInput
         self.noValueLabel = input.noValueLabel
         self.noValueOption = input.noValueOption
-        
-        value = element.value
-        formattedValue = element.formattedValue
-        isRequired = element.isRequired
-        isEditable = element.isEditable
     }
     
     /// Creates a view for a combo box input.
@@ -135,7 +131,6 @@ struct ComboBoxInput: View {
         .padding([.bottom], elementPadding)
         .onAppear {
             codedValues = model.featureForm.codedValues(fieldName: element.fieldName)
-            selectedValue = codedValues.first { $0.name == formattedValue }
         }
         .onChange(of: selectedValue) { selectedValue in
             requiredValueMissing = isRequired && selectedValue == nil

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/DateTimeInput.swift
@@ -73,6 +73,7 @@ struct DateTimeInput: View {
             requiredValueMissing = isRequired && date == nil
             do {
                 try element.updateValue(date)
+                formattedValue = element.formattedValue
             } catch {
                 print(error.localizedDescription)
             }

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/DateTimeInput.swift
@@ -22,11 +22,11 @@ struct DateTimeInput: View {
     /// The model for the ancestral form view.
     @EnvironmentObject var model: FormViewModel
     
-    /// State properties for element events.
-    @State var isRequired: Bool = false
-    @State var isEditable: Bool = false
-    @State var value: Any?
-    @State var formattedValue: String = ""
+    // State properties for element events.
+    
+    @State private var isRequired: Bool = false
+    @State private var isEditable: Bool = false
+    @State private var formattedValue: String = ""
 
     /// The current date selection.
     @State private var date: Date?
@@ -54,10 +54,6 @@ struct DateTimeInput: View {
         
         self.element = element
         self.input = element.input as! DateTimePickerFormInput
-        value = element.value
-        formattedValue = element.formattedValue
-        isRequired = element.isRequired
-        isEditable = element.isEditable
     }
     
     var body: some View {
@@ -73,13 +69,6 @@ struct DateTimeInput: View {
         .onChange(of: model.focusedElement) { focusedElement in
             isEditing = focusedElement == element
         }
-        .onAppear {
-            if formattedValue.isEmpty {
-                date = nil
-            } else {
-                date = value as? Date
-            }
-        }
         .onChange(of: date) { date in
             requiredValueMissing = isRequired && date == nil
             do {
@@ -90,11 +79,12 @@ struct DateTimeInput: View {
             model.evaluateExpressions()
         }
         .onChangeOfValue(of: element) { newValue, newFormattedValue in
-            if formattedValue.isEmpty {
+            if newFormattedValue.isEmpty {
                 date = nil
             } else {
                 date = newValue as? Date
             }
+            formattedValue = newFormattedValue
         }
         .onChangeOfIsRequired(of: element) { newIsRequired in
             isRequired = newIsRequired
@@ -117,7 +107,7 @@ struct DateTimeInput: View {
     /// - Note: Secondary foreground color is used across input views for consistency.
     @ViewBuilder var dateDisplay: some View {
         HStack {
-            Text(formattedDate ?? .noValue)
+            Text(!formattedValue.isEmpty ? formattedValue : .noValue)
                 .accessibilityIdentifier("\(element.label) Value")
                 .foregroundColor(displayColor)
             
@@ -187,15 +177,6 @@ struct DateTimeInput: View {
             return .accentColor
         } else {
             return .primary
-        }
-    }
-    
-    /// The human-readable date and time selection.
-    var formattedDate: String? {
-        if input.includeTime {
-            return date?.formatted(.dateTime.day().month().year().hour().minute())
-        } else {
-            return date?.formatted(.dateTime.day().month().year())
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/RadioButtonsInput.swift
@@ -24,11 +24,11 @@ struct RadioButtonsInput: View {
     /// The model for the ancestral form view.
     @EnvironmentObject var model: FormViewModel
     
-    /// State properties for element events.
-    @State var isRequired: Bool = false
-    @State var isEditable: Bool = false
-    @State var value: Any?
-    @State var formattedValue: String = ""
+    // State properties for element events.
+    
+    @State private var isRequired: Bool = false
+    @State private var isEditable: Bool = false
+    @State private var value: Any?
 
     /// The set of options in the input.
     @State private var codedValues = [CodedValue]()
@@ -60,11 +60,6 @@ struct RadioButtonsInput: View {
         
         self.element = element
         self.input = element.input as! RadioButtonsFormInput
-        
-        value = element.value
-        formattedValue = element.formattedValue
-        isRequired = element.isRequired
-        isEditable = element.isEditable
     }
     
     var body: some View {
@@ -112,9 +107,7 @@ struct RadioButtonsInput: View {
             .padding([.bottom], elementPadding)
             .onAppear {
                 codedValues = model.featureForm.codedValues(fieldName: element.fieldName)
-                if let selectedValue = codedValues.first(where: { $0.name == element.formattedValue }) {
-                    self.selectedValue = selectedValue
-                } else if !element.formattedValue.isEmpty {
+                if !element.formattedValue.isEmpty {
                     fallbackToComboBox = true
                 }
             }
@@ -129,8 +122,7 @@ struct RadioButtonsInput: View {
             }
             .onChangeOfValue(of: element) { newValue, newFormattedValue in
                 value = newValue
-                formattedValue = newFormattedValue
-                selectedValue = codedValues.first { $0.name == formattedValue }
+                selectedValue = codedValues.first { $0.name == newFormattedValue }
             }
             .onChangeOfIsRequired(of: element) { newIsRequired in
                 isRequired = newIsRequired

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/SwitchInput.swift
@@ -24,11 +24,10 @@ struct SwitchInput: View {
     /// The model for the ancestral form view.
     @EnvironmentObject var model: FormViewModel
     
-    /// State properties for element events.
-    @State var isRequired: Bool = false
-    @State var isEditable: Bool = false
-    @State var value: Any?
-    @State var formattedValue: String = ""
+    // State properties for element events.
+    
+    @State private var isRequired: Bool = false
+    @State private var isEditable: Bool = false
 
     /// A Boolean value indicating whether the current value doesn't exist as an option in the domain.
     ///
@@ -61,11 +60,6 @@ struct SwitchInput: View {
         
         self.element = element
         self.input = element.input as! SwitchFormInput
-        
-        value = element.value
-        formattedValue = element.formattedValue
-        isRequired = element.isRequired
-        isEditable = element.isEditable
     }
     
     var body: some View {
@@ -95,8 +89,6 @@ struct SwitchInput: View {
             .onAppear {
                 if element.formattedValue.isEmpty {
                     fallbackToComboBox = true
-                } else {
-                    isOn = input.onValue.name == formattedValue
                 }
             }
             .onChange(of: isOn) { isOn in
@@ -108,9 +100,7 @@ struct SwitchInput: View {
                 model.evaluateExpressions()
             }
             .onChangeOfValue(of: element) { newValue, newFormattedValue in
-                value = newValue
-                formattedValue = newFormattedValue
-                isOn = formattedValue == input.onValue.name
+                isOn = newFormattedValue == input.onValue.name
             }
             .onChangeOfIsRequired(of: element) { newIsRequired in
                 isRequired = newIsRequired

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
@@ -22,11 +22,11 @@ struct TextInput: View {
     /// The model for the ancestral form view.
     @EnvironmentObject var model: FormViewModel
     
-    /// State properties for element events.
-    @State var isRequired: Bool = false
-    @State var isEditable: Bool = false
-    @State var value: Any?
-    @State var formattedValue: String = ""
+    // State properties for element events.
+    
+    @State private var isRequired: Bool = false
+    @State private var isEditable: Bool = false
+    @State private var formattedValue: String = ""
 
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
@@ -57,11 +57,6 @@ struct TextInput: View {
             "\(Self.self).\(#function) element's input must be \(TextAreaFormInput.self) or \(TextBoxFormInput.self)."
         )
         self.element = element
-
-        value = element.value
-        formattedValue = element.formattedValue
-        isRequired = element.isRequired
-        isEditable = element.isEditable
     }
     
     var body: some View {
@@ -82,9 +77,6 @@ struct TextInput: View {
             fieldType: fieldType
         )
         .padding([.bottom], elementPadding)
-        .onAppear {
-            updateText()
-        }
         .onChange(of: isFocused) { isFocused in
             if isFocused && isPlaceholder {
                 isPlaceholder = false
@@ -117,7 +109,6 @@ struct TextInput: View {
             }
         }
         .onChangeOfValue(of: element) { newValue, newFormattedValue in
-            value = newValue
             formattedValue = newFormattedValue
             updateText()
         }


### PR DESCRIPTION
This updates how @State variables are used in the input types, based on [this](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/548#pullrequestreview-1791819063) discussion.

I've also removed some of that @State properties that weren't needed.