### PR TITLE
`FormView` - Fix for clearing nullable numeric fields

### DIFF
--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
@@ -215,10 +215,10 @@ private extension TextInput {
 private extension FieldFormElement {
     /// Attempts to convert the value to a type suitable for the element's field type and then update
     /// the element with the converted value.
-    func convertAndUpdateValue(_ value: String?) throws {
+    func convertAndUpdateValue(_ value: String) throws {
         if fieldType == .text {
             try updateValue(value)
-        } else if let fieldType, let value {
+        } else if let fieldType {
             if fieldType.isNumeric && value.isEmpty {
                 try updateValue(nil)
             } else if fieldType == .int16, let value = Int16(value) {

--- a/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FormView/FormInputs/TextInput.swift
@@ -216,9 +216,11 @@ private extension FieldFormElement {
     /// Attempts to convert the value to a type suitable for the element's field type and then update
     /// the element with the converted value.
     func convertAndUpdateValue(_ value: String?) throws {
-        if let value {
-            if fieldType == .text {
-                try updateValue(value)
+        if fieldType == .text {
+            try updateValue(value)
+        } else if let fieldType, let value {
+            if fieldType.isNumeric && value.isEmpty {
+                try updateValue(nil)
             } else if fieldType == .int16, let value = Int16(value) {
                 try updateValue(value)
             } else if fieldType == .int32, let value = Int32(value) {
@@ -230,8 +232,6 @@ private extension FieldFormElement {
             } else if fieldType == .float64, let value = Float64(value) {
                 try updateValue(value)
             }
-        } else {
-            try updateValue(nil)
         }
     }
 }


### PR DESCRIPTION
The current logic doesn't allow nullable numeric fields to be cleared by the user.