### PR TITLE
Don't show error text for thumbnail errors

### DIFF
--- a/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
+++ b/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
@@ -86,16 +86,11 @@ public struct AsyncImageView: View {
                 } else {
                     ProgressView()
                 }
-            case .failure(let error):
+            case .failure(_):
                 HStack(alignment: .center) {
                     Image(systemName: "exclamationmark.circle")
                         .aspectRatio(contentMode: .fit)
                         .foregroundColor(.red)
-                    Text(
-                        "An error occurred loading the image: \(error.localizedDescription).",
-                        bundle: .toolkitModule,
-                        comment: "A fallback message to display when an image cannot be loaded."
-                    )
                 }
                 .padding([.top, .bottom])
             }


### PR DESCRIPTION
Displaying the error text for an image load error clogs of the view; don't show the error text.