### PR TITLE
`FeatureFormView` - Character indicator and test repair

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
@@ -59,7 +59,7 @@ struct InputFooter: View {
             }
             .accessibilityIdentifier("\(element.label) Footer")
             Spacer()
-            if model.focusedElement == element, element.fieldType == .text, element.description.isEmpty || primaryError != nil {
+            if isShowingCharacterIndicator {
                 Text(element.formattedValue.count, format: .number)
                     .accessibilityIdentifier("\(element.label) Character Indicator")
             }
@@ -187,7 +187,14 @@ extension InputFooter {
         }
     }
     
-    /// Determines whether an error is showing in the footer.
+    /// A Boolean value which indicates whether or not the character indicator is showing in the footer.
+    var isShowingCharacterIndicator: Bool {
+        model.focusedElement == element
+        && (element.input is TextAreaFormInput || element.input is TextBoxFormInput)
+        && (element.description.isEmpty || primaryError != nil)
+    }
+    
+    /// A Boolean value which indicates whether or not an error is showing in the footer.
     var isShowingError: Bool {
         element.isEditable && primaryError != nil && model.previouslyFocusedFields.contains(element)
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -66,12 +66,15 @@ struct TextInput: View {
         InputHeader(label: element.label, isRequired: isRequired)
             .padding([.top], elementPadding)
         if isEditable {
-            textField
+            textWriter
         } else {
-            Text(text.isEmpty ? "--" : text)
-                .padding([.horizontal], 10)
-                .padding([.vertical], 5)
-                .textSelection(.enabled)
+            if isMultiline {
+                textReader
+            } else {
+                ScrollView(.horizontal) {
+                    textReader
+                }
+            }
         }
         InputFooter(element: element, error: inputError)
         .padding([.bottom], elementPadding)
@@ -132,8 +135,17 @@ private extension TextInput {
         }
     }
     
+    /// The body of the text input when the element is non-editable.
+    var textReader: some View {
+        Text(text.isEmpty ? "--" : text)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .textSelection(.enabled)
+            .lineLimit(isMultiline ? nil : 1)
+    }
+    
     /// The body of the text input when the element is editable.
-    var textField: some View {
+    var textWriter: some View {
         HStack(alignment: .bottom) {
             Group {
                 if #available(iOS 16.0, *) {

--- a/UI Test Runner/UI Test Runner.xcodeproj/project.pbxproj
+++ b/UI Test Runner/UI Test Runner.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		75022F942A7AC289000ED7B7 /* FormViewTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75022F932A7AC289000ED7B7 /* FormViewTestView.swift */; };
 		75022F962A7AC9A0000ED7B7 /* FormViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75022F952A7AC9A0000ED7B7 /* FormViewTests.swift */; };
 		7552A7542A573CBB0023DA5A /* UITestRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7552A7532A573CBB0023DA5A /* UITestRunner.swift */; };
 		7552A7562A573CBB0023DA5A /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7552A7552A573CBB0023DA5A /* Tests.swift */; };
@@ -24,6 +23,7 @@
 		75B2366B2A5CB8CE00AEFACE /* BasemapGalleryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B2366A2A5CB8CE00AEFACE /* BasemapGalleryTests.swift */; };
 		75B2366D2A5CC78C00AEFACE /* FloorFilterTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B2366C2A5CC78C00AEFACE /* FloorFilterTestView.swift */; };
 		75B2366F2A5CCADC00AEFACE /* FloorFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B2366E2A5CCADC00AEFACE /* FloorFilterTests.swift */; };
+		8A9F898F2B5B4F0A0027215E /* FeatureFormTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,7 +37,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		75022F932A7AC289000ED7B7 /* FormViewTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewTestView.swift; sourceTree = "<group>"; };
 		75022F952A7AC9A0000ED7B7 /* FormViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewTests.swift; sourceTree = "<group>"; };
 		7552A7502A573CBB0023DA5A /* UI Test Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "UI Test Runner.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7552A7532A573CBB0023DA5A /* UITestRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRunner.swift; sourceTree = "<group>"; };
@@ -57,6 +56,7 @@
 		75B2366C2A5CC78C00AEFACE /* FloorFilterTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorFilterTestView.swift; sourceTree = "<group>"; };
 		75B2366E2A5CCADC00AEFACE /* FloorFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorFilterTests.swift; sourceTree = "<group>"; };
 		75CCCD612A5F691E0098B059 /* UI Test Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "UI Test Runner.entitlements"; sourceTree = "<group>"; };
+		8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureFormTestView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,10 +152,10 @@
 		75B236672A5CB32700AEFACE /* TestViews */ = {
 			isa = PBXGroup;
 			children = (
+				8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */,
 				75B236682A5CB49B00AEFACE /* BasemapGalleryTestView.swift */,
 				7584B7532B1A798B00772AB7 /* BookmarksTestViews */,
 				75B2366C2A5CC78C00AEFACE /* FloorFilterTestView.swift */,
-				75022F932A7AC289000ED7B7 /* FormViewTestView.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -264,13 +264,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				7552A7562A573CBB0023DA5A /* Tests.swift in Sources */,
-				75022F942A7AC289000ED7B7 /* FormViewTestView.swift in Sources */,
 				7552A7542A573CBB0023DA5A /* UITestRunner.swift in Sources */,
 				7584B7552B1A79DD00772AB7 /* BookmarksTestViews.swift in Sources */,
 				75B2366D2A5CC78C00AEFACE /* FloorFilterTestView.swift in Sources */,
 				7552A7622A573D810023DA5A /* BookmarksTestCase1View.swift in Sources */,
 				7584B7592B1A817A00772AB7 /* BookmarksTestCase3View.swift in Sources */,
 				7584B7572B1A7AF100772AB7 /* BookmarksTestCase2View.swift in Sources */,
+				8A9F898F2B5B4F0A0027215E /* FeatureFormTestView.swift in Sources */,
 				7584B75B2B1A824300772AB7 /* BookmarksTestCase4View.swift in Sources */,
 				75B236692A5CB49B00AEFACE /* BasemapGalleryTestView.swift in Sources */,
 			);

--- a/UI Test Runner/UITests/FormViewTests.swift
+++ b/UI Test Runner/UITests/FormViewTests.swift
@@ -42,7 +42,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
         
         app.launch()
@@ -112,7 +112,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let returnButton = app.buttons["Return"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
         
@@ -196,7 +196,7 @@ final class FeatureFormViewTests: XCTestCase {
         let characterIndicator = app.staticTexts["Single Line No Value, Placeholder or Description Character Indicator"]
         let clearButton = app.buttons["Single Line No Value, Placeholder or Description Clear Button"]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let formTitle = app.staticTexts["InputValidation"]
         let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
         let returnButton = app.buttons["Return"]
@@ -290,7 +290,7 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let footer = app.staticTexts["numbers Footer"]
         let formTitle = app.staticTexts["Domain"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let textField = app.textFields["numbers Text Input"]
         
         app.launch()
@@ -355,7 +355,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["Required Date Value"]
         let footer = app.staticTexts["Required Date Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let nowButton = app.buttons["Required Date Now Button"]
         
         app.launch()
@@ -426,7 +426,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["Launch Date and Time for Apollo 11 Value"]
         let footer = app.staticTexts["Launch Date and Time for Apollo 11 Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let nowButton = app.buttons["Launch Date and Time for Apollo 11 Now Button"]
         
         app.launch()
@@ -495,7 +495,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["Launch Date for Apollo 11 Value"]
         let footer = app.staticTexts["Launch Date for Apollo 11 Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let todayButton = app.buttons["Launch Date for Apollo 11 Today Button"]
         
         app.launch()
@@ -559,7 +559,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["Launch Date Time End Value"]
         let footer = app.staticTexts["Launch Date Time End Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let nowButton = app.buttons["Launch Date Time End Now Button"]
         
         app.launch()
@@ -624,7 +624,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["start and end date time Value"]
         let footer = app.staticTexts["start and end date time Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let nowButton = app.buttons["start and end date time Now Button"]
         let previousMonthButton = datePicker.buttons["Previous Month"]
         let julyFirstButton = datePicker.collectionViews.staticTexts["1"]
@@ -686,7 +686,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Launch Date and Time for Apollo 11"]
         let fieldValue = app.staticTexts["Launch Date and Time for Apollo 11 Value"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         
         app.launch()
         
@@ -728,7 +728,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Combo String"]
         let fieldValue = app.staticTexts["Combo String Value"]
         let formTitle = app.staticTexts["comboBox"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let footer = app.staticTexts["Combo String Footer"]
         
         app.launch()
@@ -788,7 +788,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Combo Integer"]
         let fieldValue = app.staticTexts["Combo Integer Value"]
         let formTitle = app.staticTexts["comboBox"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let optionsButton = app.images["Combo Integer Options Button"]
         
         app.launch()
@@ -833,7 +833,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["Combo String Value"]
         let firstOptionButton = app.buttons["String 1"]
         let formTitle = app.staticTexts["comboBox"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         
         app.launch()
         
@@ -892,7 +892,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Combo String"]
         let fieldValue = app.staticTexts["Combo String Value"]
         let formTitle = app.staticTexts["comboBox"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let noValueButton = app.buttons["No value"]
         
         app.launch()
@@ -949,7 +949,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["Required Combo Box Value"]
         let footer = app.staticTexts["Required Combo Box Footer"]
         let formTitle = app.staticTexts["comboBox"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let noValueButton = app.buttons["No value"]
         let oakButton = app.buttons["Oak"]
         
@@ -1033,7 +1033,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldValue = app.staticTexts["Combo No Value False Value"]
         let firstOption = app.buttons["First"]
         let formTitle = app.staticTexts["comboBox"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let noValueButton = app.buttons["No Value"]
         let optionsButton = app.images["Combo No Value False Options Button"]
         
@@ -1100,7 +1100,7 @@ final class FeatureFormViewTests: XCTestCase {
         let birdOptionCheckmark = app.images["Radio Button Text bird Checkmark"]
         let fieldTitle = app.staticTexts["Radio Button Text"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let dogOption = app.buttons["Radio Button Text dog"]
         let dogOptionCheckmark = app.images["Radio Button Text dog Checkmark"]
         let noValueOption = app.buttons["Radio Button Text No Value"]
@@ -1158,7 +1158,7 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let fieldTitle = app.staticTexts["switch integer"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let switchLabel = app.staticTexts["switch integer Switch Label"]
         let switchView = app.switches["switch integer Switch"]
         
@@ -1198,7 +1198,7 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let fieldTitle = app.staticTexts["switch string"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let switchLabel = app.staticTexts["switch string Switch Label"]
         let switchView = app.switches["switch string Switch"]
         
@@ -1244,7 +1244,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["switch double"]
         let fieldValue = app.staticTexts["switch double Value"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         
         app.launch()
         
@@ -1279,7 +1279,7 @@ final class FeatureFormViewTests: XCTestCase {
         let expandedGroup = app.disclosureTriangles["Group with Multiple Form Elements"]
         let expandedGroupDescription = app.staticTexts["Group with Multiple Form Elements Description"]
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         
         app.launch()
         
@@ -1331,7 +1331,7 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_6_2() {
         let app = XCUIApplication()
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
-        let formViewTestsButton = app.buttons["FormView Tests"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
         let showElementsButton = app.buttons["show invisible form element"]
         let hiddenElementsGroup = app.disclosureTriangles["Group with children that are visible dependent"]
         let hiddenElementsGroupDescription = app.staticTexts["Group with children that are visible dependent Description"]


### PR DESCRIPTION
Apollo 384

- Mark B reported:
  - Character indicators are showing in radio fields. This fixes that.
  - Read-only `TextArea`s with long values are wrapping onto multiple lines. This changes them to be a horizontally scrollable single-line.
- UI test repairs