### PR TITLE
Add did change status action to `ARSwiftUIView`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/ARSwiftUIView.swift
@@ -40,7 +40,7 @@ struct ARSwiftUIView {
     
     /// Sets the closure to call when the session's geo-tracking state changes.
     /// 
-    /// ARKit invokes this callback only for `ARGeoTrackingConfiguration` sessions.
+    /// ARKit invokes the callback only for `ARGeoTrackingConfiguration` sessions.
     func onDidChangeStatus(
         perform action: @escaping (ARSession, ARGeoTrackingStatus) -> Void
     ) -> Self {
@@ -88,7 +88,7 @@ extension ARSwiftUIView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: ARViewType, context: Context) {
-        context.coordinator.onDidChangeStatusAction = onDidChangeStatusAction
+        context.coordinator.onDidChangeGeoTrackingStatusAction = onDidChangeStatusAction
         context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
         context.coordinator.onAddNodeAction = onAddNodeAction
         context.coordinator.onUpdateNodeAction = onUpdateNodeAction
@@ -101,13 +101,13 @@ extension ARSwiftUIView: UIViewRepresentable {
 
 extension ARSwiftUIView {
     class Coordinator: NSObject, ARSCNViewDelegate, ARSessionDelegate {
-        var onDidChangeStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
+        var onDidChangeGeoTrackingStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
         var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
         var onAddNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
         var onUpdateNodeAction: ((SCNSceneRenderer, SCNNode, ARAnchor) -> Void)?
         
         func session(_ session: ARSession, didChange geoTrackingStatus: ARGeoTrackingStatus) {
-            onDidChangeStatusAction?(session, geoTrackingStatus)
+            onDidChangeGeoTrackingStatusAction?(session, geoTrackingStatus)
         }
         
         func session(_ session: ARSession, didUpdate frame: ARFrame) {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/ARSwiftUIView.swift
@@ -20,7 +20,7 @@ typealias ARViewType = ARSCNView
 /// A SwiftUI version of an AR view.
 struct ARSwiftUIView {
     /// The closure to call when the session's geo-tracking state changes.
-    private(set) var onDidChangeStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
+    private(set) var onDidChangeGeoTrackingStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
     /// The closure to call when the session's frame updates.
     private(set) var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
     /// The closure to call when a node corresponding to a new anchor has been added to the view.
@@ -41,11 +41,11 @@ struct ARSwiftUIView {
     /// Sets the closure to call when the session's geo-tracking state changes.
     /// 
     /// ARKit invokes the callback only for `ARGeoTrackingConfiguration` sessions.
-    func onDidChangeStatus(
+    func onDidChangeGeoTrackingStatus(
         perform action: @escaping (ARSession, ARGeoTrackingStatus) -> Void
     ) -> Self {
         var view = self
-        view.onDidChangeStatusAction = action
+        view.onDidChangeGeoTrackingStatusAction = action
         return view
     }
     
@@ -88,7 +88,7 @@ extension ARSwiftUIView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: ARViewType, context: Context) {
-        context.coordinator.onDidChangeGeoTrackingStatusAction = onDidChangeStatusAction
+        context.coordinator.onDidChangeGeoTrackingStatusAction = onDidChangeGeoTrackingStatusAction
         context.coordinator.onDidUpdateFrameAction = onDidUpdateFrameAction
         context.coordinator.onAddNodeAction = onAddNodeAction
         context.coordinator.onUpdateNodeAction = onUpdateNodeAction

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -193,8 +193,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
         // If initial camera is not set, then we set it the flag here to true
         // and set the status text to empty.
         if !initialCameraIsSet {
-            initialCameraIsSet = true
             coachingOverlayIsActive = false
+            initialCameraIsSet = true
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -99,6 +99,17 @@ public struct WorldScaleGeoTrackingSceneView: View {
                             orientation: interfaceOrientation
                         )
                     }
+                    .onDidChangeStatus { _, geoTrackingStatus in
+                        switch geoTrackingStatus.state {
+                        case .localized:
+                            // Inactivate the overlay when geo-tracking is localized.
+                            coachingOverlayIsActive = false
+                        case .notAvailable, .initializing, .localizing:
+                            return
+                        @unknown default:
+                            fatalError("Unknown geo-tracking status.")
+                        }
+                    }
                 
                 if initialCameraIsSet {
                     sceneViewBuilder(sceneViewProxy)
@@ -193,7 +204,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
         // If initial camera is not set, then we set it the flag here to true
         // and set the status text to empty.
         if !initialCameraIsSet {
-            coachingOverlayIsActive = false
             initialCameraIsSet = true
         }
     }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -99,17 +99,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
                             orientation: interfaceOrientation
                         )
                     }
-                    .onDidChangeStatus { _, geoTrackingStatus in
-                        switch geoTrackingStatus.state {
-                        case .localized:
-                            // Inactivate the overlay when geo-tracking is localized.
-                            coachingOverlayIsActive = false
-                        case .notAvailable, .initializing, .localizing:
-                            return
-                        @unknown default:
-                            fatalError("Unknown geo-tracking status.")
-                        }
-                    }
                 
                 if initialCameraIsSet {
                     sceneViewBuilder(sceneViewProxy)
@@ -205,6 +194,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
         // and set the status text to empty.
         if !initialCameraIsSet {
             initialCameraIsSet = true
+            coachingOverlayIsActive = false
         }
     }
     


### PR DESCRIPTION
## Description

Add modifier to receive geo tracking status changed events. ref doc: https://developer.apple.com/documentation/arkit/arsessionobserver/3580878-session

After this PR is merged, follow up PRs will…

- Adjust the coaching overlay dismiss condition
- Incorporate a few condition checks in `swift/issues/4875`
- Switch between `ARGeoTrackingConfiguration` based on the geo tracking [accuracy](https://developer.apple.com/documentation/arkit/argeotrackingstatus/accuracy)
    - Let user optionally pass in the configuration object when creating the view.