### PR TITLE
AR: Add calibration view

### DIFF
--- a/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
+++ b/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
@@ -35,9 +35,6 @@ struct WorldScaleGeoTrackingExampleView: View {
         return scene
     }()
     
-    /// The basemap opacity.
-    @State private var opacity: Float = 1
-    /// The graphics overlay which shows a graphic around your initial location.
     @State private var graphicsOverlay = GraphicsOverlay()
     /// The location datasource that is used to access the device location.
     @State private var locationDataSource = SystemLocationDataSource()
@@ -54,13 +51,6 @@ struct WorldScaleGeoTrackingExampleView: View {
                         }
                     }
             }
-            // A slider to adjust the basemap opacity.
-            Slider(value: $opacity, in: 0...1)
-                .padding(.horizontal)
-        }
-        .onChange(of: opacity) { opacity in
-            guard let basemap = scene.basemap else { return }
-            basemap.baseLayers.forEach { $0.opacity = opacity }
         }
         .task {
             // Request when-in-use location authorization.

--- a/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
+++ b/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
@@ -44,7 +44,7 @@ struct WorldScaleGeoTrackingExampleView: View {
     
     var body: some View {
         VStack {
-            WorldScaleGeoTrackingSceneView(locationDataSource: locationDataSource) { proxy in
+            WorldScaleGeoTrackingSceneView(locationDataSource: locationDataSource, scene: scene) { proxy in
                 SceneView(scene: scene, graphicsOverlays: [graphicsOverlay])
                     .onSingleTapGesture { screen, _ in
                         print("Identifying...")

--- a/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
+++ b/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
@@ -54,6 +54,7 @@ struct WorldScaleGeoTrackingExampleView: View {
                         }
                     }
             }
+            .calibrationViewAlignment(.bottomLeading)
             // A slider to adjust the basemap opacity.
             Slider(value: $opacity, in: 0...1)
                 .padding(.horizontal)

--- a/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
+++ b/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
@@ -35,13 +35,16 @@ struct WorldScaleGeoTrackingExampleView: View {
         return scene
     }()
     
+    /// The basemap opacity.
+    @State private var opacity: Float = 1
+    /// The graphics overlay which shows a graphic around your initial location.
     @State private var graphicsOverlay = GraphicsOverlay()
     /// The location datasource that is used to access the device location.
     @State private var locationDataSource = SystemLocationDataSource()
     
     var body: some View {
         VStack {
-            WorldScaleGeoTrackingSceneView(locationDataSource: locationDataSource, scene: scene) { proxy in
+            WorldScaleGeoTrackingSceneView(locationDataSource: locationDataSource) { proxy in
                 SceneView(scene: scene, graphicsOverlays: [graphicsOverlay])
                     .onSingleTapGesture { screen, _ in
                         print("Identifying...")
@@ -51,6 +54,13 @@ struct WorldScaleGeoTrackingExampleView: View {
                         }
                     }
             }
+            // A slider to adjust the basemap opacity.
+            Slider(value: $opacity, in: 0...1)
+                .padding(.horizontal)
+                .onChange(of: opacity) { opacity in
+                    guard let basemap = scene.basemap else { return }
+                    basemap.baseLayers.forEach { $0.opacity = opacity }
+                }
         }
         .task {
             // Request when-in-use location authorization.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -150,7 +150,9 @@ private struct JoystickSliderView: View {
             if !editingChanged {
                 timer?.invalidate()
                 timer = nil
-                value = 0.0
+                withAnimation {
+                    value = 0.0
+                }
             }
         }
         .onChange(of: value) { value in

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -119,7 +119,8 @@ extension WorldScaleGeoTrackingSceneView {
                         setBasemapOpacity(0)
                     }
                 }
-                .frame(minWidth: 250, maxWidth: UIScreen.main.bounds.width/3)
+                .frame(idealWidth: UIScreen.main.bounds.width/3)
+                .fractionPresentationDetents(0.25)
                 .padding()
             }
             .esriBorder()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -120,9 +120,13 @@ extension WorldScaleGeoTrackingSceneView {
                     Button {
                         viewModel.isCalibrating = false
                     } label: {
-                        Image(systemName: "xmark.circle")
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 20))
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.secondary)
                             .imageScale(.large)
                     }
+                    .buttonStyle(.plain)
                     .frame(alignment: .topTrailing)
                     .padding()
                 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -23,8 +23,6 @@ extension WorldScaleGeoTrackingSceneView {
         @Binding var heading: Double
         /// The camera controller elevation.
         @Binding var elevation: Double
-        /// The calibrated elevation delta.
-        @Binding var elevationDelta: Double
         /// A Boolean value that indicates if the user is calibrating.
         @Binding var isCalibrating: Bool
         
@@ -92,14 +90,14 @@ extension WorldScaleGeoTrackingSceneView {
                             Spacer()
                         }
                     } onIncrement: {
-                        elevationDelta += 1
+                        elevation += 1
                     } onDecrement: {
-                        elevationDelta -= 1
+                        elevation -= 1
                     }
                 }
                 JoystickSliderView()
                     .onSliderDeltaValueChanged { delta in
-                        elevationDelta = delta
+                        elevation += delta
                     }
             }
         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -44,7 +44,7 @@ extension WorldScaleGeoTrackingSceneView {
             .padding()
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 15))
-            .frame(maxWidth: 350)
+            .frame(maxWidth: 414)
             .padding()
         }
         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -76,7 +76,7 @@ extension WorldScaleGeoTrackingSceneView {
                     }
                 }
                 VStack {
-                    Text("Elevation: \(viewModel.calibrationElevation?.rounded(.towardZero) ?? viewModel.cameraController.originCamera.location.z?.rounded(.towardZero) ?? 0, format: .number)")
+                    Text("Elevation: \(viewModel.calibrationElevation?.rounded(.towardZero) ?? viewModel.cameraController.originCamera.location.z?.rounded(.towardZero) ?? 0, format: .number) m")
                     HStack {
                         Button {
                             updateElevation(by: -1)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -107,7 +107,6 @@ extension WorldScaleGeoTrackingSceneView {
         @ViewBuilder
         var dismissButton: some View {
             Button {
-                viewModel.setBasemapOpacity(0)
                 withAnimation {
                     viewModel.isCalibrating = false
                 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -129,7 +129,7 @@ extension WorldScaleGeoTrackingSceneView {
                 .padding(.trailing, -20)
                 .padding(.top, -30)
             }
-            .frame(maxWidth: 300)
+            .frame(maxWidth: 350)
             .padding()
             .padding(.top, 10)
             .background(.regularMaterial)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -120,14 +120,18 @@ extension WorldScaleGeoTrackingSceneView {
                     Button {
                         viewModel.isCalibrating = false
                     } label: {
-                        Text("Done")
+                        Image(systemName: "xmark.circle")
+                            .imageScale(.large)
                     }
                     .frame(alignment: .topTrailing)
-                    
+                    .padding()
                 }
+                .padding([.trailing], -20)
+                .padding([.top,], -30)
             }
             .frame(maxWidth: .infinity)
             .padding()
+            .padding([.top], 10)
             .background(.regularMaterial)
         }
         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -1,0 +1,190 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ARKit
+import SwiftUI
+import ArcGIS
+
+extension WorldScaleGeoTrackingSceneView {
+    /// A view that allows the user to calibrate the heading of the scene view camera controller.
+    struct CalibrationView: View {
+        let scene: ArcGIS.Scene
+        /// The camera controller that will be set on the scene view.
+        @State private var cameraController: TransformationMatrixCameraController
+        /// A Boolean value that indicates if the AR experince is being calibrated.
+        @State private var isCalibrating = false
+        /// The calibrated camera heading.
+        @State private var calibrationHeading: Double?
+        /// The calibrated camera elevation.
+        @State private var calibrationElevation: Double?
+        /// The slider value for the camera heading.
+        @State private var headingSliderValue = 0.0
+        /// The slider value for the camera elevation.
+        @State private var elevationSliderValue = 0.0
+        /// The elevation timer for the "joystick" behavior.
+        @State private var headingTimer: Timer?
+        /// The heading timer for the "joystick" behavior.
+        @State private var elevationTimer: Timer?
+        /// The heading delta amount based on the heading slider value.
+        private var joystickHeadingDelta: Double {
+            Double(signOf: headingSliderValue, magnitudeOf: headingSliderValue * headingSliderValue / 25)
+        }
+        /// The elevation delta amount based on the elevation slider value.
+        private var joystickElevationDelta: Double {
+            Double(signOf: elevationSliderValue, magnitudeOf: elevationSliderValue * elevationSliderValue / 100)
+        }
+        
+        init(
+            scene: ArcGIS.Scene,
+            cameraController: TransformationMatrixCameraController,
+            isCalibrating: Bool,
+            calibrationHeading: Double?,
+            calibrationElevation: Double?
+        ) {
+            self.scene = scene
+            self.cameraController = cameraController
+            self.isCalibrating = isCalibrating
+            self.calibrationHeading = calibrationHeading
+            self.calibrationElevation = calibrationElevation
+        }
+        
+        var body: some View {
+            Button {
+                isCalibrating = true
+                setBasemapOpacity(0.5)
+            } label: {
+                Text("Calibrate")
+            }
+            .popover(isPresented: $isCalibrating) {
+                VStack {
+                    Text("Heading: \(calibrationHeading?.rounded(.towardZero) ?? cameraController.originCamera.heading.rounded(.towardZero), format: .number)")
+                    
+                    HStack {
+                        Button {
+                            let heading = cameraController.originCamera.heading - 1
+                            updateHeading(heading)
+                        } label: {
+                            Image(systemName: "minus")
+                        }
+                        Slider(value: $headingSliderValue, in: -10...10) { editingChanged in
+                            if !editingChanged {
+                                headingTimer?.invalidate()
+                                headingTimer = nil
+                                headingSliderValue = 0.0
+                            }
+                        }
+                        .onChange(of: headingSliderValue) { heading in
+                            
+                            guard headingTimer == nil else { return }
+                            // Create a timer which rotates the camera when fired.
+                            let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
+                                rotateHeading(joystickHeadingDelta)
+                            }
+                            headingTimer = timer
+                            // Add the timer to the main run loop.
+                            RunLoop.main.add(timer, forMode: .default)
+                        }
+                        
+                        Button {
+                            let heading = cameraController.originCamera.heading + 1
+                            updateHeading(heading)
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                    }
+                    VStack {
+                        Text("Elevation: \(calibrationElevation?.rounded(.towardZero) ?? cameraController.originCamera.location.z?.rounded(.towardZero) ?? 0, format: .number)")
+                        HStack {
+                            Button {
+                                updateElevation(-1)
+                            } label: {
+                                Image(systemName: "minus")
+                            }
+                            Slider(value: $elevationSliderValue, in: -20...20) { editingChanged in
+                                if !editingChanged {
+                                    elevationTimer?.invalidate()
+                                    elevationTimer = nil
+                                    elevationSliderValue = 0.0
+                                }
+                            }
+                            .onChange(of: elevationSliderValue) { elevation in
+                                
+                                guard elevationTimer == nil else { return }
+                                // Create a timer which rotates the camera when fired.
+                                let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
+                                    updateElevation(joystickElevationDelta)
+                                }
+                                elevationTimer = timer
+                                // Add the timer to the main run loop.
+                                RunLoop.main.add(timer, forMode: .default)
+                            }
+                            Button {
+                                updateElevation(1)
+                            } label: {
+                                Image(systemName: "plus")
+                            }
+                        }
+                    }
+                }
+                .onDisappear {
+                    guard !isCalibrating else { return }
+                    withAnimation(.easeInOut) {
+                        setBasemapOpacity(0)
+                    }
+                }
+                .frame(minWidth: 200, maxHeight: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
+                .padding()
+            }
+        }
+        
+        /// Sets the basemap base layers with the given opacity.
+        /// - Parameter opacity: The opacity of the layer.
+        private func setBasemapOpacity(_ opacity: Float) {
+            guard let basemap = scene.basemap else { return }
+            basemap.baseLayers.forEach { $0.opacity = opacity }
+        }
+        
+        /// Updates the heading of the scene view camera controller.
+        /// - Parameter heading: The camera heading.
+        private func updateHeading(_ heading: Double) {
+            cameraController.originCamera = cameraController.originCamera.rotatedTo(
+                heading: heading,
+                pitch: cameraController.originCamera.pitch,
+                roll: cameraController.originCamera.roll
+            )
+            calibrationHeading = heading
+        }
+        
+        /// Rotates the heading of the scene view camera controller by the heading delta in degrees.
+        /// - Parameter headingDelta: The heading delta in degrees.
+        private func rotateHeading(_ headingDelta: Double) {
+            let newHeading = cameraController.originCamera.heading + headingDelta
+            cameraController.originCamera = cameraController.originCamera.rotatedTo(
+                heading: newHeading,
+                pitch: cameraController.originCamera.pitch,
+                roll: cameraController.originCamera.roll
+            )
+            calibrationHeading = newHeading
+        }
+        
+        /// Elevates the scene view camera controller by the elevation delta.
+        /// - Parameter elevationDelta: The elevation delta.
+        private func updateElevation(_ elevationDelta: Double) {
+            cameraController.originCamera = cameraController.originCamera.elevated(by: elevationDelta)
+            if let elevation = cameraController.originCamera.location.z {
+                calibrationElevation = elevation
+            }
+        }
+    }
+}

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -44,9 +44,10 @@ extension WorldScaleGeoTrackingSceneView {
                 HStack {
                     Button {
                         let heading = viewModel.cameraController.originCamera.heading - 1
-                        updateHeading(heading)
+                        updateHeading(to: heading)
                     } label: {
                         Image(systemName: "minus")
+                            .imageScale(.large)
                     }
                     Slider(value: $headingSliderValue, in: -10...10) { editingChanged in
                         if !editingChanged {
@@ -58,8 +59,8 @@ extension WorldScaleGeoTrackingSceneView {
                     .onChange(of: headingSliderValue) { heading in
                         guard headingTimer == nil else { return }
                         // Create a timer which rotates the camera when fired.
-                        let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
-                            rotateHeading(joystickHeadingDelta)
+                        let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
+                            rotateHeading(by: joystickHeadingDelta)
                         }
                         headingTimer = timer
                         // Add the timer to the main run loop.
@@ -68,18 +69,20 @@ extension WorldScaleGeoTrackingSceneView {
                     
                     Button {
                         let heading = viewModel.cameraController.originCamera.heading + 1
-                        updateHeading(heading)
+                        updateHeading(to: heading)
                     } label: {
                         Image(systemName: "plus")
+                            .imageScale(.large)
                     }
                 }
                 VStack {
                     Text("Elevation: \(viewModel.calibrationElevation?.rounded(.towardZero) ?? viewModel.cameraController.originCamera.location.z?.rounded(.towardZero) ?? 0, format: .number)")
                     HStack {
                         Button {
-                            updateElevation(-1)
+                            updateElevation(by: -1)
                         } label: {
                             Image(systemName: "minus")
+                                .imageScale(.large)
                         }
                         Slider(value: $elevationSliderValue, in: -20...20) { editingChanged in
                             if !editingChanged {
@@ -91,17 +94,18 @@ extension WorldScaleGeoTrackingSceneView {
                         .onChange(of: elevationSliderValue) { elevation in
                             guard elevationTimer == nil else { return }
                             // Create a timer which rotates the camera when fired.
-                            let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
-                                updateElevation(joystickElevationDelta)
+                            let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
+                                updateElevation(by: joystickElevationDelta)
                             }
                             elevationTimer = timer
                             // Add the timer to the main run loop.
                             RunLoop.main.add(timer, forMode: .default)
                         }
                         Button {
-                            updateElevation(1)
+                            updateElevation(by: 1)
                         } label: {
                             Image(systemName: "plus")
+                                .imageScale(.large)
                         }
                     }
                 }
@@ -129,7 +133,7 @@ extension WorldScaleGeoTrackingSceneView {
         
         /// Updates the heading of the scene view camera controller.
         /// - Parameter heading: The camera heading.
-        private func updateHeading(_ heading: Double) {
+        private func updateHeading(to heading: Double) {
             viewModel.cameraController.originCamera = viewModel.cameraController.originCamera.rotatedTo(
                 heading: heading,
                 pitch: viewModel.cameraController.originCamera.pitch,
@@ -140,7 +144,7 @@ extension WorldScaleGeoTrackingSceneView {
         
         /// Rotates the heading of the scene view camera controller by the heading delta in degrees.
         /// - Parameter headingDelta: The heading delta in degrees.
-        private func rotateHeading(_ headingDelta: Double) {
+        private func rotateHeading(by headingDelta: Double) {
             let newHeading = viewModel.cameraController.originCamera.heading + headingDelta
             viewModel.cameraController.originCamera = viewModel.cameraController.originCamera.rotatedTo(
                 heading: newHeading,
@@ -152,7 +156,7 @@ extension WorldScaleGeoTrackingSceneView {
         
         /// Elevates the scene view camera controller by the elevation delta.
         /// - Parameter elevationDelta: The elevation delta.
-        private func updateElevation(_ elevationDelta: Double) {
+        private func updateElevation(by elevationDelta: Double) {
             viewModel.cameraController.originCamera = viewModel.cameraController.originCamera.elevated(by: elevationDelta)
             if let elevation = viewModel.cameraController.originCamera.location.z {
                 viewModel.calibrationElevation = elevation

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -108,9 +108,7 @@ extension WorldScaleGeoTrackingSceneView {
             }
             .onDisappear {
                 guard !viewModel.isCalibrating else { return }
-                withAnimation(.easeInOut) {
-                    setBasemapOpacity(0)
-                }
+                viewModel.setBasemapOpacity(0)
             }
             .overlay(alignment: .topTrailing) {
                 HStack {
@@ -127,13 +125,6 @@ extension WorldScaleGeoTrackingSceneView {
             .frame(maxWidth: .infinity)
             .padding()
             .background(.regularMaterial)
-        }
-        
-        /// Sets the basemap base layers with the given opacity.
-        /// - Parameter opacity: The opacity of the layer.
-        private func setBasemapOpacity(_ opacity: Float) {
-            guard let basemap = viewModel.scene.basemap else { return }
-            basemap.baseLayers.forEach { $0.opacity = opacity }
         }
         
         /// Updates the heading of the scene view camera controller.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -25,6 +25,10 @@ extension WorldScaleGeoTrackingSceneView {
         @Binding var elevation: Double
         /// A Boolean value that indicates if the user is calibrating.
         @Binding var isCalibrating: Bool
+        /// The initial camera controller elevation.
+        @Binding var initialElevation: Double
+        /// The elevation delta value after calibrating.
+        @State private var elevationDelta = 0.0
         
         var body: some View {
             VStack {
@@ -58,6 +62,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
+                            Text(heading.isLess(than: 0) || heading.isZero ? "" : "+") +
                             Text(heading, format: .number.precision(.fractionLength(0)))
                             + Text("°")
                             Spacer()
@@ -85,7 +90,8 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(elevation, format: .number.precision(.fractionLength(0)))
+                            Text(elevationDelta.isLess(than: 0) || elevationDelta.isZero ? "" : "+") +
+                            Text(elevationDelta, format: .number.precision(.fractionLength(0)))
                             + Text(" m")
                             Spacer()
                         }
@@ -99,6 +105,12 @@ extension WorldScaleGeoTrackingSceneView {
                     .onSliderDeltaValueChanged { delta in
                         elevation += delta
                     }
+            }
+            .onChange(of: elevation) { elevation in
+                elevationDelta =  elevation - initialElevation
+            }
+            .onAppear {
+                elevationDelta =  elevation - initialElevation
             }
         }
         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -121,7 +121,7 @@ extension WorldScaleGeoTrackingSceneView {
                         viewModel.isCalibrating = false
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 20))
+                            .font(.title3)
                             .symbolRenderingMode(.hierarchical)
                             .foregroundStyle(.secondary)
                             .imageScale(.large)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -43,8 +43,7 @@ extension WorldScaleGeoTrackingSceneView {
                 
                 HStack {
                     Button {
-                        let heading = viewModel.cameraController.originCamera.heading - 1
-                        updateHeading(to: heading)
+                        rotateHeading(by: -1)
                     } label: {
                         Image(systemName: "minus")
                             .imageScale(.large)
@@ -68,8 +67,7 @@ extension WorldScaleGeoTrackingSceneView {
                     }
                     
                     Button {
-                        let heading = viewModel.cameraController.originCamera.heading + 1
-                        updateHeading(to: heading)
+                        rotateHeading(by: 1)
                     } label: {
                         Image(systemName: "plus")
                             .imageScale(.large)
@@ -139,18 +137,6 @@ extension WorldScaleGeoTrackingSceneView {
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 15))
             .padding()
-        }
-        
-        /// Updates the heading of the scene view camera controller.
-        /// - Parameter heading: The camera heading.
-        private func updateHeading(to heading: Double) {
-            let originCamera = viewModel.cameraController.originCamera
-            viewModel.cameraController.originCamera = originCamera.rotatedTo(
-                heading: heading,
-                pitch: originCamera.pitch,
-                roll: originCamera.roll
-            )
-            viewModel.calibrationHeading = heading
         }
         
         /// Rotates the heading of the scene view camera controller by the heading delta in degrees.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -44,7 +44,7 @@ extension WorldScaleGeoTrackingSceneView {
             .padding()
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 15))
-            .frame(maxWidth: 414)
+            .frame(maxWidth: 430)
             .padding()
         }
         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -73,7 +73,7 @@ extension WorldScaleGeoTrackingSceneView {
                     }
                 }
                 JoystickSliderView()
-                    .onSliderValueChanged { delta in
+                    .onSliderDeltaValueChanged { delta in
                         rotateHeading(by: delta)
                     }
             }
@@ -100,7 +100,7 @@ extension WorldScaleGeoTrackingSceneView {
                     }
                 }
                 JoystickSliderView()
-                    .onSliderValueChanged { delta in
+                    .onSliderDeltaValueChanged { delta in
                         updateElevation(by: delta)
                     }
             }
@@ -156,8 +156,8 @@ struct JoystickSliderView: View {
     private var joystickDelta: Double {
         Double(signOf: value, magnitudeOf: value * value / 25)
     }
-    /// User defined action to be performed when the slider value changes.
-    var sliderValueChangedAction: ((Double) -> Void)? = nil
+    /// User defined action to be performed when the slider delta value changes.
+    var sliderDeltaValueChangedAction: ((Double) -> Void)? = nil
     
     var body: some View {
         Slider(value: $value, in: -10...10) { editingChanged in
@@ -169,12 +169,11 @@ struct JoystickSliderView: View {
         }
         .onChange(of: value) { value in
             guard timer == nil else { return }
-            // Create a timer which rotates the camera when fired.
+            // Start a timer when slider is active.
             let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
-                if let onSliderValueChanged = sliderValueChangedAction {
-                    // Returns the joystick slider delta value
-                    // when the slider value changes.
-                    onSliderValueChanged(joystickDelta)
+                if let onSliderDeltaValueChanged = sliderDeltaValueChangedAction {
+                    // Returns the joystick slider delta value.
+                    onSliderDeltaValueChanged(joystickDelta)
                 }
             }
             self.timer = timer
@@ -183,13 +182,13 @@ struct JoystickSliderView: View {
         }
     }
     
-    /// Sets an action to perform when the slider value changes.
-    /// - Parameter action: The action to perform when the slider value has changed.
-    public func onSliderValueChanged(
+    /// Sets an action to perform when the slider delta value changes.
+    /// - Parameter action: The action to perform when the slider delta value has changed.
+    public func onSliderDeltaValueChanged(
         perform action: @escaping (Double) -> Void
     ) -> JoystickSliderView {
         var copy = self
-        copy.sliderValueChangedAction = action
+        copy.sliderDeltaValueChangedAction = action
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -121,7 +121,7 @@ extension WorldScaleGeoTrackingSceneView {
 }
 
 /// A view for a joystick style slider.
-struct JoystickSliderView: View {
+private struct JoystickSliderView: View {
     /// The slider value.
     @State private var value = 0.0
     /// The timer for the "joystick" behavior.
@@ -158,7 +158,7 @@ struct JoystickSliderView: View {
     
     /// Sets an action to perform when the slider delta value changes.
     /// - Parameter action: The action to perform when the slider delta value has changed.
-    public func onSliderDeltaValueChanged(
+    func onSliderDeltaValueChanged(
         perform action: @escaping (Double) -> Void
     ) -> JoystickSliderView {
         var copy = self

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -63,6 +63,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .foregroundStyle(.secondary)
                             Spacer()
                             Text((viewModel.calibrationHeading ?? viewModel.cameraController.originCamera.heading), format: .number.precision(.fractionLength(0)))
+                            + Text("°")
                             Spacer()
                         }
                     } onIncrement: {
@@ -84,11 +85,12 @@ extension WorldScaleGeoTrackingSceneView {
                 HStack {
                     Stepper() {
                         HStack {
-                            Text("Elevation (m)")
+                            Text("Elevation")
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
                             Text((viewModel.calibrationElevation ?? viewModel.cameraController.originCamera.location.z ?? 0), format: .number.precision(.fractionLength(0)))
+                            + Text(" m")
                             Spacer()
                         }
                     } onIncrement: {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -62,7 +62,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text((viewModel.calibrationHeading ?? viewModel.cameraController.originCamera.heading).formatted(.number.noFractionalDigits))
+                            Text((viewModel.calibrationHeading ?? viewModel.cameraController.originCamera.heading), format: .number.precision(.fractionLength(0)))
                             Spacer()
                         }
                     } onIncrement: {
@@ -88,7 +88,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text((viewModel.calibrationElevation ?? viewModel.cameraController.originCamera.location.z ?? 0).formatted(.number.noFractionalDigits))
+                            Text((viewModel.calibrationElevation ?? viewModel.cameraController.originCamera.location.z ?? 0), format: .number.precision(.fractionLength(0)))
                             Spacer()
                         }
                     } onIncrement: {
@@ -189,11 +189,5 @@ struct JoystickSliderView: View {
         var copy = self
         copy.sliderValueChangedAction = action
         return copy
-    }
-}
-
-private extension FloatingPointFormatStyle {
-    var noFractionalDigits: FloatingPointFormatStyle<Value> {
-        precision(.fractionLength(0...0))
     }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -37,6 +37,10 @@ extension WorldScaleGeoTrackingSceneView {
             Double(signOf: elevationSliderValue, magnitudeOf: elevationSliderValue * elevationSliderValue / 100)
         }
         
+        init(viewModel: ViewModel) {
+            self.viewModel = viewModel
+        }
+        
         var body: some View {
             Button {
                 viewModel.isCalibrating = true
@@ -63,7 +67,6 @@ extension WorldScaleGeoTrackingSceneView {
                             }
                         }
                         .onChange(of: headingSliderValue) { heading in
-                            
                             guard headingTimer == nil else { return }
                             // Create a timer which rotates the camera when fired.
                             let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
@@ -97,7 +100,6 @@ extension WorldScaleGeoTrackingSceneView {
                                 }
                             }
                             .onChange(of: elevationSliderValue) { elevation in
-                                
                                 guard elevationTimer == nil else { return }
                                 // Create a timer which rotates the camera when fired.
                                 let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
@@ -123,6 +125,9 @@ extension WorldScaleGeoTrackingSceneView {
                 }
                 .frame(minWidth: 200, maxHeight: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
                 .padding()
+            }
+            .onChange(of: viewModel.scene.basemap?.loadStatus) { loadStatus in
+                viewModel.scene.basemap?.baseLayers.forEach( { $0.opacity = 0 })
             }
         }
         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -63,7 +63,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .foregroundStyle(.secondary)
                             Spacer()
                             Text(heading.isLess(than: 0) || heading.rounded().isZero ? "" : "+") +
-                            Text(heading, format: .number.precision(.fractionLength(0)))
+                            Text((heading.truncatingRemainder(dividingBy: 180)), format: .number.precision(.fractionLength(0)))
                             + Text("°")
                             Spacer()
                         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -123,12 +123,12 @@ extension WorldScaleGeoTrackingSceneView {
                         setBasemapOpacity(0)
                     }
                 }
-                .frame(minWidth: 250, maxWidth: UIScreen.main.bounds.width/3, alignment: .bottomLeading)
+                .frame(minWidth: 250, maxWidth: UIScreen.main.bounds.width/3)
                 .padding()
             }
+            .esriBorder()
             .padding([.horizontal], 10)
             .padding([.vertical], 10)
-            .esriBorder()
         }
         
         /// Sets the basemap base layers with the given opacity.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -39,38 +39,40 @@ extension WorldScaleGeoTrackingSceneView {
         
         var body: some View {
             VStack {
-                Text("Heading: \(viewModel.calibrationHeading?.rounded(.towardZero) ?? viewModel.cameraController.originCamera.heading.rounded(.towardZero), format: .number)")
-                
-                HStack {
-                    Button {
-                        rotateHeading(by: -1)
-                    } label: {
-                        Image(systemName: "minus")
-                            .imageScale(.large)
-                    }
-                    Slider(value: $headingSliderValue, in: -10...10) { editingChanged in
-                        if !editingChanged {
-                            headingTimer?.invalidate()
-                            headingTimer = nil
-                            headingSliderValue = 0.0
-                        }
-                    }
-                    .onChange(of: headingSliderValue) { heading in
-                        guard headingTimer == nil else { return }
-                        // Create a timer which rotates the camera when fired.
-                        let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
-                            rotateHeading(by: joystickHeadingDelta)
-                        }
-                        headingTimer = timer
-                        // Add the timer to the main run loop.
-                        RunLoop.main.add(timer, forMode: .default)
-                    }
+                VStack {
+                    Text("Heading: \(viewModel.calibrationHeading?.rounded(.towardZero) ?? viewModel.cameraController.originCamera.heading.rounded(.towardZero), format: .number)")
                     
-                    Button {
-                        rotateHeading(by: 1)
-                    } label: {
-                        Image(systemName: "plus")
-                            .imageScale(.large)
+                    HStack {
+                        Button {
+                            rotateHeading(by: -1)
+                        } label: {
+                            Image(systemName: "minus")
+                                .imageScale(.large)
+                        }
+                        Slider(value: $headingSliderValue, in: -10...10) { editingChanged in
+                            if !editingChanged {
+                                headingTimer?.invalidate()
+                                headingTimer = nil
+                                headingSliderValue = 0.0
+                            }
+                        }
+                        .onChange(of: headingSliderValue) { heading in
+                            guard headingTimer == nil else { return }
+                            // Create a timer which rotates the camera when fired.
+                            let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
+                                rotateHeading(by: joystickHeadingDelta)
+                            }
+                            headingTimer = timer
+                            // Add the timer to the main run loop.
+                            RunLoop.main.add(timer, forMode: .default)
+                        }
+                        
+                        Button {
+                            rotateHeading(by: 1)
+                        } label: {
+                            Image(systemName: "plus")
+                                .imageScale(.large)
+                        }
                     }
                 }
                 VStack {
@@ -109,28 +111,23 @@ extension WorldScaleGeoTrackingSceneView {
                 }
             }
             .overlay(alignment: .topTrailing) {
-                HStack {
-                    Spacer()
-                    Button {
+                Button {
+                    viewModel.setBasemapOpacity(0)
+                    withAnimation {
                         viewModel.isCalibrating = false
-                        viewModel.setBasemapOpacity(0)
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.title3)
-                            .symbolRenderingMode(.hierarchical)
-                            .foregroundStyle(.secondary)
-                            .imageScale(.large)
                     }
-                    .buttonStyle(.plain)
-                    .frame(alignment: .topTrailing)
-                    .padding()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title3)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                        .imageScale(.large)
                 }
-                .padding(.trailing, -20)
-                .padding(.top, -30)
+                .buttonStyle(.plain)
+                .padding([.top, .trailing], -5)
             }
             .frame(maxWidth: 350)
             .padding()
-            .padding(.top, 10)
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 15))
             .padding()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -37,10 +37,6 @@ extension WorldScaleGeoTrackingSceneView {
             Double(signOf: elevationSliderValue, magnitudeOf: elevationSliderValue * elevationSliderValue / 100)
         }
         
-        init(viewModel: ViewModel) {
-            self.viewModel = viewModel
-        }
-        
         var body: some View {
             Button {
                 viewModel.isCalibrating = true

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -133,7 +133,7 @@ extension WorldScaleGeoTrackingSceneView {
             .padding()
             .padding(.top, 10)
             .background(.regularMaterial)
-            .cornerRadius(10)
+            .clipShape(RoundedRectangle(cornerRadius: 15))
             .shadow(radius: 50)
         }
         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -108,15 +108,12 @@ extension WorldScaleGeoTrackingSceneView {
                     }
                 }
             }
-            .onDisappear {
-                guard !viewModel.isCalibrating else { return }
-                viewModel.setBasemapOpacity(0)
-            }
             .overlay(alignment: .topTrailing) {
                 HStack {
                     Spacer()
                     Button {
                         viewModel.isCalibrating = false
+                        viewModel.setBasemapOpacity(0)
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .font(.title3)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -129,12 +129,12 @@ extension WorldScaleGeoTrackingSceneView {
                 .padding(.trailing, -20)
                 .padding(.top, -30)
             }
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: 300)
             .padding()
             .padding(.top, 10)
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 15))
-            .shadow(radius: 50)
+            .padding()
         }
         
         /// Updates the heading of the scene view camera controller.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -62,7 +62,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(heading.isLess(than: 0) || heading.isZero ? "" : "+") +
+                            Text(heading.isLess(than: 0) || heading.rounded().isZero ? "" : "+") +
                             Text(heading, format: .number.precision(.fractionLength(0)))
                             + Text("°")
                             Spacer()
@@ -90,7 +90,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(elevationDelta.isLess(than: 0) || elevationDelta.isZero ? "" : "+") +
+                            Text(elevationDelta.isLess(than: 0) || elevationDelta.rounded().isZero ? "" : "+") +
                             Text(elevationDelta, format: .number.precision(.fractionLength(0)))
                             + Text(" m")
                             Spacer()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -126,22 +126,25 @@ extension WorldScaleGeoTrackingSceneView {
                     .frame(alignment: .topTrailing)
                     .padding()
                 }
-                .padding([.trailing], -20)
-                .padding([.top,], -30)
+                .padding(.trailing, -20)
+                .padding(.top, -30)
             }
             .frame(maxWidth: .infinity)
             .padding()
-            .padding([.top], 10)
+            .padding(.top, 10)
             .background(.regularMaterial)
+            .cornerRadius(10)
+            .shadow(radius: 50)
         }
         
         /// Updates the heading of the scene view camera controller.
         /// - Parameter heading: The camera heading.
         private func updateHeading(to heading: Double) {
-            viewModel.cameraController.originCamera = viewModel.cameraController.originCamera.rotatedTo(
+            let originCamera = viewModel.cameraController.originCamera
+            viewModel.cameraController.originCamera = originCamera.rotatedTo(
                 heading: heading,
-                pitch: viewModel.cameraController.originCamera.pitch,
-                roll: viewModel.cameraController.originCamera.roll
+                pitch: originCamera.pitch,
+                roll: originCamera.roll
             )
             viewModel.calibrationHeading = heading
         }
@@ -149,11 +152,12 @@ extension WorldScaleGeoTrackingSceneView {
         /// Rotates the heading of the scene view camera controller by the heading delta in degrees.
         /// - Parameter headingDelta: The heading delta in degrees.
         private func rotateHeading(by headingDelta: Double) {
-            let newHeading = viewModel.cameraController.originCamera.heading + headingDelta
-            viewModel.cameraController.originCamera = viewModel.cameraController.originCamera.rotatedTo(
+            let originCamera = viewModel.cameraController.originCamera
+            let newHeading = originCamera.heading + headingDelta
+            viewModel.cameraController.originCamera = originCamera.rotatedTo(
                 heading: newHeading,
-                pitch: viewModel.cameraController.originCamera.pitch,
-                roll: viewModel.cameraController.originCamera.roll
+                pitch: originCamera.pitch,
+                roll: originCamera.roll
             )
             viewModel.calibrationHeading = newHeading
         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -123,12 +123,12 @@ extension WorldScaleGeoTrackingSceneView {
                         setBasemapOpacity(0)
                     }
                 }
-                .frame(minWidth: 200, maxHeight: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
+                .frame(minWidth: 250, maxWidth: UIScreen.main.bounds.width/3, alignment: .bottomLeading)
                 .padding()
             }
-            .onChange(of: viewModel.scene.basemap?.loadStatus) { loadStatus in
-                viewModel.scene.basemap?.baseLayers.forEach( { $0.opacity = 0 })
-            }
+            .padding([.horizontal], 10)
+            .padding([.vertical], 10)
+            .esriBorder()
         }
         
         /// Sets the basemap base layers with the given opacity.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -296,10 +296,10 @@ extension WorldScaleGeoTrackingSceneView {
     @MainActor
     class ViewModel: ObservableObject {
         /// The scene.
-        @Published var scene: ArcGIS.Scene
+        let scene: ArcGIS.Scene
         /// The camera controller that will be set on the scene view.
-        @Published var cameraController: TransformationMatrixCameraController
-        /// A Boolean value that indicates if the AR experince is being calibrated.
+        let cameraController: TransformationMatrixCameraController
+        /// A Boolean value that indicates if the AR experience is being calibrated.
         @Published var isCalibrating = false
         /// The calibrated camera heading.
         @Published var calibrationHeading: Double?

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -159,6 +159,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(.regularMaterial)
+                    .disabled(!initialCameraIsSet)
                 } else {
                     CalibrationView(viewModel: viewModel)
                 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -20,8 +20,16 @@ import ArcGIS
 public struct WorldScaleGeoTrackingSceneView: View {
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSwiftUIViewProxy()
-    /// The view model for the calibration view.
-    @StateObject private var viewModel: ViewModel
+    /// The camera controller that will be set on the scene view.
+    @State private var cameraController: TransformationMatrixCameraController
+    /// The camera controller heading.
+    @State var heading: Double = 0
+    /// The camera controller elevation.
+    @State var elevation: Double = 0
+    /// The calibrated elevation delta.
+    @State private var elevationDelta: Double = 0
+    /// A Boolean value that indicates if the user is calibrating.
+    @State var isCalibrating = false
     /// The current interface orientation.
     @State private var interfaceOrientation: InterfaceOrientation?
     /// The location datasource that is used to access the device location.
@@ -67,6 +75,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
         let cameraController = TransformationMatrixCameraController()
         cameraController.translationFactor = 1
         cameraController.clippingDistance = clippingDistance
+        _cameraController = .init(initialValue: cameraController)
         
         if ARGeoTrackingConfiguration.isSupported {
             configuration = ARGeoTrackingConfiguration()
@@ -76,8 +85,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
         }
         
         _locationDataSource = .init(initialValue: locationDataSource)
-        
-        _viewModel = StateObject(wrappedValue: ViewModel(cameraController: cameraController))
     }
     
     public var body: some View {
@@ -89,7 +96,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
                         
                         sceneViewProxy.updateCamera(
                             frame: frame,
-                            cameraController: viewModel.cameraController,
+                            cameraController: cameraController,
                             orientation: interfaceOrientation,
                             initialTransformation: .identity
                         )
@@ -101,7 +108,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 
                 if initialCameraIsSet {
                     sceneViewBuilder(sceneViewProxy)
-                        .cameraController(viewModel.cameraController)
+                        .cameraController(cameraController)
                         .attributionBarHidden(true)
                         .spaceEffect(.transparent)
                         .atmosphereEffect(.off)
@@ -148,11 +155,11 @@ public struct WorldScaleGeoTrackingSceneView: View {
         .overlay(alignment: calibrationViewAlignment) {
             if configuration is ARWorldTrackingConfiguration,
                !calibrationViewIsHidden {
-                if !viewModel.isCalibrating {
+                if !isCalibrating {
                     VStack {
                         Button {
                             withAnimation {
-                                viewModel.isCalibrating = true
+                                isCalibrating = true
                             }
                         } label: {
                             Text("Calibrate")
@@ -164,8 +171,27 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     }
                     .padding()
                 } else {
-                    CalibrationView(viewModel: viewModel)
+                    CalibrationView(
+                        heading: $heading,
+                        elevation: $elevation,
+                        elevationDelta: $elevationDelta,
+                        isCalibrating: $isCalibrating
+                    )
                 }
+            }
+        }
+        .onChange(of: heading) { heading in
+            let originCamera = cameraController.originCamera
+            cameraController.originCamera = originCamera.rotatedTo(
+                heading: heading,
+                pitch: originCamera.pitch,
+                roll: originCamera.roll
+            )
+        }
+        .onChange(of: elevationDelta) { elevationDelta in
+            cameraController.originCamera = cameraController.originCamera.elevated(by: elevationDelta)
+            if let elevation = cameraController.originCamera.location.z {
+                self.elevation = elevation
             }
         }
         .overlay(alignment: .top) {
@@ -201,7 +227,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
         
         if !initialCameraIsSet {
             let heading = 0.0
-            viewModel.cameraController.originCamera = Camera(
+            cameraController.originCamera = Camera(
                 latitude: location.position.y,
                 longitude: location.position.x,
                 altitude: altitude,
@@ -209,22 +235,23 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 pitch: 90,
                 roll: 0
             )
-            viewModel.calibrationElevation = altitude
+            self.heading = heading
+            elevation = altitude
         } else {
             // Ignore location updates when calibrating heading and elevation.
-            guard !viewModel.isCalibrating else { return }
-            viewModel.cameraController.originCamera = Camera(
+            guard !isCalibrating else { return }
+            cameraController.originCamera = Camera(
                 latitude: location.position.y,
                 longitude: location.position.x,
-                altitude: viewModel.calibrationElevation ?? altitude,
-                heading: viewModel.calibrationHeading ?? 0,
+                altitude: elevation,
+                heading: heading,
                 pitch: 90,
                 roll: 0
             )
         }
         
         // We have to do this or the error gets bigger and bigger.
-        viewModel.cameraController.transformationMatrix = .identity
+        cameraController.transformationMatrix = .identity
         arViewProxy.session.run(configuration, options: .resetTracking)
         
         // If initial camera is not set, then we set it the flag here to true
@@ -288,24 +315,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 Text("horizontalAccuracy: \(currentLocation.horizontalAccuracy, format: .number)")
                 Text("verticalAccuracy: \(currentLocation.verticalAccuracy, format: .number)")
             }
-        }
-    }
-}
-
-extension WorldScaleGeoTrackingSceneView {
-    @MainActor
-    class ViewModel: ObservableObject {
-        /// The camera controller that will be set on the scene view.
-        let cameraController: TransformationMatrixCameraController
-        /// A Boolean value that indicates if the AR experience is being calibrated.
-        @Published var isCalibrating = false
-        /// The calibrated camera heading.
-        @Published var calibrationHeading: Double?
-        /// The calibrated camera elevation.
-        @Published var calibrationElevation: Double?
-        
-        init(cameraController: TransformationMatrixCameraController) {
-            self.cameraController = cameraController
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -20,6 +20,8 @@ import ArcGIS
 public struct WorldScaleGeoTrackingSceneView: View {
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSwiftUIViewProxy()
+    /// The scene view.
+    @State private var scene: ArcGIS.Scene
     /// The camera controller that will be set on the scene view.
     @State private var cameraController: TransformationMatrixCameraController
     /// The current interface orientation.
@@ -48,32 +50,15 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @State private var currentLocation: Location?
     /// The valid accuracy threshold for a location in meters.
     private var validAccuracyThreshold = 0.0
-    /// The basemap opacity.
-    @State private var basemapOpacity = 0.0
     /// A Boolean value that indicates if the AR experince is being calibrated.
     @State private var isCalibrating = false
-    /// The slider value for the camera heading.
-    @State private var headingSliderValue = 0.0
-    /// The slider value for the camera elevation.
-    @State private var elevationSliderValue = 0.0
-    /// The elevation timer for the "joystick" behavior.
-    @State private var headingTimer: Timer?
-    /// The heading timer for the "joystick" behavior.
-    @State private var elevationTimer: Timer?
-    /// The heading delta amount based on the heading slider value.
-    private var joystickHeadingDelta: Double {
-        Double(signOf: headingSliderValue, magnitudeOf: headingSliderValue * headingSliderValue / 25)
-    }
-    /// The elevation delta amount based on the elevation slider value.
-    private var joystickElevationDelta: Double {
-        Double(signOf: elevationSliderValue, magnitudeOf: elevationSliderValue * elevationSliderValue / 100)
-    }
     
     /// Creates a world scale scene view.
     /// - Parameters:
     ///   - locationDataSource: The location datasource used to acquire the device's location.
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
     ///   of `nil` means that no data will be clipped.
+    ///   - scene: The scene used in the scene view.
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
     ///   augmented reality video feed.
     /// - Remark: The provided scene view will have certain properties overridden in order to
@@ -82,8 +67,12 @@ public struct WorldScaleGeoTrackingSceneView: View {
     public init(
         locationDataSource: LocationDataSource = SystemLocationDataSource(),
         clippingDistance: Double? = nil,
+        scene: ArcGIS.Scene,
         @ViewBuilder sceneView: @escaping (SceneViewProxy) -> SceneView
     ) {
+        scene.basemap?.baseLayers.forEach({ $0.opacity = 0.5})
+        _scene = .init(initialValue: scene)
+        
         sceneViewBuilder = sceneView
         
         let cameraController = TransformationMatrixCameraController()
@@ -170,10 +159,20 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 }
             } catch {}
         }
+        .onChange(of: scene.basemap?.loadStatus) { loadStatus in
+            guard loadStatus == .loaded else { return }
+            setBasemapOpacity(0)
+        }
         .toolbar {
             ToolbarItem(placement: .bottomBar) {
                 if !calibrationViewIsHidden {
-                    calibrationView
+                    CalibrationView(
+                        scene: scene,
+                        cameraController: cameraController,
+                        isCalibrating: isCalibrating,
+                        calibrationHeading: calibrationHeading,
+                        calibrationElevation: calibrationElevation
+                    )
                 }
             }
         }
@@ -282,123 +281,11 @@ public struct WorldScaleGeoTrackingSceneView: View {
         return view
     }
     
-    /// Updates the heading of the scene view camera controller.
-    /// - Parameter heading: The camera heading.
-    func updateHeading(_ heading: Double) {
-        cameraController.originCamera = cameraController.originCamera.rotatedTo(
-            heading: heading,
-            pitch: cameraController.originCamera.pitch,
-            roll: cameraController.originCamera.roll
-        )
-        calibrationHeading = heading
-    }
-    
-    /// Rotates the heading of the scene view camera controller by the heading delta in degrees.
-    /// - Parameter headingDelta: The heading delta in degrees.
-    func rotateHeading(_ headingDelta: Double) {
-        let newHeading = cameraController.originCamera.heading + headingDelta
-        cameraController.originCamera = cameraController.originCamera.rotatedTo(
-            heading: newHeading,
-            pitch: cameraController.originCamera.pitch,
-            roll: cameraController.originCamera.roll
-        )
-        calibrationHeading = newHeading
-    }
-    
-    /// Elevates the scene view camera controller by the elevation delta.
-    /// - Parameter elevationDelta: The elevation delta.
-    func updateElevation(_ elevationDelta: Double) {
-        cameraController.originCamera = cameraController.originCamera.elevated(by: elevationDelta)
-        if let elevation = cameraController.originCamera.location.z {
-            calibrationElevation = elevation
-        }
-    }
-    
-    /// A view that allows the user to calibrate the heading of the scene view camera controller.
-    var calibrationView: some View {
-        Button {
-            isCalibrating = true
-            basemapOpacity = 0.5
-        } label: {
-            Text("Calibrate")
-        }
-        .popover(isPresented: $isCalibrating) {
-            VStack {
-                Text("Heading: \(calibrationHeading?.rounded(.towardZero) ?? cameraController.originCamera.heading.rounded(.towardZero), format: .number)")
-                
-                HStack {
-                    Button {
-                        let heading = cameraController.originCamera.heading - 1
-                        updateHeading(heading)
-                    } label: {
-                        Image(systemName: "minus")
-                    }
-                    Slider(value: $headingSliderValue, in: -10...10) { editingChanged in
-                        if !editingChanged {
-                            headingTimer?.invalidate()
-                            headingTimer = nil
-                            headingSliderValue = 0.0
-                        }
-                    }
-                    .onChange(of: headingSliderValue) { heading in
-                        
-                        guard headingTimer == nil else { return }
-                        // Create a timer which rotates the camera when fired.
-                        let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
-                            rotateHeading(joystickHeadingDelta)
-                        }
-                        headingTimer = timer
-                        // Add the timer to the main run loop.
-                        RunLoop.main.add(timer, forMode: .default)
-                    }
-                    
-                    Button {
-                        let heading = cameraController.originCamera.heading + 1
-                        updateHeading(heading)
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                }
-                VStack {
-                    Text("Elevation: \(calibrationElevation?.rounded(.towardZero) ?? cameraController.originCamera.location.z?.rounded(.towardZero) ?? 0, format: .number)")
-                    HStack {
-                        Button {
-                            updateElevation(-1)
-                        } label: {
-                            Image(systemName: "minus")
-                        }
-                        Slider(value: $elevationSliderValue, in: -20...20) { editingChanged in
-                            if !editingChanged {
-                                elevationTimer?.invalidate()
-                                elevationTimer = nil
-                                elevationSliderValue = 0.0
-                            }
-                        }
-                        .onChange(of: elevationSliderValue) { elevation in
-                            
-                            guard elevationTimer == nil else { return }
-                            // Create a timer which rotates the camera when fired.
-                            let timer = Timer(timeInterval: 0.1, repeats: true) { [self] (_) in
-                                updateElevation(joystickElevationDelta)
-                            }
-                            elevationTimer = timer
-                            // Add the timer to the main run loop.
-                            RunLoop.main.add(timer, forMode: .default)
-                        }
-                        Button {
-                            updateElevation(1)
-                        } label: {
-                            Image(systemName: "plus")
-                        }
-                    }
-                }
-            }
-            .frame(minWidth: 200, maxHeight: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
-            .padding()
-        }
-        .onDisappear {
-            basemapOpacity = 0.0
-        }
+    /// Sets the basemap base layers with the given opacity.
+    /// - Parameter opacity: The opacity of the layer.
+    private func setBasemapOpacity(_ opacity: Float) {
+        guard let basemap = scene.basemap else { return }
+        basemap.baseLayers.forEach { $0.opacity = opacity }
     }
     
     /// A view that displays the horizontal and vertical accuracy of the current location datasource location.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -168,14 +168,17 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                     .disabled(!initialCameraIsSet)
                     .padding()
-                } else {
-                    CalibrationView(
-                        heading: $heading,
-                        elevation: $elevation,
-                        elevationDelta: $elevationDelta,
-                        isCalibrating: $isCalibrating
-                    )
                 }
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if isCalibrating {
+                CalibrationView(
+                    heading: $heading,
+                    elevation: $elevation,
+                    elevationDelta: $elevationDelta,
+                    isCalibrating: $isCalibrating
+                )
             }
         }
         .onChange(of: heading) { heading in

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -156,19 +156,17 @@ public struct WorldScaleGeoTrackingSceneView: View {
             if configuration is ARWorldTrackingConfiguration,
                !calibrationViewIsHidden {
                 if !isCalibrating {
-                    VStack {
-                        Button {
-                            withAnimation {
-                                isCalibrating = true
-                            }
-                        } label: {
-                            Text("Calibrate")
+                    Button {
+                        withAnimation {
+                            isCalibrating = true
                         }
-                        .padding()
-                        .background(.regularMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                        .disabled(!initialCameraIsSet)
+                    } label: {
+                        Text("Calibrate")
                     }
+                    .padding()
+                    .background(.regularMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .disabled(!initialCameraIsSet)
                     .padding()
                 } else {
                     CalibrationView(

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -138,14 +138,10 @@ public struct WorldScaleGeoTrackingSceneView: View {
         .task {
             do {
                 try await locationDataSource.start()
-                await withTaskGroup(of: Void.self) { group in
-                    group.addTask {
-                        for await location in locationDataSource.locations {
-                            lastLocationTimestamp = location.timestamp
-                            currentLocation = location
-                            await updateSceneView(for: location)
-                        }
-                    }
+                for await location in locationDataSource.locations {
+                    lastLocationTimestamp = location.timestamp
+                    currentLocation = location
+                    updateSceneView(for: location)
                 }
             } catch {}
         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -52,6 +52,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
     private var validAccuracyThreshold = 0.0
     /// Determines the alignment of the calibration view.
     private var calibrationViewAlignment: Alignment = .bottom
+    /// The initial camera controller elevation.
+    @State private var initialElevation = 0.0
     
     /// Creates a world scale scene view.
     /// - Parameters:
@@ -142,7 +144,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     CalibrationView(
                         heading: $heading,
                         elevation: $elevation,
-                        isCalibrating: $isCalibrating
+                        isCalibrating: $isCalibrating,
+                        initialElevation: $initialElevation
                     )
                     .padding(.bottom)
                 }
@@ -233,6 +236,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
             )
             self.heading = heading
             elevation = altitude
+            initialElevation = altitude
         } else {
             // Ignore location updates when calibrating heading and elevation.
             guard !isCalibrating else { return }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -152,8 +152,10 @@ public struct WorldScaleGeoTrackingSceneView: View {
                !calibrationViewIsHidden {
                 if !viewModel.isCalibrating {
                     Button {
-                        viewModel.isCalibrating = true
                         viewModel.setBasemapOpacity(0.5)
+                        withAnimation {
+                            viewModel.isCalibrating = true
+                        }
                     } label: {
                         Text("Calibrate")
                     }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -159,9 +159,10 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     } label: {
                         Text("Calibrate")
                     }
-                    .frame(maxWidth: .infinity)
                     .padding()
                     .background(.regularMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .padding()
                     .disabled(!initialCameraIsSet)
                 } else {
                     CalibrationView(viewModel: viewModel)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -151,19 +151,21 @@ public struct WorldScaleGeoTrackingSceneView: View {
             if configuration is ARWorldTrackingConfiguration,
                !calibrationViewIsHidden {
                 if !viewModel.isCalibrating {
-                    Button {
-                        viewModel.setBasemapOpacity(0.5)
-                        withAnimation {
-                            viewModel.isCalibrating = true
+                    VStack {
+                        Button {
+                            viewModel.setBasemapOpacity(0.5)
+                            withAnimation {
+                                viewModel.isCalibrating = true
+                            }
+                        } label: {
+                            Text("Calibrate")
                         }
-                    } label: {
-                        Text("Calibrate")
+                        .padding()
+                        .background(.regularMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .disabled(!initialCameraIsSet)
                     }
                     .padding()
-                    .background(.regularMaterial)
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                    .padding()
-                    .disabled(!initialCameraIsSet)
                 } else {
                     CalibrationView(viewModel: viewModel)
                 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -148,7 +148,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
             } catch {}
         }
         .overlay(alignment: calibrationViewAlignment) {
-            if !calibrationViewIsHidden {
+            if configuration is ARWorldTrackingConfiguration,
+               !calibrationViewIsHidden {
                 if !viewModel.isCalibrating {
                     Button {
                         viewModel.isCalibrating = true

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -44,6 +44,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @State private var currentLocation: Location?
     /// The valid accuracy threshold for a location in meters.
     private var validAccuracyThreshold = 0.0
+    /// Determines the alignment of the calibration view.
+    private var calibrationViewAlignment: Alignment = .bottomLeading
     
     /// Creates a world scale scene view.
     /// - Parameters:
@@ -145,7 +147,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 }
             } catch {}
         }
-        .overlay(alignment: .bottomLeading) {
+        .overlay(alignment: calibrationViewAlignment) {
             if !calibrationViewIsHidden {
                 CalibrationView(viewModel: viewModel)
             }
@@ -257,6 +259,14 @@ public struct WorldScaleGeoTrackingSceneView: View {
     public func calibrationViewHidden(_ hidden: Bool) -> Self {
         var view = self
         view.calibrationViewIsHidden = hidden
+        return view
+    }
+    
+    /// Sets the alignment of the calibration view.
+    /// - Parameter alignment: The alignment for the calibration view.
+    public func calibrationViewAlignemnt(_ alignment: Alignment) -> Self {
+        var view = self
+        view.calibrationViewAlignment = alignment
         return view
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -317,8 +317,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
             .frame(maxWidth: .infinity, alignment: .center)
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
-            .padding(.top)
+            .padding([.horizontal, .top])
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -26,8 +26,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @State var heading: Double = 0
     /// The camera controller elevation.
     @State var elevation: Double = 0
-    /// The calibrated elevation delta.
-    @State private var elevationDelta: Double = 0
     /// A Boolean value that indicates if the user is calibrating.
     @State var isCalibrating = false
     /// The current interface orientation.
@@ -144,7 +142,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     CalibrationView(
                         heading: $heading,
                         elevation: $elevation,
-                        elevationDelta: $elevationDelta,
                         isCalibrating: $isCalibrating
                     )
                     .padding(.bottom)
@@ -196,11 +193,9 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 roll: originCamera.roll
             )
         }
-        .onChange(of: elevationDelta) { elevationDelta in
+        .onChange(of: elevation) { elevation in
+            let elevationDelta = elevation - (cameraController.originCamera.location.z ?? 0)
             cameraController.originCamera = cameraController.originCamera.elevated(by: elevationDelta)
-            if let elevation = cameraController.originCamera.location.z {
-                self.elevation = elevation
-            }
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -178,6 +178,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
         }
         .onChange(of: viewModel.scene.basemap?.loadStatus) { loadStatus in
             guard loadStatus == .loaded else { return }
+            // Hide basemap baselayers once basemap is loaded
+            // so camera feed is visible.
             viewModel.setBasemapOpacity(0)
         }
     }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -45,7 +45,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
     /// The valid accuracy threshold for a location in meters.
     private var validAccuracyThreshold = 0.0
     /// Determines the alignment of the calibration view.
-    private var calibrationViewAlignment: Alignment = .bottomLeading
+    private var calibrationViewAlignment: Alignment = .bottom
     
     /// Creates a world scale scene view.
     /// - Parameters:
@@ -149,7 +149,18 @@ public struct WorldScaleGeoTrackingSceneView: View {
         }
         .overlay(alignment: calibrationViewAlignment) {
             if !calibrationViewIsHidden {
-                CalibrationView(viewModel: viewModel)
+                if !viewModel.isCalibrating {
+                    Button {
+                        viewModel.isCalibrating = true
+                    } label: {
+                        Text("Calibrate")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(.regularMaterial)
+                } else {
+                    CalibrationView(viewModel: viewModel)
+                }
             }
         }
         .overlay(alignment: .top) {
@@ -264,7 +275,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
     
     /// Sets the alignment of the calibration view.
     /// - Parameter alignment: The alignment for the calibration view.
-    public func calibrationViewAlignemnt(_ alignment: Alignment) -> Self {
+    public func calibrationViewAlignment(_ alignment: Alignment) -> Self {
         var view = self
         view.calibrationViewAlignment = alignment
         return view

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -145,11 +145,9 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 }
             } catch {}
         }
-        .toolbar {
-            ToolbarItem(placement: .bottomBar) {
-                if !calibrationViewIsHidden {
-                    CalibrationView(viewModel: viewModel)
-                }
+        .overlay(alignment: .bottomLeading) {
+            if !calibrationViewIsHidden {
+                CalibrationView(viewModel: viewModel)
             }
         }
         .overlay(alignment: .top) {
@@ -158,6 +156,11 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(8)
                 .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
+        }
+        .onChange(of: viewModel.scene.basemap?.loadStatus) { loadStatus in
+            withAnimation {
+                viewModel.scene.basemap?.baseLayers.forEach( { $0.opacity = 0 })
+            }
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -152,6 +152,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 if !viewModel.isCalibrating {
                     Button {
                         viewModel.isCalibrating = true
+                        viewModel.setBasemapOpacity(0.5)
                     } label: {
                         Text("Calibrate")
                     }
@@ -171,9 +172,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
         }
         .onChange(of: viewModel.scene.basemap?.loadStatus) { loadStatus in
-            withAnimation {
-                viewModel.scene.basemap?.baseLayers.forEach( { $0.opacity = 0 })
-            }
+            guard loadStatus == .loaded else { return }
+            viewModel.setBasemapOpacity(0)
         }
     }
     
@@ -309,6 +309,13 @@ extension WorldScaleGeoTrackingSceneView {
         init(scene: ArcGIS.Scene, cameraController: TransformationMatrixCameraController) {
             self.scene = scene
             self.cameraController = cameraController
+        }
+        
+        /// Sets the basemap base layers with the given opacity.
+        /// - Parameter opacity: The opacity of the layer.
+        func setBasemapOpacity(_ opacity: Float) {
+            guard let basemap = scene.basemap else { return }
+            basemap.baseLayers.forEach { $0.opacity = opacity }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -101,17 +101,6 @@ extension View {
         modifier(SelectedModifier(isSelected: isSelected))
     }
     
-    /// Returns a new view with fraction presentation detents, if presentation
-    /// detents are supported (iOS 16 and up).
-    func fractionPresentationDetents(_ fraction: CGFloat) -> some View {
-        if #available(iOS 16.0, *) {
-            return self
-                .presentationDetents([.fraction(fraction)])
-        } else {
-            return self
-        }
-    }
-    
     /// Returns a new view with medium presentation detents, if presentation
     /// detents are supported (iOS 16 and up).
     func mediumPresentationDetents() -> some View {

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -101,6 +101,17 @@ extension View {
         modifier(SelectedModifier(isSelected: isSelected))
     }
     
+    /// Returns a new view with fraction presentation detents, if presentation
+    /// detents are supported (iOS 16 and up).
+    func fractionPresentationDetents(_ fraction: CGFloat) -> some View {
+        if #available(iOS 16.0, *) {
+            return self
+                .presentationDetents([.fraction(fraction)])
+        } else {
+            return self
+        }
+    }
+    
     /// Returns a new view with medium presentation detents, if presentation
     /// detents are supported (iOS 16 and up).
     func mediumPresentationDetents() -> some View {


### PR DESCRIPTION
Closes `swift/4516`

Screenshots:

iPhone:

Calibrate button:
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/117859673/876742e3-ccd8-4df7-b7a1-e6ae73f4927a" width="300">

Calibration view:
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/117859673/c0222398-7d89-4a73-ac18-0f9023c5cceb" width="300">

iPad:

Calibrate button:
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/117859673/75e7840d-0fdd-40d5-b59b-514c996b14ee" width="300">

Calibration view:
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/117859673/67132bb4-e033-4989-9981-3940fbf1c4d5" width="300">
