### PR TITLE
AR: Adjust coaching overlay display conditions

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/ARCoachingOverlay.swift
@@ -45,7 +45,7 @@ struct ARCoachingOverlay: UIViewRepresentable {
     func makeUIView(context: Context) -> ARCoachingOverlayView {
         let view = ARCoachingOverlayView()
         view.delegate = context.coordinator
-        view.activatesAutomatically = false
+        view.activatesAutomatically = true
         return view
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -28,8 +28,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @State private var locationDataSource: LocationDataSource
     /// A Boolean value indicating if the camera was initially set.
     @State private var initialCameraIsSet = false
-    /// A Boolean value that indicates whether the coaching overlay is hidden.
-    @State private var coachingOverlayIsHidden = false
+    /// A Boolean value that indicates whether the coaching overlay view is active.
+    @State private var coachingOverlayIsActive = false
     /// The current camera of the scene view.
     @State private var currentCamera: Camera?
     /// A Boolean value that indicates whether the calibration view is hidden.
@@ -113,10 +113,10 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)
                     .onCoachingOverlayActivate { _ in
-                        coachingOverlayIsHidden = false
+                        coachingOverlayIsActive = true
                     }
                     .onCoachingOverlayDeactivate { _ in
-                        coachingOverlayIsHidden = true
+                        coachingOverlayIsActive = false
                     }
                     .onCoachingOverlayRequestSessionReset { _ in
                         if let currentLocation {
@@ -170,7 +170,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @MainActor
     private func updateSceneView(for location: Location) {
         // Do not update the scene view when the coaching overlay is in place.
-        guard coachingOverlayIsHidden else { return }
+        guard !coachingOverlayIsActive else { return }
         
         // Do not use cached location more than 10 seconds old.
         guard abs(lastLocationTimestamp?.timeIntervalSinceNow ?? 0) < 10 else { return }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -30,8 +30,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @State private var initialCameraIsSet = false
     /// A Boolean value that indicates whether to hide the coaching overlay view.
     private var coachingOverlayIsHidden = false
-    /// A Boolean value that indicates whether the coaching overlay view is active.
-    @State private var coachingOverlayIsActive = true
     /// The current camera of the scene view.
     @State private var currentCamera: Camera?
     /// A Boolean value that indicates whether the calibration view is hidden.
@@ -48,6 +46,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @State private var currentLocation: Location?
     /// The valid accuracy threshold for a location in meters.
     private var validAccuracyThreshold = 0.0
+    /// The app's tracking requirements for the coaching overlay to show/dismiss.
+    @State private var goal: ARCoachingOverlayView.Goal
     
     /// Creates a world scale scene view.
     /// - Parameters:
@@ -73,10 +73,12 @@ public struct WorldScaleGeoTrackingSceneView: View {
         
         if ARGeoTrackingConfiguration.isSupported {
             configuration = ARGeoTrackingConfiguration()
+            _goal = .init(initialValue: .geoTracking)
         } else {
             configuration = ARWorldTrackingConfiguration()
-            configuration.worldAlignment = .gravityAndHeading
+            _goal = .init(initialValue: .tracking)
         }
+        configuration.worldAlignment = .gravityAndHeading
         
         _locationDataSource = .init(initialValue: locationDataSource)
     }
@@ -115,7 +117,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 if !coachingOverlayIsHidden {
                     ARCoachingOverlay(goal: .geoTracking)
                         .sessionProvider(arViewProxy)
-                        .active(coachingOverlayIsActive)
                         .allowsHitTesting(false)
                 }
             }
@@ -193,7 +194,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
         // If initial camera is not set, then we set it the flag here to true
         // and set the status text to empty.
         if !initialCameraIsSet {
-            coachingOverlayIsActive = false
             initialCameraIsSet = true
         }
     }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -118,6 +118,11 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     .onCoachingOverlayDeactivate { _ in
                         coachingOverlayIsHidden = true
                     }
+                    .onCoachingOverlayRequestSessionReset { _ in
+                        if let currentLocation {
+                            updateSceneView(for: currentLocation)
+                        }
+                    }
                     .allowsHitTesting(false)
             }
         }


### PR DESCRIPTION
## Description

This PR adjusts the coaching overlay show/dismiss conditions for the world scale AR view. See comments in the code.

The table top AR view also uses the coaching overlay. However, it is manually controlled by inactivating the overlay when the plane anchor is added. Thus, changes in this PR won't affect the behavior of the overlay in the table top AR view.

https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/67228cfadc9b6f0af0c8e52ee3a597f91b04118e/Sources/ArcGISToolkit/Components/Augmented%20Reality/TableTopSceneView.swift#L171-L173

See more details in `swift/issues/4909`