### PR TITLE
fix overlay alignment issue, safe area fixes

### DIFF
--- a/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
+++ b/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
@@ -35,35 +35,24 @@ struct WorldScaleGeoTrackingExampleView: View {
         return scene
     }()
     
-    /// The basemap opacity.
-    @State private var opacity: Float = 1
     /// The graphics overlay which shows a graphic around your initial location.
     @State private var graphicsOverlay = GraphicsOverlay()
     /// The location datasource that is used to access the device location.
     @State private var locationDataSource = SystemLocationDataSource()
     
     var body: some View {
-        VStack {
-            WorldScaleGeoTrackingSceneView(locationDataSource: locationDataSource) { proxy in
-                SceneView(scene: scene, graphicsOverlays: [graphicsOverlay])
-                    .onSingleTapGesture { screen, _ in
-                        print("Identifying...")
-                        Task {
-                            let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
-                            print("\(results.count) identify result(s).")
-                        }
+        WorldScaleGeoTrackingSceneView(locationDataSource: locationDataSource) { proxy in
+            SceneView(scene: scene, graphicsOverlays: [graphicsOverlay])
+                .onSingleTapGesture { screen, _ in
+                    print("Identifying...")
+                    Task {
+                        let results = try await proxy.identifyLayers(screenPoint: screen, tolerance: 20)
+                        print("\(results.count) identify result(s).")
                     }
-            }
-            .calibrationViewHidden(false)
-            .calibrationViewAlignment(.bottomLeading)
-            // A slider to adjust the basemap opacity.
-            Slider(value: $opacity, in: 0...1)
-                .padding(.horizontal)
-                .onChange(of: opacity) { opacity in
-                    guard let basemap = scene.basemap else { return }
-                    basemap.baseLayers.forEach { $0.opacity = opacity }
                 }
         }
+        .calibrationViewHidden(false)
+        .calibrationViewAlignment(.bottomLeading)
         .task {
             // Request when-in-use location authorization.
             // This is necessary for 2 reasons:

--- a/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
+++ b/Examples/Examples/WorldScaleGeoTrackingExampleView.swift
@@ -51,6 +51,8 @@ struct WorldScaleGeoTrackingExampleView: View {
                         }
                     }
             }
+            .calibrationViewHidden(false)
+            .calibrationViewAlignment(.bottomLeading)
         }
         .task {
             // Request when-in-use location authorization.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -63,6 +63,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .foregroundStyle(.secondary)
                             Spacer()
                             Text((viewModel.calibrationHeading ?? viewModel.cameraController.originCamera.heading), format: .number.precision(.fractionLength(0)))
+                            + Text("°")
                             Spacer()
                         }
                     } onIncrement: {
@@ -84,11 +85,12 @@ extension WorldScaleGeoTrackingSceneView {
                 HStack {
                     Stepper() {
                         HStack {
-                            Text("Elevation (m)")
+                            Text("Elevation")
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
                             Text((viewModel.calibrationElevation ?? viewModel.cameraController.originCamera.location.z ?? 0), format: .number.precision(.fractionLength(0)))
+                            + Text("m")
                             Spacer()
                         }
                     } onIncrement: {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -110,7 +110,38 @@ public struct WorldScaleGeoTrackingSceneView: View {
                             currentCamera = camera
                         }
                 }
-                
+            }
+            .ignoresSafeArea(.all)
+            .overlay(alignment: calibrationViewAlignment) {
+                if configuration is ARWorldTrackingConfiguration,
+                   !calibrationViewIsHidden {
+                    if !viewModel.isCalibrating {
+                        Button {
+                            withAnimation {
+                                viewModel.isCalibrating = true
+                            }
+                        } label: {
+                            Text("Calibrate")
+                                .padding()
+                        }
+                        .background(.regularMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .disabled(!initialCameraIsSet)
+                        .padding()
+                        .padding(.vertical)
+                    }
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if viewModel.isCalibrating {
+                    CalibrationView(viewModel: viewModel)
+                        .padding(.bottom)
+                }
+            }
+            .overlay(alignment: .top) {
+                accuracyView
+            }
+            .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)
                     .onCoachingOverlayActivate { _ in
@@ -144,36 +175,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
                     updateSceneView(for: location)
                 }
             } catch {}
-        }
-        .overlay(alignment: calibrationViewAlignment) {
-            if configuration is ARWorldTrackingConfiguration,
-               !calibrationViewIsHidden {
-                if !viewModel.isCalibrating {
-                    VStack {
-                        Button {
-                            withAnimation {
-                                viewModel.isCalibrating = true
-                            }
-                        } label: {
-                            Text("Calibrate")
-                        }
-                        .padding()
-                        .background(.regularMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                        .disabled(!initialCameraIsSet)
-                    }
-                    .padding()
-                } else {
-                    CalibrationView(viewModel: viewModel)
-                }
-            }
-        }
-        .overlay(alignment: .top) {
-            accuracyView
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(8)
-                .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
         }
     }
     
@@ -282,12 +283,20 @@ public struct WorldScaleGeoTrackingSceneView: View {
     }
     
     /// A view that displays the horizontal and vertical accuracy of the current location datasource location.
+    @ViewBuilder
     var accuracyView: some View {
-        VStack {
-            if let currentLocation {
-                Text("horizontalAccuracy: \(currentLocation.horizontalAccuracy, format: .number)")
-                Text("verticalAccuracy: \(currentLocation.verticalAccuracy, format: .number)")
+        if let currentLocation {
+            VStack {
+                Text("H. Accuracy: \(currentLocation.horizontalAccuracy.formatted(.number.precision(.fractionLength(2))))")
+                Text("V. Accuracy: \(currentLocation.verticalAccuracy.formatted(.number.precision(.fractionLength(2))))")
             }
+            .multilineTextAlignment(.center)
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .padding(.horizontal)
+            .padding(.top)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -122,7 +122,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
             .overlay(alignment: calibrationViewAlignment) {
                 if configuration is ARWorldTrackingConfiguration,
                    !calibrationViewIsHidden {
-                    if !viewModel.isCalibrating {
+                    if !isCalibrating {
                         Button {
                             withAnimation {
                                 isCalibrating = true
@@ -140,7 +140,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 }
             }
             .overlay(alignment: .bottom) {
-                if viewModel.isCalibrating {
+                if isCalibrating {
                     CalibrationView(
                         heading: $heading,
                         elevation: $elevation,

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -70,12 +70,12 @@ public struct WorldScaleGeoTrackingSceneView: View {
         cameraController.translationFactor = 1
         cameraController.clippingDistance = clippingDistance
         
-        if ARGeoTrackingConfiguration.isSupported {
-            configuration = ARGeoTrackingConfiguration()
-        } else {
+//        if ARGeoTrackingConfiguration.isSupported {
+//            configuration = ARGeoTrackingConfiguration()
+//        } else {
             configuration = ARWorldTrackingConfiguration()
             configuration.worldAlignment = .gravityAndHeading
-        }
+//        }
         
         _locationDataSource = .init(initialValue: locationDataSource)
         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -77,12 +77,12 @@ public struct WorldScaleGeoTrackingSceneView: View {
         cameraController.clippingDistance = clippingDistance
         _cameraController = .init(initialValue: cameraController)
         
-//        if ARGeoTrackingConfiguration.isSupported {
-//            configuration = ARGeoTrackingConfiguration()
-//        } else {
+        if ARGeoTrackingConfiguration.isSupported {
+            configuration = ARGeoTrackingConfiguration()
+        } else {
             configuration = ARWorldTrackingConfiguration()
             configuration.worldAlignment = .gravityAndHeading
-//        }
+        }
         
         _locationDataSource = .init(initialValue: locationDataSource)
     }


### PR DESCRIPTION
- fix safe area
- fix calibration button, calibration view alignment issues
- remove opacity slider (because it now conflicts with the safe area fix)

The coaching overlay was causing the alignment issues. It had to be moved to the final overlay.