### PR TITLE
Add custom joystick style slider

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -31,7 +31,7 @@ extension WorldScaleGeoTrackingSceneView {
         @State private var elevationDelta = 0.0
         /// A number format style for signed values with their fractional component removed.
         private let numberFormat = FloatingPointFormatStyle<Double>.number
-            .precision(.fractionLength(0))
+            .precision(.fractionLength(1))
             .sign(strategy: .always(includingZero: false))
         
         var body: some View {
@@ -79,10 +79,6 @@ extension WorldScaleGeoTrackingSceneView {
                     .onChanged { delta in
                         heading = (heading + delta).clamped(to: -180...180)
                     }
-                    .onEnded {
-                        // Round the value now that it stopped changing.
-                        heading = heading.rounded()
-                    }
             }
         }
         
@@ -108,10 +104,6 @@ extension WorldScaleGeoTrackingSceneView {
                 Joyslider()
                     .onChanged { delta in
                         elevation += delta
-                    }
-                    .onEnded {
-                        // Round the value now that it stopped changing.
-                        elevation = elevation.rounded()
                     }
             }
             .onChange(of: elevation) { elevation in

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -62,20 +62,20 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(heading.isLess(than: 0) || heading.rounded().isZero ? "" : "+") +
-                            Text((heading.truncatingRemainder(dividingBy: 180)), format: .number.precision(.fractionLength(0)))
+                            Text(heading.isLess(than: 0) || heading.rounded().isZero ? "" : "+")
+                            + Text(heading, format: .number.precision(.fractionLength(0)))
                             + Text("°")
                             Spacer()
                         }
                     } onIncrement: {
-                        heading += 1
+                        heading = (heading + 1).clamped(to: -180...180)
                     } onDecrement: {
-                        heading -= 1
+                        heading = (heading - 1).clamped(to: -180...180)
                     }
                 }
                 Joyslider()
                     .onValueChanged { delta in
-                        heading += delta
+                        heading = (heading + delta).clamped(to: -180...180)
                     }
             }
         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -63,7 +63,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .foregroundStyle(.secondary)
                             Spacer()
                             Text(heading.isLess(than: 0) || heading.rounded().isZero ? "" : "+") +
-                            Text(heading, format: .number.precision(.fractionLength(0)))
+                            Text((heading.truncatingRemainder(dividingBy: 180)), format: .number.precision(.fractionLength(0)))
                             + Text("°")
                             Spacer()
                         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -73,8 +73,8 @@ extension WorldScaleGeoTrackingSceneView {
                         heading -= 1
                     }
                 }
-                JoystickSliderView()
-                    .onSliderDeltaValueChanged { delta in
+                Joyslider()
+                    .onValueChanged { delta in
                         heading += delta
                     }
             }
@@ -101,8 +101,8 @@ extension WorldScaleGeoTrackingSceneView {
                         elevation -= 1
                     }
                 }
-                JoystickSliderView()
-                    .onSliderDeltaValueChanged { delta in
+                Joyslider()
+                    .onValueChanged { delta in
                         elevation += delta
                     }
             }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -44,7 +44,7 @@ struct Joyslider: View {
                             }
                             .onEnded { _ in
                                 isChanging = false
-                                withAnimation(.bouncy) {
+                                withAnimation(.bouncy.speed(1.5)) {
                                     offset = 0
                                 }
                                 onEndedAction?()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -1,9 +1,16 @@
+// Copyright 2024 Esri
 //
-//  Joyslider.swift
-//  Joystick
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ryan Olson on 2/5/24.
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import SwiftUI
 

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -45,7 +45,7 @@ struct Joyslider: View {
                     )
             }
         }
-        .frame(height: Thumb.size)
+        .frame(height: Thumb.size + 4)
         .task(id: isChanging) {
             guard isChanging else { return }
             while !Task.isCancelled {
@@ -72,13 +72,14 @@ private struct Thumb: View {
     static let size: Double = 26
     var body: some View {
         Circle()
+            .stroke(Color.accentColor, lineWidth: 2)
             .foregroundStyle(.background)
             .frame(width: Self.size, height: Self.size)
             .background {
                 Circle()
                     .frame(width: Self.size, height: Self.size)
                     .foregroundStyle(.background)
-                    .shadow(color: .secondary.opacity(0.5), radius: 3, x: 0, y: 1)
+                    .shadow(color: .secondary.opacity(0.5), radius: 5, x: 0, y: 2)
             }
     }
 }
@@ -102,17 +103,15 @@ private struct Track: View {
     }
     
     var fill: some ShapeStyle {
-        let accent = Color.accentColor.opacity(abs(factor))
-        
         if offset >= 0 {
             return LinearGradient(
-                gradient: Gradient(colors: [.systemFill, accent]),
+                gradient: Gradient(colors: [.clear, .accentColor]),
                 startPoint: .leading,
                 endPoint: .trailing
             )
         } else {
             return LinearGradient(
-                gradient: Gradient(colors: [.systemFill, accent]),
+                gradient: Gradient(colors: [.clear, .accentColor]),
                 startPoint: .trailing,
                 endPoint: .leading
             )

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -73,7 +73,6 @@ private struct Thumb: View {
     var body: some View {
         Circle()
             .stroke(Color.accentColor, lineWidth: 2)
-            .foregroundStyle(.background)
             .frame(width: Self.size, height: Self.size)
             .background {
                 Circle()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -14,11 +14,16 @@
 
 import SwiftUI
 
+/// A slider that acts similar to a joystick controller.
+/// The slider provides delta values as they change between -1...1.
 struct Joyslider: View {
-    var onValueChangedAction: ((Double) -> Void)?
+    private var onValueChangedAction: ((Double) -> Void)?
     
+    /// The x offset of the thumb in points.
     @State private var offset: Double = 0
+    /// A factor between -1 and 1 that specifies the current percentage of the thumb's position.
     @State private var factor: Double = 0
+    /// A Boolean value indicating if the user is dragging the thumb.
     @State private var isChanging = false
     
     var body: some View {
@@ -61,6 +66,7 @@ struct Joyslider: View {
         }
     }
     
+    /// Specifies an on value changed action.
     func onValueChanged(perform action: @escaping (Double) -> Void) -> Joyslider {
         var copy = self
         copy.onValueChangedAction = action
@@ -68,8 +74,11 @@ struct Joyslider: View {
     }
 }
 
+/// Thumb view for the joyslider.
 private struct Thumb: View {
+    /// The size of the thumb.
     static let size: Double = 26
+    
     var body: some View {
         Circle()
             .stroke(Color.accentColor, lineWidth: 2)
@@ -83,8 +92,11 @@ private struct Thumb: View {
     }
 }
 
+/// Track view for the joyslider.
 private struct Track: View {
+    /// A Boolean value indicating if the user is dragging the thumb.
     let offset: Double
+    /// A factor between -1 and 1 that specifies the current percentage of the thumb's position.
     let factor: Double
     
     var body: some View {
@@ -119,6 +131,7 @@ private struct Track: View {
 }
 
 private extension Color {
+    /// The system fill color.
     static var systemFill: Color { Color(UIColor.systemFill) }
 }
 

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -52,16 +52,21 @@ struct Joyslider: View {
         }
         .frame(height: Thumb.size + 4)
         .task(id: isChanging) {
+            // This task block executes whenever isChanging property changes.
+            // If isChanging is `false`, then return.
             guard isChanging else { return }
+            // Run a loop while the Task is not cancelled.
             while !Task.isCancelled {
+                // Sleep for 50 milliseconds.
                 if #available(iOS 17, *) {
                     try? await Task.sleep(for: .milliseconds(50))
                 } else {
                     try? await Task.sleep(nanoseconds: 50_000_000)
                 }
+                // If task is cancelled after sleeping, return.
                 if Task.isCancelled { return }
-                let change = factor
-                onValueChangedAction?(change)
+                // Otherwise change the value.
+                onValueChangedAction?(factor)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -39,7 +39,7 @@ struct Joyslider: View {
                                 isChanging = true
                                 
                                 let halfWidth = (geometry.size.width / 2)
-                                offset = max(min(value.translation.width, halfWidth), -halfWidth)
+                                offset = value.translation.width.clamped(to: -halfWidth...halfWidth)
                                 factor = offset / halfWidth
                             }
                             .onEnded { _ in

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -108,7 +108,7 @@ private struct Thumb: View {
 
 /// Track view for the joyslider.
 private struct Track: View {
-    /// A Boolean value indicating if the user is dragging the thumb.
+    /// The x offset of the thumb in points.
     let offset: Double
     /// A factor between -1 and 1 that specifies the current percentage of the thumb's position.
     let factor: Double

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -121,7 +121,7 @@ private struct Track: View {
                 Capsule(style: .continuous)
                     .fill(fill)
                     .frame(width: abs(offset))
-                    .offset(x: offset/2)
+                    .offset(x: offset / 2)
             }
         }
         .frame(height: 4)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -17,7 +17,8 @@ import SwiftUI
 /// A slider that acts similar to a joystick controller.
 /// The slider provides delta values as they change between -1...1.
 struct Joyslider: View {
-    private var onValueChangedAction: ((Double) -> Void)?
+    private var onChangedAction: ((Double) -> Void)?
+    private var onEndedAction: (() -> Void)?
     
     /// The x offset of the thumb in points.
     @State private var offset: Double = 0
@@ -46,6 +47,7 @@ struct Joyslider: View {
                                 withAnimation(.bouncy) {
                                     offset = 0
                                 }
+                                onEndedAction?()
                             }
                     )
             }
@@ -66,15 +68,22 @@ struct Joyslider: View {
                 // If task is cancelled after sleeping, return.
                 if Task.isCancelled { return }
                 // Otherwise change the value.
-                onValueChangedAction?(factor)
+                onChangedAction?(factor)
             }
         }
     }
     
-    /// Specifies an on value changed action.
-    func onValueChanged(perform action: @escaping (Double) -> Void) -> Joyslider {
+    /// Specifies an action to perform when the value changes.
+    func onChanged(perform action: @escaping (Double) -> Void) -> Joyslider {
         var copy = self
-        copy.onValueChangedAction = action
+        copy.onChangedAction = action
+        return copy
+    }
+    
+    /// Specifies an action to perform when the value stops changing.
+    func onEnded(perform action: @escaping () -> Void) -> Joyslider {
+        var copy = self
+        copy.onEndedAction = action
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Joyslider.swift
@@ -1,0 +1,127 @@
+//
+//  Joyslider.swift
+//  Joystick
+//
+//  Created by Ryan Olson on 2/5/24.
+//
+
+import SwiftUI
+
+struct Joyslider: View {
+    var onValueChangedAction: ((Double) -> Void)?
+    
+    @State private var offset: Double = 0
+    @State private var factor: Double = 0
+    @State private var isChanging = false
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Track(offset: offset, factor: factor)
+                Thumb()
+                    .offset(x: offset)
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                isChanging = true
+                                
+                                let halfWidth = (geometry.size.width / 2)
+                                offset = max(min(value.translation.width, halfWidth), -halfWidth)
+                                factor = offset / halfWidth
+                            }
+                            .onEnded { _ in
+                                isChanging = false
+                                withAnimation(.bouncy) {
+                                    offset = 0
+                                }
+                            }
+                    )
+            }
+        }
+        .frame(height: Thumb.size)
+        .task(id: isChanging) {
+            guard isChanging else { return }
+            while !Task.isCancelled {
+                if #available(iOS 17, *) {
+                    try? await Task.sleep(for: .milliseconds(50))
+                } else {
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                }
+                if Task.isCancelled { return }
+                let change = factor
+                onValueChangedAction?(change)
+            }
+        }
+    }
+    
+    func onValueChanged(perform action: @escaping (Double) -> Void) -> Joyslider {
+        var copy = self
+        copy.onValueChangedAction = action
+        return copy
+    }
+}
+
+private struct Thumb: View {
+    static let size: Double = 26
+    var body: some View {
+        Circle()
+            .foregroundStyle(.background)
+            .frame(width: Self.size, height: Self.size)
+            .background {
+                Circle()
+                    .frame(width: Self.size, height: Self.size)
+                    .foregroundStyle(.background)
+                    .shadow(color: .secondary.opacity(0.5), radius: 3, x: 0, y: 1)
+            }
+    }
+}
+
+private struct Track: View {
+    let offset: Double
+    let factor: Double
+    
+    var body: some View {
+        ZStack {
+            Capsule(style: .continuous)
+                .fill(Color.systemFill)
+            if offset != 0 {
+                Capsule(style: .continuous)
+                    .fill(fill)
+                    .frame(width: abs(offset))
+                    .offset(x: offset/2)
+            }
+        }
+        .frame(height: 4)
+    }
+    
+    var fill: some ShapeStyle {
+        let accent = Color.accentColor.opacity(abs(factor))
+        
+        if offset >= 0 {
+            return LinearGradient(
+                gradient: Gradient(colors: [.systemFill, accent]),
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        } else {
+            return LinearGradient(
+                gradient: Gradient(colors: [.systemFill, accent]),
+                startPoint: .trailing,
+                endPoint: .leading
+            )
+        }
+    }
+}
+
+private extension Color {
+    static var systemFill: Color { Color(UIColor.systemFill) }
+}
+
+#Preview {
+    VStack {
+        Slider(value: .constant(0.5))
+        Joyslider()
+        Slider(value: .constant(0.5))
+    }
+    .padding()
+}

--- a/Sources/ArcGISToolkit/Extensions/Foundation/FloatingPoint.swift
+++ b/Sources/ArcGISToolkit/Extensions/Foundation/FloatingPoint.swift
@@ -1,0 +1,28 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension FloatingPoint {
+    /// Returns a value clamped to the given range. If the value is `nan`,
+    /// it is clamped to the lower bound of the range.
+    /// - Parameter limits: The range of the resultant value.
+    /// - Returns: A value clamped to `limits`.
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        Self.minimum(
+            Self.maximum(self, limits.lowerBound),
+            limits.upperBound
+        )
+    }
+}


### PR DESCRIPTION
The current slider doesn't work for me. There are 2 problems I see with it:

- it looks exactly like the system slider (because it is), but the behavior is different. If the behavior is different, it should probably look different.
-  left side of the slider is blue, which seems to indicate that the value is half, but the value is never half. The concept of "half" doesn't exist for what we are doing.

This PR introduces a custom joystick slider that looks very close to the system slider, but has slightly different colors applied.

Also this PR fixes a bug where you can see "-0" in the text in certain situations.

This is what the custom slider looks like as you are dragging it:

![IMG_6841](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/3718875/e2199ca4-21ac-4803-899d-cc74a1d32a77)

This is what it looks like at rest:

![IMG_6840](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/3718875/e994f04d-2e81-4a0c-9b99-b8203894b1fe)
