### PR TITLE
Cleanup calibration related state variables 

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -15,20 +15,63 @@
 import ARKit
 import SwiftUI
 import ArcGIS
+import Combine
 
+extension WorldScaleGeoTrackingSceneView {
+    /// A view model that stores state information for the calibration.
+    @MainActor
+    class CalibrationViewModel: ObservableObject {
+        /// The total heading correction.
+        @Published
+        private(set) var totalHeadingCorrection: Double = 0
+        
+        /// The total elevation correction.
+        @Published
+        private(set) var totalElevationCorrection: Double = 0
+
+        // A subject for the heading corrections to publish as they come in.
+        private var headingSubject = PassthroughSubject<Double, Never>()
+        
+        // A subject for the elevation corrections to publish as they come in.
+        private var elevationSubject = PassthroughSubject<Double, Never>()
+        
+        /// The heading corrections.
+        var headingCorrections: AnyPublisher<Double, Never> {
+            headingSubject.eraseToAnyPublisher()
+        }
+        
+        /// The elevation corrections.
+        var elevationCorrections: AnyPublisher<Double, Never> {
+            elevationSubject.eraseToAnyPublisher()
+        }
+        
+        /// Propose a heading correction.
+        /// This will limit the total heading correction to -180...180
+        fileprivate func propose(headingCorrection: Double) {
+            let newTotalHeadingCorrection = (totalHeadingCorrection + headingCorrection)
+                .clamped(to: -180...180)
+            let allowedHeadingCorrection = newTotalHeadingCorrection - totalHeadingCorrection
+            totalHeadingCorrection = newTotalHeadingCorrection
+            headingSubject.send(allowedHeadingCorrection)
+        }
+        
+        /// Propose an elevation correction.
+        fileprivate func propose(elevationCorrection: Double) {
+            totalElevationCorrection += elevationCorrection
+            elevationSubject.send(elevationCorrection)
+        }
+    }
+}
+    
 extension WorldScaleGeoTrackingSceneView {
     /// A view that allows the user to calibrate the heading of the scene view camera controller.
     struct CalibrationView: View {
-        /// The camera controller heading.
-        @Binding var heading: Double
-        /// The camera controller elevation.
-        @Binding var elevation: Double
-        /// A Boolean value that indicates if the user is calibrating.
-        @Binding var isCalibrating: Bool
-        /// The initial camera controller elevation.
-        @Binding var initialElevation: Double
-        /// The elevation delta value after calibrating.
-        @State private var elevationDelta = 0.0
+        @ObservedObject
+        var viewModel: CalibrationViewModel
+        
+        /// A Boolean value that indicates if the user is presenting the calibration view.
+        @Binding
+        var isPresented: Bool
         /// A number format style for signed values with their fractional component removed.
         private let numberFormat = FloatingPointFormatStyle<Double>.number
             .precision(.fractionLength(1))
@@ -66,18 +109,18 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(heading, format: numberFormat) + Text("°")
+                            Text(viewModel.totalHeadingCorrection, format: numberFormat) + Text("°")
                             Spacer()
                         }
                     } onIncrement: {
-                        heading = (heading + 1).clamped(to: -180...180)
+                        viewModel.propose(headingCorrection: 1)
                     } onDecrement: {
-                        heading = (heading - 1).clamped(to: -180...180)
+                        viewModel.propose(headingCorrection: -1)
                     }
                 }
                 Joyslider()
                     .onChanged { delta in
-                        heading = (heading + delta).clamped(to: -180...180)
+                        viewModel.propose(headingCorrection: delta)
                     }
             }
         }
@@ -92,25 +135,19 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(elevationDelta, format: numberFormat) + Text(" m")
+                            Text(viewModel.totalElevationCorrection, format: numberFormat) + Text(" m")
                             Spacer()
                         }
                     } onIncrement: {
-                        elevation += 1
+                        viewModel.propose(elevationCorrection: 1)
                     } onDecrement: {
-                        elevation -= 1
+                        viewModel.propose(elevationCorrection: -1)
                     }
                 }
                 Joyslider()
                     .onChanged { delta in
-                        elevation += delta
+                        viewModel.propose(elevationCorrection: delta)
                     }
-            }
-            .onChange(of: elevation) { elevation in
-                elevationDelta =  elevation - initialElevation
-            }
-            .onAppear {
-                elevationDelta =  elevation - initialElevation
             }
         }
         
@@ -118,7 +155,7 @@ extension WorldScaleGeoTrackingSceneView {
         var dismissButton: some View {
             Button {
                 withAnimation {
-                    isCalibrating = false
+                    isPresented = false
                 }
             } label: {
                 Image(systemName: "xmark.circle.fill")

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -45,8 +45,8 @@ extension WorldScaleGeoTrackingSceneView {
             elevationSubject.eraseToAnyPublisher()
         }
         
-        /// Propose a heading correction.
-        /// This will limit the total heading correction to -180...180
+        /// Proposes a heading correction.
+        /// This will limit the total heading correction to -180...180.
         fileprivate func propose(headingCorrection: Double) {
             let newTotalHeadingCorrection = (totalHeadingCorrection + headingCorrection)
                 .clamped(to: -180...180)
@@ -55,7 +55,7 @@ extension WorldScaleGeoTrackingSceneView {
             headingSubject.send(allowedHeadingCorrection)
         }
         
-        /// Propose an elevation correction.
+        /// Proposes an elevation correction.
         fileprivate func propose(elevationCorrection: Double) {
             totalElevationCorrection += elevationCorrection
             elevationSubject.send(elevationCorrection)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -22,10 +22,6 @@ public struct WorldScaleGeoTrackingSceneView: View {
     @State private var arViewProxy = ARSwiftUIViewProxy()
     /// The camera controller that will be set on the scene view.
     @State private var cameraController: TransformationMatrixCameraController
-    /// The camera controller heading.
-    @State var heading: Double = 0
-    /// The camera controller elevation.
-    @State var elevation: Double = 0
     /// A Boolean value that indicates if the user is calibrating.
     @State var isCalibrating = false
     /// The current interface orientation.
@@ -52,8 +48,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
     private var validAccuracyThreshold = 0.0
     /// Determines the alignment of the calibration view.
     private var calibrationViewAlignment: Alignment = .bottom
-    /// The initial camera controller elevation.
-    @State private var initialElevation = 0.0
+    
+    @ObservedObject private var calibrationViewModel = CalibrationViewModel()
     
     /// Creates a world scale scene view.
     /// - Parameters:
@@ -141,13 +137,8 @@ public struct WorldScaleGeoTrackingSceneView: View {
             }
             .overlay(alignment: .bottom) {
                 if isCalibrating {
-                    CalibrationView(
-                        heading: $heading,
-                        elevation: $elevation,
-                        isCalibrating: $isCalibrating,
-                        initialElevation: $initialElevation
-                    )
-                    .padding(.bottom)
+                    CalibrationView(viewModel: calibrationViewModel, isPresented: $isCalibrating)
+                        .padding(.bottom)
                 }
             }
             .overlay(alignment: .top) {
@@ -188,17 +179,16 @@ public struct WorldScaleGeoTrackingSceneView: View {
                 }
             } catch {}
         }
-        .onChange(of: heading) { heading in
+        .onReceive(calibrationViewModel.headingCorrections) { correction in
             let originCamera = cameraController.originCamera
             cameraController.originCamera = originCamera.rotatedTo(
-                heading: heading,
+                heading: originCamera.heading + correction,
                 pitch: originCamera.pitch,
                 roll: originCamera.roll
             )
         }
-        .onChange(of: elevation) { elevation in
-            let elevationDelta = elevation - (cameraController.originCamera.location.z ?? 0)
-            cameraController.originCamera = cameraController.originCamera.elevated(by: elevationDelta)
+        .onReceive(calibrationViewModel.elevationCorrections) { correction in
+            cameraController.originCamera = cameraController.originCamera.elevated(by: correction)
         }
     }
     
@@ -225,26 +215,22 @@ public struct WorldScaleGeoTrackingSceneView: View {
         let altitude = (location.position.z ?? 0) + location.verticalAccuracy
         
         if !initialCameraIsSet {
-            let heading = 0.0
             cameraController.originCamera = Camera(
                 latitude: location.position.y,
                 longitude: location.position.x,
                 altitude: altitude,
-                heading: heading,
+                heading: 0,
                 pitch: 90,
                 roll: 0
             )
-            self.heading = heading
-            elevation = altitude
-            initialElevation = altitude
         } else {
             // Ignore location updates when calibrating heading and elevation.
             guard !isCalibrating else { return }
             cameraController.originCamera = Camera(
                 latitude: location.position.y,
                 longitude: location.position.x,
-                altitude: elevation,
-                heading: heading,
+                altitude: altitude + calibrationViewModel.totalElevationCorrection,
+                heading: calibrationViewModel.totalHeadingCorrection,
                 pitch: 90,
                 roll: 0
             )

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -48,7 +48,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
     private var validAccuracyThreshold = 0.0
     /// Determines the alignment of the calibration view.
     private var calibrationViewAlignment: Alignment = .bottom
-    
+    /// The view model for the calibration view.
     @ObservedObject private var calibrationViewModel = CalibrationViewModel()
     
     /// Creates a world scale scene view.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -49,7 +49,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
     /// Determines the alignment of the calibration view.
     private var calibrationViewAlignment: Alignment = .bottom
     /// The view model for the calibration view.
-    @ObservedObject private var calibrationViewModel = CalibrationViewModel()
+    @StateObject private var calibrationViewModel = CalibrationViewModel()
     
     /// Creates a world scale scene view.
     /// - Parameters:


### PR DESCRIPTION
The heading, elevation and initial elevation state variables seemed to add complication. The calibration view can just have a stream (publisher) of corrections and the corrections can be applied in real-time. Then when the total correction is needed (when a new location is received), the total correction can be applied at that time. All this can be tracked in a view model.