### PR TITLE
AR: Localize calibration view

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -91,7 +91,7 @@ extension WorldScaleGeoTrackingSceneView {
         var body: some View {
             VStack {
                 HStack(alignment: .firstTextBaseline) {
-                    Text("Calibration")
+                    Text(calibrationLabel)
                         .font(.title)
                         .lineLimit(1)
                     Spacer()
@@ -116,7 +116,7 @@ extension WorldScaleGeoTrackingSceneView {
                 HStack {
                     Stepper() {
                         HStack {
-                            Text("Heading")
+                            Text(headingLabel)
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
@@ -142,7 +142,7 @@ extension WorldScaleGeoTrackingSceneView {
                 HStack {
                     Stepper() {
                         HStack {
-                            Text("Elevation")
+                            Text(elevationLabel)
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
@@ -177,5 +177,38 @@ extension WorldScaleGeoTrackingSceneView {
             }
             .buttonStyle(.plain)
         }
+    }
+}
+
+private extension WorldScaleGeoTrackingSceneView.CalibrationView {
+    var calibrationLabel: String {
+        String(
+            localized: "Calibration",
+            bundle: .toolkitModule,
+            comment: """
+                 A label for the calibration view used to calibrate the camera
+                 for the AR experience.
+                 """
+        )
+    }
+    var headingLabel: String {
+        String(
+            localized: "heading",
+            bundle: .toolkitModule,
+            comment: """
+                 A label for the slider that adjusts the camera heading for the
+                 AR experience.
+                 """
+        )
+    }
+    var elevationLabel: String {
+        String(
+            localized: "elevation",
+            bundle: .toolkitModule,
+            comment: """
+                 A label for the slider that adjusts the camera elevation for the
+                 AR experience.
+                 """
+        )
     }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/CalibrationView.swift
@@ -72,10 +72,21 @@ extension WorldScaleGeoTrackingSceneView {
         /// A Boolean value that indicates if the user is presenting the calibration view.
         @Binding
         var isPresented: Bool
+        
         /// A number format style for signed values with their fractional component removed.
         private let numberFormat = FloatingPointFormatStyle<Double>.number
             .precision(.fractionLength(1))
             .sign(strategy: .always(includingZero: false))
+        
+        /// The total heading correction measurement in degrees.
+        private var totalHeadingCorrectionMeasurement: Measurement<UnitAngle> {
+            Measurement<UnitAngle>(value: viewModel.totalHeadingCorrection, unit: .degrees)
+        }
+        
+        /// The total elevation correction measurement in meters.
+        private var totalElevationCorrectionMeasurement: Measurement<UnitLength> {
+            Measurement<UnitLength>(value: viewModel.totalElevationCorrection, unit: .meters)
+        }
         
         var body: some View {
             VStack {
@@ -109,7 +120,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(viewModel.totalHeadingCorrection, format: numberFormat) + Text("°")
+                            Text(totalHeadingCorrectionMeasurement, format: .measurement(width: .narrow, numberFormatStyle: numberFormat))
                             Spacer()
                         }
                     } onIncrement: {
@@ -135,7 +146,7 @@ extension WorldScaleGeoTrackingSceneView {
                                 .font(.body.smallCaps())
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Text(viewModel.totalElevationCorrection, format: numberFormat) + Text(" m")
+                            Text(totalElevationCorrectionMeasurement, format: .measurement(width: .abbreviated, usage: .asProvided, numberFormatStyle: numberFormat))
                             Spacer()
                         }
                     } onIncrement: {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleGeoTrackingSceneView.swift
@@ -124,7 +124,7 @@ public struct WorldScaleGeoTrackingSceneView: View {
                                 isCalibrating = true
                             }
                         } label: {
-                            Text("Calibrate")
+                            Text(calibrateLabel)
                                 .padding()
                         }
                         .background(.regularMaterial)
@@ -309,5 +309,17 @@ public struct WorldScaleGeoTrackingSceneView: View {
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .padding([.horizontal, .top])
         }
+    }
+}
+
+private extension WorldScaleGeoTrackingSceneView {
+    var calibrateLabel: String {
+        String(
+            localized: "Calibrate",
+            bundle: .toolkitModule,
+            comment: """
+                 A label for a button to show the calibration view.
+                 """
+        )
     }
 }

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -38,6 +38,13 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A label for a button to open the system file browser. */
 "Browse" = "Browse";
 
+/* A label for a button to show the calibration view. */
+"Calibrate" = "Calibrate";
+
+/* A label for the calibration view used to calibrate the camera
+for the AR experience. */
+"Calibration" = "Calibration";
+
 /* A label for a button to cancel an operation. */
 "Cancel" = "Cancel";
 
@@ -84,6 +91,10 @@ network element for more than one trace starting point. */
 /* A label indicating an element could not be identified as a starting point
 for a utility network trace. */
 "Element could not be identified." = "Element could not be identified.";
+
+/* A label for the slider that adjusts the camera elevation for the
+AR experience. */
+"elevation" = "elevation";
 
 /* A label in reference to an error that occurred during a utility network trace. */
 "Error" = "Error";
@@ -133,6 +144,10 @@ contains one or more facilities in a floor-aware map or scene. */
 /* A label in reference to function outputs returned as results of a utility network
 trace operation. */
 "Function Results" = "Function Results";
+
+/* A label for the slider that adjusts the camera heading for the
+AR experience. */
+"heading" = "heading";
 
 /* A label in reference to media elements contained within a popup. */
 "Media" = "Media";


### PR DESCRIPTION
Closes `swift/4951`.

Localizes the labels for the calibration view and the units for heading and elevation. Once these changes are merged I will update the `l10n-staging` branch.