### PR TITLE
Don't show divider if input type is `nil`

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -139,7 +139,9 @@ extension FeatureFormView {
             EmptyView()
         }
         // BarcodeScannerFormInput is not currently supported
-        if element.isVisible && !(element.input is BarcodeScannerFormInput) {
+        if element.isVisible &&
+            !(element.input is BarcodeScannerFormInput) &&
+            element.input != nil {
             Divider()
         }
     }


### PR DESCRIPTION
This simply removes the divider if the input type is `nil`, as nothing but an empty view will be shown.