### PR TITLE
AR: Fix calibration view tap gesture conflict

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -90,8 +90,7 @@ public struct WorldScaleSceneView: View {
                         sceneView: sceneViewBuilder
                     )
                     .onSingleTapGesture { tapPoint in
-                        let scenePoint = arScreenToLocation(screenPoint: tapPoint)
-                        onSingeTapGestureAction?(tapPoint, scenePoint)
+                        handleSingleTap(tapPoint)
                     }
                 } else {
                     WorldTrackingSceneView(
@@ -105,8 +104,7 @@ public struct WorldScaleSceneView: View {
                         sceneView: sceneViewBuilder
                     )
                     .onSingleTapGesture { tapPoint in
-                        let scenePoint = arScreenToLocation(screenPoint: tapPoint)
-                        onSingeTapGestureAction?(tapPoint, scenePoint)
+                        handleSingleTap(tapPoint)
                     }
                 }
             case .geoTracking:
@@ -121,8 +119,7 @@ public struct WorldScaleSceneView: View {
                     sceneView: sceneViewBuilder
                 )
                 .onSingleTapGesture { tapPoint in
-                    let scenePoint = arScreenToLocation(screenPoint: tapPoint)
-                    onSingeTapGestureAction?(tapPoint, scenePoint)
+                    handleSingleTap(tapPoint)
                 }
             case .worldTracking:
                 WorldTrackingSceneView(
@@ -136,8 +133,7 @@ public struct WorldScaleSceneView: View {
                     sceneView: sceneViewBuilder
                 )
                 .onSingleTapGesture { tapPoint in
-                    let scenePoint = arScreenToLocation(screenPoint: tapPoint)
-                    onSingeTapGestureAction?(tapPoint, scenePoint)
+                    handleSingleTap(tapPoint)
                 }
             }
         }
@@ -192,6 +188,13 @@ public struct WorldScaleSceneView: View {
                     .padding(.bottom)
             }
         }
+    }
+    
+    /// Handles a single tap on the view.
+    /// - Parameter tapPoint: The tapped screen point.
+    private func handleSingleTap(_ tapPoint: CGPoint) {
+        let scenePoint = arScreenToLocation(screenPoint: tapPoint)
+        onSingeTapGestureAction?(tapPoint, scenePoint)
     }
     
     /// Sets the visibility of the calibration view for the AR experience.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -44,6 +44,8 @@ public struct WorldScaleSceneView: View {
     @State private var locationDataSource = SystemLocationDataSource()
     /// The error from the view.
     @State private var error: Error?
+    /// The closure to call upon a single tap.
+    private var onSingeTapGestureAction: ((CGPoint, Point?) -> Void)? = nil
     
     /// Creates a world scale scene view.
     /// - Parameters:
@@ -87,6 +89,10 @@ public struct WorldScaleSceneView: View {
                         locationDataSource: locationDataSource,
                         sceneView: sceneViewBuilder
                     )
+                    .onSingleTapGesture { tapPoint in
+                        let scenePoint = arScreenToLocation(screenPoint: tapPoint)
+                        onSingeTapGestureAction?(tapPoint, scenePoint)
+                    }
                 } else {
                     WorldTrackingSceneView(
                         arViewProxy: arViewProxy,
@@ -98,6 +104,10 @@ public struct WorldScaleSceneView: View {
                         locationDataSource: locationDataSource,
                         sceneView: sceneViewBuilder
                     )
+                    .onSingleTapGesture { tapPoint in
+                        let scenePoint = arScreenToLocation(screenPoint: tapPoint)
+                        onSingeTapGestureAction?(tapPoint, scenePoint)
+                    }
                 }
             case .geoTracking:
                 GeoTrackingSceneView(
@@ -110,6 +120,10 @@ public struct WorldScaleSceneView: View {
                     locationDataSource: locationDataSource,
                     sceneView: sceneViewBuilder
                 )
+                .onSingleTapGesture { tapPoint in
+                    let scenePoint = arScreenToLocation(screenPoint: tapPoint)
+                    onSingeTapGestureAction?(tapPoint, scenePoint)
+                }
             case .worldTracking:
                 WorldTrackingSceneView(
                     arViewProxy: arViewProxy,
@@ -121,6 +135,10 @@ public struct WorldScaleSceneView: View {
                     locationDataSource: locationDataSource,
                     sceneView: sceneViewBuilder
                 )
+                .onSingleTapGesture { tapPoint in
+                    let scenePoint = arScreenToLocation(screenPoint: tapPoint)
+                    onSingeTapGestureAction?(tapPoint, scenePoint)
+                }
             }
         }
         .onDisappear {
@@ -281,11 +299,9 @@ public extension WorldScaleSceneView {
     func onSingleTapGesture(
         perform action: @escaping (_ screenPoint: CGPoint, _ scenePoint: Point?) -> Void
     ) -> some View {
-        self
-            .onSingleTapGesture { tapPoint in
-                let scenePoint = arScreenToLocation(screenPoint: tapPoint)
-                action(tapPoint, scenePoint)
-            }
+        var copy = self
+        copy.onSingeTapGestureAction = action
+        return copy
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -79,62 +79,14 @@ public struct WorldScaleSceneView: View {
                 // By default we try the geo-tracking configuration. If it is not available at
                 // the current location, fall back to world-tracking.
                 if geoTrackingIsAvailable {
-                    GeoTrackingSceneView(
-                        arViewProxy: arViewProxy,
-                        cameraController: cameraController,
-                        calibrationViewModel: calibrationViewModel,
-                        clippingDistance: clippingDistance,
-                        initialCameraIsSet: $initialCameraIsSet,
-                        calibrationViewIsPresented: isCalibrating,
-                        locationDataSource: locationDataSource,
-                        sceneView: sceneViewBuilder
-                    )
-                    .onSingleTapGesture { tapPoint in
-                        handleSingleTap(tapPoint)
-                    }
+                    geoTrackingSceneView
                 } else {
-                    WorldTrackingSceneView(
-                        arViewProxy: arViewProxy,
-                        cameraController: cameraController,
-                        calibrationViewModel: calibrationViewModel,
-                        clippingDistance: clippingDistance,
-                        initialCameraIsSet: $initialCameraIsSet,
-                        calibrationViewIsPresented: isCalibrating,
-                        locationDataSource: locationDataSource,
-                        sceneView: sceneViewBuilder
-                    )
-                    .onSingleTapGesture { tapPoint in
-                        handleSingleTap(tapPoint)
-                    }
+                    worldTrackingSceneView
                 }
             case .geoTracking:
-                GeoTrackingSceneView(
-                    arViewProxy: arViewProxy,
-                    cameraController: cameraController,
-                    calibrationViewModel: calibrationViewModel,
-                    clippingDistance: clippingDistance,
-                    initialCameraIsSet: $initialCameraIsSet,
-                    calibrationViewIsPresented: isCalibrating,
-                    locationDataSource: locationDataSource,
-                    sceneView: sceneViewBuilder
-                )
-                .onSingleTapGesture { tapPoint in
-                    handleSingleTap(tapPoint)
-                }
+                geoTrackingSceneView
             case .worldTracking:
-                WorldTrackingSceneView(
-                    arViewProxy: arViewProxy,
-                    cameraController: cameraController,
-                    calibrationViewModel: calibrationViewModel,
-                    clippingDistance: clippingDistance,
-                    initialCameraIsSet: $initialCameraIsSet,
-                    calibrationViewIsPresented: isCalibrating,
-                    locationDataSource: locationDataSource,
-                    sceneView: sceneViewBuilder
-                )
-                .onSingleTapGesture { tapPoint in
-                    handleSingleTap(tapPoint)
-                }
+                worldTrackingSceneView
             }
         }
         .onDisappear {
@@ -187,6 +139,40 @@ public struct WorldScaleSceneView: View {
                 CalibrationView(viewModel: calibrationViewModel, isPresented: $isCalibrating)
                     .padding(.bottom)
             }
+        }
+    }
+    
+    /// A world scale geo-tracking scene view.
+    @ViewBuilder private var geoTrackingSceneView: some View {
+        GeoTrackingSceneView(
+            arViewProxy: arViewProxy,
+            cameraController: cameraController,
+            calibrationViewModel: calibrationViewModel,
+            clippingDistance: clippingDistance,
+            initialCameraIsSet: $initialCameraIsSet,
+            calibrationViewIsPresented: isCalibrating,
+            locationDataSource: locationDataSource,
+            sceneView: sceneViewBuilder
+        )
+        .onSingleTapGesture { tapPoint in
+            handleSingleTap(tapPoint)
+        }
+    }
+    
+    /// A world scale world-tracking scene view.
+    @ViewBuilder private var worldTrackingSceneView : some View {
+        WorldTrackingSceneView(
+            arViewProxy: arViewProxy,
+            cameraController: cameraController,
+            calibrationViewModel: calibrationViewModel,
+            clippingDistance: clippingDistance,
+            initialCameraIsSet: $initialCameraIsSet,
+            calibrationViewIsPresented: isCalibrating,
+            locationDataSource: locationDataSource,
+            sceneView: sceneViewBuilder
+        )
+        .onSingleTapGesture { tapPoint in
+            handleSingleTap(tapPoint)
         }
     }
     


### PR DESCRIPTION
Closes `swift/5014`.

Fixes bug where tap gestures on stepper controls in the calibration view were recognized on `WorldScaleSceneView`.