### PR TITLE
Handle Feature Form title changed event

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -66,16 +66,15 @@ public struct FeatureFormView: View {
     /// A Boolean value indicating whether the initial expression evaluation is running.
     @State var isEvaluatingInitialExpressions = true
     
+    /// The title of the feature form view.
+    @State private var title: String = ""
+
     /// Initializes a form view.
     /// - Parameters:
     ///   - featureForm: The feature form defining the editing experience.
     public init(featureForm: FeatureForm) {
         _model = StateObject(wrappedValue: FormViewModel(featureForm: featureForm))
-        title = featureForm.title
     }
-    
-    /// The title of the feature form view.
-    @State private var title: String
 
     public var body: some View {
         ScrollViewReader { scrollViewProxy in

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -96,7 +96,7 @@ public struct FeatureFormView: View {
                     withAnimation { scrollViewProxy.scrollTo(focusedElement, anchor: .top) }
                 }
             }
-            .onChangeOfTitle(of: model.featureForm) { newTitle in
+            .onTitleChange(of: model.featureForm) { newTitle in
                 title = newTitle
             }
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -71,8 +71,12 @@ public struct FeatureFormView: View {
     ///   - featureForm: The feature form defining the editing experience.
     public init(featureForm: FeatureForm) {
         _model = StateObject(wrappedValue: FormViewModel(featureForm: featureForm))
+        title = featureForm.title
     }
     
+    /// The title of the feature form view.
+    @State private var title: String
+
     public var body: some View {
         ScrollViewReader { scrollViewProxy in
             ScrollView {
@@ -80,7 +84,7 @@ public struct FeatureFormView: View {
                     ProgressView()
                 } else {
                     VStack(alignment: .leading) {
-                        FormHeader(title: model.featureForm.title)
+                        FormHeader(title: title)
                             .padding([.bottom], elementPadding)
                         ForEach(model.visibleElements, id: \.self) { element in
                             makeElement(element)
@@ -92,6 +96,9 @@ public struct FeatureFormView: View {
                 if let focusedElement = model.focusedElement {
                     withAnimation { scrollViewProxy.scrollTo(focusedElement, anchor: .top) }
                 }
+            }
+            .onChange(of: model.featureForm.title) { newTitle in
+                title = newTitle
             }
         }
         .scrollDismissesKeyboard(

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -97,7 +97,7 @@ public struct FeatureFormView: View {
                     withAnimation { scrollViewProxy.scrollTo(focusedElement, anchor: .top) }
                 }
             }
-            .onChange(of: model.featureForm.title) { newTitle in
+            .onChangeOfTitle(of: model.featureForm) { newTitle in
                 title = newTitle
             }
         }
@@ -147,8 +147,7 @@ extension FeatureFormView {
         }
         // BarcodeScannerFormInput is not currently supported
         if element.isVisible &&
-            !(element.input is BarcodeScannerFormInput) &&
-            element.input != nil {
+            !(element.input is BarcodeScannerFormInput) {
             Divider()
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -132,15 +132,15 @@ struct ComboBoxInput: View {
             element.updateValue(selectedValue?.code)
             model.evaluateExpressions()
         }
-        .onChangeOfValue(of: element) { newValue, newFormattedValue in
+        .onValueChange(of: element) { newValue, newFormattedValue in
             value = newValue
             formattedValue = newFormattedValue
             selectedValue = element.codedValues.first { $0.name == formattedValue }
         }
-        .onChangeOfIsRequired(of: element) { newIsRequired in
+        .onIsRequiredChange(of: element) { newIsRequired in
             isRequired = newIsRequired
         }
-        .onChangeOfIsEditable(of: element) { newIsEditable in
+        .onIsEditableChange(of: element) { newIsEditable in
             isEditable = newIsEditable
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -71,7 +71,7 @@ struct DateTimeInput: View {
             formattedValue = element.formattedValue
             model.evaluateExpressions()
         }
-        .onChangeOfValue(of: element) { newValue, newFormattedValue in
+        .onValueChange(of: element) { newValue, newFormattedValue in
             if newFormattedValue.isEmpty {
                 date = nil
             } else {
@@ -79,10 +79,10 @@ struct DateTimeInput: View {
             }
             formattedValue = newFormattedValue
         }
-        .onChangeOfIsRequired(of: element) { newIsRequired in
+        .onIsRequiredChange(of: element) { newIsRequired in
             isRequired = newIsRequired
         }
-        .onChangeOfIsEditable(of: element) { newIsEditable in
+        .onIsEditableChange(of: element) { newIsEditable in
             isEditable = newIsEditable
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
@@ -26,6 +26,11 @@ struct InputFooter: View {
     /// The form element the footer belongs to.
     let element: FieldFormElement
     
+    /// An ID regenerated each time the element's value changes.
+    ///
+    /// Allows the footer to be recomputed to reflect changes in validation errors or input length.
+    @State private var id = UUID()
+    
     var body: some View {
         HStack(alignment: .top) {
             Group {
@@ -56,6 +61,12 @@ struct InputFooter: View {
         }
         .font(.footnote)
         .foregroundColor(isShowingError ? .red : .secondary)
+        .id(id)
+        .task {
+            for await _ in element.$value {
+                id = UUID()
+            }
+        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -110,14 +110,14 @@ struct RadioButtonsInput: View {
                 element.updateValue(selectedValue?.code)
                 model.evaluateExpressions()
             }
-            .onChangeOfValue(of: element) { newValue, newFormattedValue in
+            .onValueChange(of: element) { newValue, newFormattedValue in
                 value = newValue
                 selectedValue = element.codedValues.first { $0.name == newFormattedValue }
             }
-            .onChangeOfIsRequired(of: element) { newIsRequired in
+            .onIsRequiredChange(of: element) { newIsRequired in
                 isRequired = newIsRequired
             }
-            .onChangeOfIsEditable(of: element) { newIsEditable in
+            .onIsEditableChange(of: element) { newIsEditable in
                 isEditable = newIsEditable
             }
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -93,13 +93,13 @@ struct SwitchInput: View {
                 element.updateValue(isOn ? input.onValue.code : input.offValue.code)
                 model.evaluateExpressions()
             }
-            .onChangeOfValue(of: element) { newValue, newFormattedValue in
+            .onValueChange(of: element) { newValue, newFormattedValue in
                 isOn = newFormattedValue == input.onValue.name
             }
-            .onChangeOfIsRequired(of: element) { newIsRequired in
+            .onIsRequiredChange(of: element) { newIsRequired in
                 isRequired = newIsRequired
             }
-            .onChangeOfIsEditable(of: element) { newIsEditable in
+            .onIsEditableChange(of: element) { newIsEditable in
                 isEditable = newIsEditable
             }
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -102,14 +102,14 @@ struct TextInput: View {
                 model.evaluateExpressions()
             }
         }
-        .onChangeOfValue(of: element) { newValue, newFormattedValue in
+        .onValueChange(of: element) { newValue, newFormattedValue in
             formattedValue = newFormattedValue
             updateText()
         }
-        .onChangeOfIsRequired(of: element) { newIsRequired in
+        .onIsRequiredChange(of: element) { newIsRequired in
             isRequired = newIsRequired
         }
-        .onChangeOfIsEditable(of: element) { newIsEditable in
+        .onIsEditableChange(of: element) { newIsEditable in
             isEditable = newIsEditable
         }
     }

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View+FeatureForm.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View+FeatureForm.swift
@@ -1,0 +1,36 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArcGIS
+import Combine
+import SwiftUI
+
+extension View {
+    /// Modifier for watching ``FeatureForm.titleChanged`` events.
+    /// - Parameters:
+    ///   - featureForm: The feature form to watch for changes on.
+    ///   - action: The action which watches for changes.
+    /// - Returns: The modified view.
+    func onChangeOfTitle(
+        of featureForm: FeatureForm,
+        action: @escaping (_ newTitle: String) -> Void
+    ) -> some View {
+        return self
+            .task(id: ObjectIdentifier(featureForm)) {
+                for await title in featureForm.$title {
+                    action(title)
+                }
+            }
+    }
+}

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View+FormInput.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View+FormInput.swift
@@ -22,7 +22,7 @@ extension View {
     ///   - element: The form element to watch for changes on.
     ///   - action: The action which watches for changes.
     /// - Returns: The modified view.
-    func onChangeOfIsEditable(
+    func onIsEditableChange(
         of element: FieldFormElement,
         action: @escaping (_ newIsEditable: Bool) -> Void
     ) -> some View {
@@ -39,7 +39,7 @@ extension View {
     ///   - element: The form element to watch for changes on.
     ///   - action: The action which watches for changes.
     /// - Returns: The modified view.
-    func onChangeOfIsRequired(
+    func onIsRequiredChange(
         of element: FieldFormElement,
         action: @escaping (_ newIsRequired: Bool) -> Void
     ) -> some View {
@@ -56,7 +56,7 @@ extension View {
     ///   - element: The form element to watch for changes on.
     ///   - action: The action which watches for changes.
     /// - Returns: The modified view.
-    func onChangeOfValue(
+    func onValueChange(
         of element: FieldFormElement,
         action: @escaping (_ newValue: Any?, _ newFormattedValue: String) -> Void
     ) -> some View {


### PR DESCRIPTION
Apollo # 488

Add `. onChangeOfTitle` modifier to `View` and use it to handle changes to `FeatureForm.title`.

Also fix compile warning with `element.input != nil` as now `input` is non-nullable`.

~Should be merged AFTER https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/593, as this is based on that work.~ #593 has been merged.