### PR TITLE
Change combo box picker Done button color to .accentColor

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -145,8 +145,9 @@ extension FeatureFormView {
             EmptyView()
         }
         // BarcodeScannerFormInput is not currently supported
-        if element.isVisible &&
-            !(element.input is BarcodeScannerFormInput) {
+        if element.isVisible,
+            !(element.input is BarcodeScannerFormInput),
+           !(element.input is UnsupportedFormInput) {
             Divider()
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -146,7 +146,7 @@ extension FeatureFormView {
         }
         // BarcodeScannerFormInput is not currently supported
         if element.isVisible,
-            !(element.input is BarcodeScannerFormInput),
+           !(element.input is BarcodeScannerFormInput),
            !(element.input is UnsupportedFormInput) {
             Divider()
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -205,6 +205,7 @@ struct ComboBoxInput: View {
                         } label: {
                             Text.done
                                 .fontWeight(.semibold)
+                                .foregroundColor(.accentColor)
                         }
                         .buttonStyle(.plain)
                     }


### PR DESCRIPTION
Apollo # 502 - Swift - Toolkit - Combo box "Done" button blends in

Also, Apollo # 492 - UnsupportedElement/Input toolkit implementation -- Swift