### PR TITLE
Combo Box Clear button should only show if the field is not required

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -101,17 +101,21 @@ struct ComboBoxInput: View {
                     .foregroundColor(selectedValue != nil ? .primary : .secondary)
                     .accessibilityIdentifier("\(element.label) Value")
                 if isEditable {
-                    if selectedValue == nil {
-                        Image(systemName: "list.bullet")
-                            .foregroundColor(.secondary)
-                            .accessibilityIdentifier("\(element.label) Options Button")
-                    } else {
+                    if selectedValue != nil, !isRequired {
+                        // Only show clear button if we have a value
+                        // and we're not required. (i.e., Don't show clear if
+                        // the field is required.)
                         ClearButton {
                             model.focusedElement = element
                             defer { model.focusedElement = nil }
                             selectedValue = nil
                         }
                         .accessibilityIdentifier("\(element.label) Clear Button")
+                    } else {
+                        // Otherwise, always show list icon.
+                        Image(systemName: "list.bullet")
+                            .foregroundColor(.secondary)
+                            .accessibilityIdentifier("\(element.label) Options Button")
                     }
                 }
             }

--- a/Test Runner/UI Tests/FormViewTests.swift
+++ b/Test Runner/UI Tests/FormViewTests.swift
@@ -976,26 +976,14 @@ final class FeatureFormViewTests: XCTestCase {
             "Pine"
         )
         
-        XCTAssertTrue(
+        XCTAssertFalse(
             clearButton.isHittable,
-            "The clear button isn't hittable."
-        )
-        
-        clearButton.tap()
-        
-        XCTAssertEqual(
-            fieldValue.label,
-            "Enter Value"
+            "The clear button is hittable."
         )
         
         XCTAssertTrue(
             footer.exists,
             "The footer doesn't exist."
-        )
-        
-        XCTAssertEqual(
-            footer.label,
-            "Required"
         )
         
         fieldValue.tap()


### PR DESCRIPTION
Apollo # 501

Only show the Clear button in the combo box input if the field is not required AND there is an existing value.