### PR TITLE
Catalyst Updates.

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
@@ -38,8 +38,11 @@ struct InputHeader: View {
     }
     
     var body: some View {
-        Text(verbatim: "\(label + (isRequired ? " *" : ""))")
-            .font(.subheadline)
-            .foregroundColor(.secondary)
+        HStack {
+            Text(verbatim: "\(label + (isRequired ? " *" : ""))")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Spacer()
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
@@ -49,20 +49,20 @@ struct GroupView<Content>: View where Content: View {
     }
     
     var body: some View {
-        DisclosureGroup(self.element.label, isExpanded: $isExpanded) {
-            Group {
-                Text(element.description)
-                    .accessibilityIdentifier("\(element.label) Description")
-                    .font(.subheadline)
-                Divider()
+        Group {
+            DisclosureGroup(isExpanded: $isExpanded) {
                 ForEach(visibleElements, id: \.label) { formElement in
                     if let element = formElement as? FieldFormElement {
                         viewCreator(element)
                     }
                 }
+            } label: {
+                Header(element: element)
+                    .catalystPadding(4)
             }
-            // Reapply leading alignment for content within the DisclosureGroup
-            .frame(maxWidth: .infinity, alignment: .leading)
+            if !isExpanded {
+                Divider()
+            }
         }
         .onAppear {
             element.elements.forEach { element in
@@ -81,6 +81,37 @@ struct GroupView<Content>: View where Content: View {
                 task.cancel()
             }
             isVisibleTasks.removeAll()
+        }
+    }
+}
+
+extension GroupView {
+    /// A view displaying a label and description of a `GroupFormElement`.
+    struct Header: View {
+        let element: GroupFormElement
+        
+        var body: some View {
+            VStack(alignment: .leading) {
+                // Text views with empty text still take up some vertical space in
+                // a view, so conditionally check for an empty title and description.
+                if !element.label.isEmpty {
+                    Text(element.label)
+                        .multilineTextAlignment(.leading)
+                        .font(.title2)
+                        .foregroundColor(.primary)
+                }
+                
+                if !element.description.isEmpty {
+                    Text(element.description)
+                        .multilineTextAlignment(.leading)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("\(element.label) Description")
+                }
+            }
+#if targetEnvironment(macCatalyst)
+            .padding(.leading, 4)
+#endif
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
@@ -99,6 +99,7 @@ extension GroupView {
                         .multilineTextAlignment(.leading)
                         .font(.title2)
                         .foregroundColor(.primary)
+                        .accessibilityIdentifier("\(element.label)")
                 }
                 
                 if !element.description.isEmpty {

--- a/Test Runner/UI Tests/FormViewTests.swift
+++ b/Test Runner/UI Tests/FormViewTests.swift
@@ -1262,9 +1262,9 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_6_1() {
         let app = XCUIApplication()
         let collapsedGroupFirstElement = app.staticTexts["Single Line Text"]
-        let collapsedGroup = app.disclosureTriangles["Group with Multiple Form Elements 2"]
+        let collapsedGroup = app.staticTexts["Group with Multiple Form Elements 2"]
         let expandedGroupFirstElement = app.staticTexts["MultiLine Text"]
-        let expandedGroup = app.disclosureTriangles["Group with Multiple Form Elements"]
+        let expandedGroup = app.staticTexts["Group with Multiple Form Elements"]
         let expandedGroupDescription = app.staticTexts["Group with Multiple Form Elements Description"]
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
         let formViewTestsButton = app.buttons["Feature Form Tests"]
@@ -1321,7 +1321,7 @@ final class FeatureFormViewTests: XCTestCase {
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
         let formViewTestsButton = app.buttons["Feature Form Tests"]
         let showElementsButton = app.buttons["show invisible form element"]
-        let hiddenElementsGroup = app.disclosureTriangles["Group with children that are visible dependent"]
+        let hiddenElementsGroup = app.staticTexts["Group with children that are visible dependent"]
         let hiddenElementsGroupDescription = app.staticTexts["Group with children that are visible dependent Description"]
         let groupElement = app.staticTexts["single line text 3"]
         


### PR DESCRIPTION
Apollo # 307 - Group element title & caret coloring
Apollo # 293 - Group view on Mac Catalyst is ugly

This also fixes field element label alignment on Catalyst, which was displaying the labels as "centered".