### PR TITLE
Only show clear button in DateIinput if date is not required

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -113,7 +113,7 @@ struct DateTimeInput: View {
                     Image(systemName: "calendar")
                         .foregroundColor(.secondary)
                         .accessibilityIdentifier("\(element.label) Calendar Image")
-                } else {
+                } else if !isRequired {
                     ClearButton {
                         model.focusedElement = element
                         defer { model.focusedElement = nil }


### PR DESCRIPTION
Finalizes the Clear button updates based on the latest design [here](https://devtopia.esri.com/runtime/common-toolkit/blob/main/designs/Forms/InputValidationDesign.md#clear-button-usage).