### PR TITLE
AR: Fix timing crash for `initialCameraIsSet`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -172,7 +172,9 @@ public struct GeoTrackingSceneView: View {
     private func handleGeoTrackingStatusChange(_ status: ARGeoTrackingStatus) {
         switch status.state {
         case .notAvailable, .initializing, .localizing:
-            initialCameraIsSet = false
+            Task.detached { @MainActor in
+                initialCameraIsSet = false
+            }
         case .localized:
             // Update the camera controller every time geo-tracking is localized,
             // to ensure the best experience.
@@ -184,7 +186,9 @@ public struct GeoTrackingSceneView: View {
                     heading: currentHeading + 90,
                     altitude: currentLocation.position.z ?? 0
                 )
-                initialCameraIsSet = true
+                Task.detached { @MainActor in
+                    initialCameraIsSet = true
+                }
             }
         @unknown default:
             fatalError("Unknown ARGeoTrackingStatus.State")

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -96,11 +96,9 @@ public struct GeoTrackingSceneView: View {
                     .onDidChangeGeoTrackingStatus { _, status in
                         handleGeoTrackingStatusChange(status)
                     }
-                
-                if initialCameraIsSet {
-                    sceneViewBuilder(sceneViewProxy)
-                        .worldScaleSetup(cameraController: cameraController)
-                }
+                sceneViewBuilder(sceneViewProxy)
+                    .worldScaleSetup(cameraController: cameraController)
+                    .opacity(initialCameraIsSet ? 1 : 0)
             }
             .ignoresSafeArea(.all)
             .overlay {
@@ -172,9 +170,7 @@ public struct GeoTrackingSceneView: View {
     private func handleGeoTrackingStatusChange(_ status: ARGeoTrackingStatus) {
         switch status.state {
         case .notAvailable, .initializing, .localizing:
-            Task.detached { @MainActor in
-                initialCameraIsSet = false
-            }
+            initialCameraIsSet = false
         case .localized:
             // Update the camera controller every time geo-tracking is localized,
             // to ensure the best experience.
@@ -186,9 +182,7 @@ public struct GeoTrackingSceneView: View {
                     heading: currentHeading + 90,
                     altitude: currentLocation.position.z ?? 0
                 )
-                Task.detached { @MainActor in
-                    initialCameraIsSet = true
-                }
+                initialCameraIsSet = true
             }
         @unknown default:
             fatalError("Unknown ARGeoTrackingStatus.State")

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -112,14 +112,12 @@ struct WorldTrackingSceneView: View {
                             orientation: interfaceOrientation
                         )
                     }
-                
-                if initialCameraIsSet {
-                    sceneViewBuilder(sceneViewProxy)
-                        .worldScaleSetup(cameraController: cameraController)
-                        .onCameraChanged { camera in
-                            currentCamera = camera
-                        }
-                }
+                sceneViewBuilder(sceneViewProxy)
+                    .worldScaleSetup(cameraController: cameraController)
+                    .onCameraChanged { camera in
+                        currentCamera = camera
+                    }
+                    .opacity(initialCameraIsSet ? 1 : 0)
             }
             .ignoresSafeArea(.all)
             .overlay {


### PR DESCRIPTION
See `swift/issues/4991` and https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/581#discussion_r1496354549

I tried a few ideas, but couldn't get it work, so I used the detached task here to force the boolean to be set on the next runloop cycle (source [here](https://www.hackingwithswift.com/quick-start/concurrency/how-to-use-mainactor-to-run-code-on-the-main-queue)).

Other ideas I tried…

1. Mark `onDidUpdateFrame(perform:)` as MainActor. Because the crash happens on this modifier, my thinking was that putting it on the main serial queue will ensure:
    - this modifier is strictly executed **after**, not the same time, as `sceneViewBuilder` view being instantiated, so the core scene view exists when the FOV intrinsics are set
    - by running the modifier on main thread, other potential SwiftUI UI level issue are avoided
2. Mark `setFieldOfView(for:orientation:)` as MainActor. This method is further deep in the crash stack. The thinking was to at least make this method run **after** the scene view builder is instantiated, to ensure core scene view is there.

Neither of these 2 ideas worked, so I opted for the old solution to delay the Boolean setter by 1 cycle. I'm not sure how that affects the main queue sequencing, but assume it gives more time for the scene view builder to initialize before the `setFieldOfView` method runs. Again, only wish SwiftUI is open source… so we can see *when* the views are exactly drawn. 🥲 