### PR TITLE
`FeatureFormView` - Various revisions

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -139,18 +139,3 @@ extension FeatureFormView {
         }
     }
 }
-
-private extension View {
-    /// Configures the behavior in which scrollable content interacts with the software keyboard.
-    /// - Returns: A view that dismisses the keyboard when the  scroll.
-    /// - Parameter immediately: A Boolean value that will cause the keyboard to the keyboard to
-    /// dismiss as soon as scrolling starts when `true` and interactively when `false`.
-    func scrollDismissesKeyboard(immediately: Bool) -> some View {
-        if #available(iOS 16.0, *) {
-            return self
-                .scrollDismissesKeyboard(immediately ? .immediately : .interactively)
-        } else {
-            return self
-        }
-    }
-}

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -84,7 +84,7 @@ public struct FeatureFormView: View {
                 } else {
                     VStack(alignment: .leading) {
                         FormHeader(title: title)
-                            .padding([.bottom], elementPadding)
+                            .padding(.bottom, elementPadding)
                         ForEach(model.visibleElements, id: \.self) { element in
                             makeElement(element)
                         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -64,7 +64,7 @@ public struct FeatureFormView: View {
     @StateObject private var model: FormViewModel
     
     /// A Boolean value indicating whether the initial expression evaluation is running.
-    @State var isEvaluatingInitialExpressions = true
+    @State private var isEvaluatingInitialExpressions = true
     
     /// The title of the feature form view.
     @State private var title: String = ""

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
@@ -20,8 +20,8 @@ struct FormInputStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .frame(minHeight: 30)
-            .padding([.horizontal], 10)
-            .padding([.vertical], 5)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
             .background(Color(uiColor: .tertiarySystemFill))
             .cornerRadius(10)
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -19,8 +19,6 @@ import SwiftUI
 ///
 /// This is the preferable input type for long lists of coded value domains.
 struct ComboBoxInput: View {
-    @Environment(\.formElementPadding) var elementPadding
-    
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
@@ -91,7 +89,6 @@ struct ComboBoxInput: View {
     var body: some View {
         VStack(alignment: .leading) {
             InputHeader(label: element.label, isRequired: isRequired)
-                .padding([.top], elementPadding)
             
             HStack {
                 Text(selectedValue?.name ?? placeholderValue)
@@ -127,7 +124,6 @@ struct ComboBoxInput: View {
             
             InputFooter(element: element)
         }
-        .padding([.bottom], elementPadding)
         .onChange(of: selectedValue) { selectedValue in
             element.updateValue(selectedValue?.code)
             model.evaluateExpressions()

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -183,6 +183,7 @@ struct DateTimeInput: View {
             input.includesTime ? Text.now : .today
         }
         .accessibilityIdentifier("\(element.label) \(input.includesTime ? "Now" : "Today") Button")
+        .buttonStyle(.plain)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -17,8 +17,6 @@ import ArcGIS
 
 /// A view for date/time input.
 struct DateTimeInput: View {
-    @Environment(\.formElementPadding) var elementPadding
-    
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
@@ -55,13 +53,11 @@ struct DateTimeInput: View {
     var body: some View {
         Group {
             InputHeader(element: element)
-                .padding([.top], elementPadding)
             
             dateEditor
             
             InputFooter(element: element)
         }
-        .padding([.bottom], elementPadding)
         .onChange(of: model.focusedElement) { focusedElement in
             isEditing = focusedElement == element
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
@@ -17,11 +17,13 @@ import SwiftUI
 
 /// A view shown at the bottom of a field element in a form.
 struct InputFooter: View {
-    /// The view model for the form.
-    @EnvironmentObject var model: FormViewModel
+    @Environment(\.formElementPadding) var elementPadding
     
     /// The validation error visibility configuration of a form.
     @Environment(\.validationErrorVisibility) private var validationErrorVisibility
+    
+    /// The view model for the form.
+    @EnvironmentObject var model: FormViewModel
     
     /// The form element the footer belongs to.
     let element: FieldFormElement
@@ -62,6 +64,7 @@ struct InputFooter: View {
         .font(.footnote)
         .foregroundColor(isShowingError ? .red : .secondary)
         .id(id)
+        .padding(.bottom, elementPadding)
         .task {
             for await _ in element.$value {
                 id = UUID()

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
@@ -17,6 +17,8 @@ import ArcGIS
 
 /// A view shown at the top of a field element in a form.
 struct InputHeader: View {
+    @Environment(\.formElementPadding) var elementPadding
+    
     /// The name of the form element.
     let label: String
     
@@ -44,5 +46,6 @@ struct InputHeader: View {
                 .foregroundColor(.secondary)
             Spacer()
         }
+        .padding(.top, elementPadding)
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -19,8 +19,6 @@ import SwiftUI
 ///
 /// This is the preferable input type for short lists of coded value domains.
 struct RadioButtonsInput: View {
-    @Environment(\.formElementPadding) var elementPadding
-    
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
@@ -65,7 +63,6 @@ struct RadioButtonsInput: View {
         } else {
             Group {
                 InputHeader(label: element.label, isRequired: isRequired)
-                    .padding([.top], elementPadding)
                 
                 VStack(alignment: .leading, spacing: .zero) {
                     if input.noValueOption == .show {
@@ -96,7 +93,6 @@ struct RadioButtonsInput: View {
                 
                 InputFooter(element: element)
             }
-            .padding([.bottom], elementPadding)
             .onAppear {
                 if let selectedValue = element.codedValues.first(where: { $0.name == element.formattedValue }) {
                     self.selectedValue = selectedValue

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
@@ -17,8 +17,6 @@ import SwiftUI
 
 /// A view for a read only field form element.
 struct ReadOnlyInput: View {
-    @Environment(\.formElementPadding) var elementPadding
-    
     @State private var formattedValue: String = ""
     
     /// The input's parent element.
@@ -27,7 +25,7 @@ struct ReadOnlyInput: View {
     var body: some View {
         Group {
             InputHeader(label: element.label, isRequired: false)
-                .padding(.top, elementPadding)
+            
             if element.isMultiline {
                 textReader
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -37,7 +35,6 @@ struct ReadOnlyInput: View {
                 }
             }
             InputFooter(element: element)
-                .padding(.bottom, elementPadding)
         }
         .accessibilityIdentifier("\(element.label) Read Only Input")
         .onAppear {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -19,8 +19,6 @@ import SwiftUI
 ///
 /// The switch represents two mutually exclusive values, such as: yes/no, on/off, true/false.
 struct SwitchInput: View {
-    @Environment(\.formElementPadding) var elementPadding
-    
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
@@ -68,19 +66,19 @@ struct SwitchInput: View {
         } else {
             Group {
                 InputHeader(label: element.label, isRequired: isRequired)
-                    .padding([.top], elementPadding)
+                
                 HStack {
                     Text(isOn ? input.onValue.name : input.offValue.name)
                         .accessibilityIdentifier("\(element.label) Switch Label")
                     Spacer()
                     Toggle("", isOn: $isOn)
-                        .toggleStyle(.switch)
                         .accessibilityIdentifier("\(element.label) Switch")
+                        .toggleStyle(.switch)
                 }
                 .formInputStyle()
+                
                 InputFooter(element: element)
             }
-            .padding([.bottom], elementPadding)
             .onAppear {
                 if element.formattedValue.isEmpty {
                     fallbackToComboBox = true

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -17,8 +17,6 @@ import SwiftUI
 
 /// A view for text input.
 struct TextInput: View {
-    @Environment(\.formElementPadding) var elementPadding
-    
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
@@ -59,11 +57,13 @@ struct TextInput: View {
     }
     
     var body: some View {
-        InputHeader(label: element.label, isRequired: isRequired)
-            .padding([.top], elementPadding)
-        textWriter
-        InputFooter(element: element)
-        .padding([.bottom], elementPadding)
+        Group {
+            InputHeader(label: element.label, isRequired: isRequired)
+            
+            textWriter
+            
+            InputFooter(element: element)
+        }
         .onChange(of: isFocused) { isFocused in
             if isFocused && isPlaceholder {
                 isPlaceholder = false
@@ -114,12 +114,12 @@ private extension TextInput {
         HStack(alignment: .bottom) {
             Group {
                 if #available(iOS 16.0, *) {
-                        TextField(
-                            element.label,
-                            text: $text,
-                            prompt: Text(element.hint).foregroundColor(.secondary),
-                            axis: element.isMultiline ? .vertical : .horizontal
-                        )
+                    TextField(
+                        element.label,
+                        text: $text,
+                        prompt: Text(element.hint).foregroundColor(.secondary),
+                        axis: element.isMultiline ? .vertical : .horizontal
+                    )
                 } else if element.isMultiline {
                     TextEditor(text: $text)
                         .foregroundColor(isPlaceholder ? .secondary : .primary)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import Combine
 import SwiftUI
 
 /// - Since: 200.4

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
@@ -16,7 +16,7 @@ import ArcGIS
 import SwiftUI
 
 /// - Since: 200.4
-@MainActor public class FormViewModel: ObservableObject {
+@MainActor class FormViewModel: ObservableObject {
     /// The feature form.
     private(set) var featureForm: FeatureForm
     

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View+FormInput.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View+FormInput.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import Combine
 import SwiftUI
 
 extension View {

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -92,6 +92,19 @@ extension View {
             .padding(isMacCatalyst ? [.horizontal] : [], length)
     }
     
+    /// Configures the behavior in which scrollable content interacts with the software keyboard.
+    /// - Returns: A view that dismisses the keyboard when the  scroll.
+    /// - Parameter immediately: A Boolean value that will cause the keyboard to the keyboard to
+    /// dismiss as soon as scrolling starts when `true` and interactively when `false`.
+    func scrollDismissesKeyboard(immediately: Bool) -> some View {
+        if #available(iOS 16.0, *) {
+            return self
+                .scrollDismissesKeyboard(immediately ? .immediately : .interactively)
+        } else {
+            return self
+        }
+    }
+    
     /// View modifier used to denote the view is selected.
     /// - Parameter isSelected: `true` if the view is selected, `false` otherwise.
     /// - Returns: The modified view.

--- a/Test Runner/UI Tests/FormViewTests.swift
+++ b/Test Runner/UI Tests/FormViewTests.swift
@@ -1262,12 +1262,19 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_6_1() {
         let app = XCUIApplication()
         let collapsedGroupFirstElement = app.staticTexts["Single Line Text"]
-        let collapsedGroup = app.staticTexts["Group with Multiple Form Elements 2"]
         let expandedGroupFirstElement = app.staticTexts["MultiLine Text"]
-        let expandedGroup = app.staticTexts["Group with Multiple Form Elements"]
-        let expandedGroupDescription = app.staticTexts["Group with Multiple Form Elements Description"]
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
         let formViewTestsButton = app.buttons["Feature Form Tests"]
+        
+#if targetEnvironment(macCatalyst)
+        let collapsedGroup = app.disclosureTriangles["Group with Multiple Form Elements 2"]
+        let expandedGroup = app.disclosureTriangles["Group with Multiple Form Elements"]
+        let expandedGroupDescription = app.disclosureTriangles["Group with Multiple Form Elements Description"]
+#else
+        let collapsedGroup = app.staticTexts["Group with Multiple Form Elements 2"]
+        let expandedGroup = app.staticTexts["Group with Multiple Form Elements"]
+        let expandedGroupDescription = app.staticTexts["Group with Multiple Form Elements Description"]
+#endif
         
         app.launch()
         


### PR DESCRIPTION
- Makes `FormViewModel` non-public
- Removes an unneeded `Combine` import
- Fixes a `@State` property that should’ve been marked private
- Unifies padding usage and moves padding directly onto the header/footer
- Relocates an extension on `View` to the proper extensions file
- Applies plain button styling on the today/now button in the calendar picker for macCatalyst
- Applies auto-indent to `TextInput.swift`
- Fixes test 6.1 for macCatalyst