### PR TITLE
AR: Fix safe area

### DIFF
--- a/Examples/Examples/WorldScaleExampleView.swift
+++ b/Examples/Examples/WorldScaleExampleView.swift
@@ -63,7 +63,7 @@ struct WorldScaleExampleView: View {
         .onSingleTapGesture { _, scenePoint in
             graphicsOverlay.addGraphic(Graphic(geometry: scenePoint))
         }
-        .ignoresSafeArea(edges: .bottom)
+        .ignoresSafeArea(edges: [.horizontal, .bottom])
         .task {
             // Request when-in-use location authorization.
             // This is necessary for 2 reasons:

--- a/Examples/Examples/WorldScaleExampleView.swift
+++ b/Examples/Examples/WorldScaleExampleView.swift
@@ -63,6 +63,7 @@ struct WorldScaleExampleView: View {
         .onSingleTapGesture { _, scenePoint in
             graphicsOverlay.addGraphic(Graphic(geometry: scenePoint))
         }
+        .ignoresSafeArea(edges: .bottom)
         .task {
             // Request when-in-use location authorization.
             // This is necessary for 2 reasons:

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -111,7 +111,6 @@ public struct GeoTrackingSceneView: View {
                         .worldScaleSetup(cameraController: cameraController)
                 }
             }
-            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -111,7 +111,7 @@ public struct GeoTrackingSceneView: View {
                         .worldScaleSetup(cameraController: cameraController)
                 }
             }
-            .edgesIgnoringSafeArea(.bottom)
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -111,7 +111,7 @@ public struct GeoTrackingSceneView: View {
                         .worldScaleSetup(cameraController: cameraController)
                 }
             }
-            .ignoresSafeArea(.all)
+            .edgesIgnoringSafeArea(.bottom)
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -127,7 +127,6 @@ struct WorldTrackingSceneView: View {
                         }
                 }
             }
-            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -127,7 +127,7 @@ struct WorldTrackingSceneView: View {
                         }
                 }
             }
-            .ignoresSafeArea(.all)
+            .edgesIgnoringSafeArea(.bottom)
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -127,7 +127,7 @@ struct WorldTrackingSceneView: View {
                         }
                 }
             }
-            .edgesIgnoringSafeArea(.bottom)
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)


### PR DESCRIPTION
This PR changes the safe area from ignoring all edges to only the bottom edge. When the top edge safe area is ignored when the `WorldScaleSceneView` is used with a navigation bar, the navigation bar is transparent and the camera feed is visible:

<img width="500" alt="Screenshot 2024-03-18 at 1 31 32 PM" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/117859673/f6030411-f0c4-4fcb-84ad-8db68beb3063">



This safe area change fixes the navigation bar appearance and looks like this when there is no navigation bar present:
<img width="500" alt="Screenshot 2024-03-18 at 1 32 49 PM" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/117859673/9fc07a2c-dc69-48c9-bfb6-c00115d17215">
