### PR TITLE
AR: default tracking mode

### DIFF
--- a/Examples/Examples/WorldScaleExampleView.swift
+++ b/Examples/Examples/WorldScaleExampleView.swift
@@ -49,7 +49,7 @@ struct WorldScaleExampleView: View {
     @State private var locationDataSource = SystemLocationDataSource()
     
     var body: some View {
-        WorldScaleSceneView(trackingMode: .worldTracking) { proxy in
+        WorldScaleSceneView { proxy in
             SceneView(scene: scene, graphicsOverlays: [graphicsOverlay])
                 .onSingleTapGesture { screen, _ in
                     print("Identifying...")

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -63,7 +63,7 @@ public struct WorldScaleSceneView: View {
     /// and view drawing mode.
     public init(
         clippingDistance: Double? = nil,
-        trackingMode: TrackingMode,
+        trackingMode: TrackingMode = .worldTracking,
         sceneViewBuilder: @escaping (SceneViewProxy) -> SceneView
     ) {
         self.clippingDistance = clippingDistance

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep1.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep1.swift
@@ -5,8 +5,7 @@ import ArcGISToolkit
 struct WorldScaleExampleView: View {
     var body: some View {
         WorldScaleSceneView(
-            clippingDistance: 400,
-            trackingMode: .worldScale
+            clippingDistance: 400
         )
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep2.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep2.swift
@@ -20,8 +20,7 @@ struct WorldScaleExampleView: View {
     
     var body: some View {
         WorldScaleSceneView(
-            clippingDistance: 400,
-            trackingMode: .worldScale
+            clippingDistance: 400
         ) { _ in
             SceneView(scene: scene)
         }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep3.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep3.swift
@@ -21,8 +21,7 @@ struct WorldScaleExampleView: View {
     
     var body: some View {
         WorldScaleSceneView(
-            clippingDistance: 400,
-            trackingMode: .worldScale
+            clippingDistance: 400
         ) { _ in
             SceneView(scene: scene)
         }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep4.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/WorldScaleSceneView/WorldScaleSceneViewStep4.swift
@@ -21,8 +21,7 @@ struct WorldScaleExampleView: View {
     
     var body: some View {
         WorldScaleSceneView(
-            clippingDistance: 400,
-            trackingMode: .worldScale
+            clippingDistance: 400
         ) { _ in
             SceneView(scene: scene)
         }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/WorldScaleSceneViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/WorldScaleSceneViewTutorial.tutorial
@@ -11,7 +11,7 @@
         
         @Steps {
             @Step {
-                Initialize a `WorldScaleSceneView`. Specify the clipping distance and tracking mode. 
+                Initialize a `WorldScaleSceneView`. Specify the clipping distance. The tracking mode is set to `worldTracking` by default.
                 
                 The clipping distance is the distance in meters that the ArcGIS Scene data will be clipped to.
                 The tracking mode determines the type of tracking configuration that will be used by the AR view. 

--- a/Tests/ArcGISToolkitTests/ARTests.swift
+++ b/Tests/ArcGISToolkitTests/ARTests.swift
@@ -151,9 +151,7 @@ import XCTest
     }
     
     func testWorldScaleWorldTrackingInitWithDefaults() throws {
-        let view = WorldScaleSceneView(
-            trackingMode: .worldTracking
-        ) { _ in
+        let view = WorldScaleSceneView { _ in
             SceneView(scene: Scene())
         }
         


### PR DESCRIPTION
This PR makes `worldTracking` the default tracking mode in the initializer for the `WorldScaleSceneView`.