### PR TITLE
`FeatureFormView` - Additional revisions pre-merge

### DIFF
--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -20,7 +20,6 @@ import SwiftUI
 /// a utility network and trace configurations.
 struct UtilityNetworkTraceExampleView: View {
     @Environment(\.isPortraitOrientation)
-    
     private var isPortraitOrientation
     
     /// The map with the utility networks.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -67,7 +67,7 @@ public struct FeatureFormView: View {
     @State private var isEvaluatingInitialExpressions = true
     
     /// The title of the feature form view.
-    @State private var title: String = ""
+    @State private var title = ""
     
     /// Initializes a form view.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -22,11 +22,8 @@ struct ComboBoxInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    /// A Boolean value indicating whether a value for the input is required.
-    @State private var isRequired = false
-    
-    /// The element's current value.
-    @State private var value: Any?
+    /// The phrase to use when filtering by coded value name.
+    @State private var filterPhrase = ""
     
     /// The formatted version of the element's current value.
     @State private var formattedValue = ""
@@ -34,11 +31,14 @@ struct ComboBoxInput: View {
     /// A Boolean value indicating if the combo box picker is presented.
     @State private var isPresented = false
     
-    /// The phrase to use when filtering by coded value name.
-    @State private var filterPhrase = ""
+    /// A Boolean value indicating whether a value for the input is required.
+    @State private var isRequired = false
     
     /// The selected option.
     @State private var selectedValue: CodedValue?
+    
+    /// The element's current value.
+    @State private var value: Any?
     
     /// The input's parent element.
     private let element: FieldFormElement

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -40,7 +40,7 @@ struct ComboBoxInput: View {
     /// The element's current value.
     @State private var value: Any?
     
-    /// The input's parent element.
+    /// The element the input belongs to.
     private let element: FieldFormElement
     
     /// The text used to represent a `nil` value.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -23,8 +23,8 @@ struct ComboBoxInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
+    @State private var isRequired = false
     
-    @State private var isRequired: Bool = false
     @State private var value: Any?
     @State private var formattedValue: String = ""
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -22,7 +22,6 @@ struct ComboBoxInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    // State properties for element events.
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -83,10 +83,6 @@ struct ComboBoxInput: View {
         self.element = element
         self.noValueLabel = noValueLabel
         self.noValueOption = noValueOption
-        
-        value = element.value
-        formattedValue = element.formattedValue
-        isRequired = element.isRequired
     }
     
     var body: some View {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -23,6 +23,7 @@ struct ComboBoxInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
+    /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
     @State private var value: Any?

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -26,6 +26,7 @@ struct ComboBoxInput: View {
     @State private var isRequired = false
     
     @State private var value: Any?
+    /// The formatted version of the element's current value.
     @State private var formattedValue = ""
     
     /// A Boolean value indicating if the combo box picker is presented.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -27,6 +27,7 @@ struct ComboBoxInput: View {
     @State private var isRequired = false
     
     @State private var value: Any?
+    
     /// The formatted version of the element's current value.
     @State private var formattedValue = ""
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -26,7 +26,7 @@ struct ComboBoxInput: View {
     @State private var isRequired = false
     
     @State private var value: Any?
-    @State private var formattedValue: String = ""
+    @State private var formattedValue = ""
     
     /// A Boolean value indicating if the combo box picker is presented.
     @State private var isPresented = false

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -25,6 +25,7 @@ struct ComboBoxInput: View {
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
+    /// The element's current value.
     @State private var value: Any?
     
     /// The formatted version of the element's current value.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -53,7 +53,7 @@ struct DateTimeInput: View {
     
     var body: some View {
         Group {
-            InputHeader(element: element)
+            InputHeader(label: element.label, isRequired: isRequired)
             
             dateEditor
             

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -21,6 +21,7 @@ struct DateTimeInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
+    /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
     /// The formatted version of the element's current value.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -20,17 +20,17 @@ struct DateTimeInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    /// A Boolean value indicating whether a value for the input is required.
-    @State private var isRequired = false
+    /// The current date selection.
+    @State private var date: Date?
     
     /// The formatted version of the element's current value.
     @State private var formattedValue = ""
     
-    /// The current date selection.
-    @State private var date: Date?
-    
     /// A Boolean value indicating whether a new date (or time is being set).
     @State private var isEditing = false
+    
+    /// A Boolean value indicating whether a value for the input is required.
+    @State private var isRequired = false
     
     /// The input's parent element.
     private let element: FieldFormElement

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -32,7 +32,7 @@ struct DateTimeInput: View {
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
-    /// The input's parent element.
+    /// The element the input belongs to.
     private let element: FieldFormElement
     
     /// The input configuration of the view.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -23,7 +23,7 @@ struct DateTimeInput: View {
     // State properties for element events.
     @State private var isRequired = false
     
-    @State private var formattedValue: String = ""
+    @State private var formattedValue = ""
     
     /// The current date selection.
     @State private var date: Date?

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -23,6 +23,7 @@ struct DateTimeInput: View {
     // State properties for element events.
     @State private var isRequired = false
     
+    /// The formatted version of the element's current value.
     @State private var formattedValue = ""
     
     /// The current date selection.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -21,8 +21,8 @@ struct DateTimeInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
+    @State private var isRequired = false
     
-    @State private var isRequired: Bool = false
     @State private var formattedValue: String = ""
     
     /// The current date selection.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -20,7 +20,6 @@ struct DateTimeInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    // State properties for element events.
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -103,8 +103,8 @@ struct DateTimeInput: View {
             } else {
                 if date == nil {
                     Image(systemName: "calendar")
-                        .foregroundColor(.secondary)
                         .accessibilityIdentifier("\(element.label) Calendar Image")
+                        .foregroundColor(.secondary)
                 } else if !isRequired {
                     ClearButton {
                         model.focusedElement = element

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/EditableStateInputWrapper.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/EditableStateInputWrapper.swift
@@ -23,7 +23,7 @@ struct EditableStateInputWrapper: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
     
-    /// The input's element.
+    /// The element the input belongs to.
     let element: FieldFormElement
     
     var body: some View {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
@@ -25,13 +25,13 @@ struct InputFooter: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    /// The form element the footer belongs to.
-    let element: FieldFormElement
     /// An ID regenerated each time the element's value changes.
     ///
     /// Allows the footer to be recomputed to reflect changes in validation errors or input length.
     @State private var id = UUID()
     
+    /// The form element the footer belongs to.
+    let element: FieldFormElement
     
     var body: some View {
         HStack(alignment: .top) {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
@@ -30,7 +30,7 @@ struct InputFooter: View {
     /// Allows the footer to be recomputed to reflect changes in validation errors or input length.
     @State private var id = UUID()
     
-    /// The form element the footer belongs to.
+    /// The element the input belongs to.
     let element: FieldFormElement
     
     var body: some View {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputFooter.swift
@@ -27,11 +27,11 @@ struct InputFooter: View {
     
     /// The form element the footer belongs to.
     let element: FieldFormElement
-    
     /// An ID regenerated each time the element's value changes.
     ///
     /// Allows the footer to be recomputed to reflect changes in validation errors or input length.
     @State private var id = UUID()
+    
     
     var body: some View {
         HStack(alignment: .top) {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
@@ -25,12 +25,6 @@ struct InputHeader: View {
     /// A Boolean value indicating whether a value for the input is required.
     let isRequired: Bool
     
-    /// - Parameter element: The form element the header is for.
-    init(element: FieldFormElement) {
-        self.label = element.label
-        self.isRequired = element.isRequired
-    }
-    
     /// - Parameters:
     ///   - label: The name of the form element.
     ///   - isRequired: A Boolean value indicating whether the a value for the input is required.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
@@ -22,7 +22,7 @@ struct InputHeader: View {
     /// The name of the form element.
     let label: String
     
-    /// A Boolean value indicating whether the a value for the input is required.
+    /// A Boolean value indicating whether a value for the input is required.
     let isRequired: Bool
     
     /// - Parameter element: The form element the header is for.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -35,7 +35,7 @@ struct RadioButtonsInput: View {
     /// The element's current value.
     @State private var value: Any?
     
-    /// The field's parent element.
+    /// The element the input belongs to.
     private let element: FieldFormElement
     
     /// The input configuration of the field.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -23,8 +23,8 @@ struct RadioButtonsInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
+    @State private var isRequired = false
     
-    @State private var isRequired: Bool = false
     @State private var value: Any?
     
     /// The selected option.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -25,6 +25,7 @@ struct RadioButtonsInput: View {
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
+    /// The element's current value.
     @State private var value: Any?
     
     /// The selected option.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -22,18 +22,18 @@ struct RadioButtonsInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
+    /// A Boolean value indicating whether a ``ComboBoxInput`` should be used instead.
+    /// This will be `true` if the current value doesn't exist as an option in the domain
+    @State private var fallbackToComboBox = false
+    
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
-    
-    /// The element's current value.
-    @State private var value: Any?
     
     /// The selected option.
     @State private var selectedValue: CodedValue?
     
-    /// A Boolean value indicating whether a ``ComboBoxInput`` should be used instead.
-    /// This will be `true` if the current value doesn't exist as an option in the domain
-    @State private var fallbackToComboBox = false
+    /// The element's current value.
+    @State private var value: Any?
     
     /// The field's parent element.
     private let element: FieldFormElement

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -22,7 +22,6 @@ struct RadioButtonsInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    // State properties for element events.
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -23,6 +23,7 @@ struct RadioButtonsInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
+    /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
     @State private var value: Any?

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
@@ -20,7 +20,7 @@ struct ReadOnlyInput: View {
     /// The formatted version of the element's current value.
     @State private var formattedValue = ""
     
-    /// The input's parent element.
+    /// The element the input belongs to.
     let element: FieldFormElement
     
     var body: some View {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 /// A view for a read only field form element.
 struct ReadOnlyInput: View {
-    @State private var formattedValue: String = ""
+    @State private var formattedValue = ""
     
     /// The input's parent element.
     let element: FieldFormElement

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
@@ -17,6 +17,7 @@ import SwiftUI
 
 /// A view for a read only field form element.
 struct ReadOnlyInput: View {
+    /// The formatted version of the element's current value.
     @State private var formattedValue = ""
     
     /// The input's parent element.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -22,9 +22,6 @@ struct SwitchInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    /// A Boolean value indicating whether a value for the input is required.
-    @State private var isRequired = false
-    
     /// A Boolean value indicating whether the current value doesn't exist as an option in the domain.
     ///
     /// In this scenario a ``ComboBoxInput`` should be used instead.
@@ -32,6 +29,9 @@ struct SwitchInput: View {
     
     /// A Boolean value indicating whether the switch is toggled on or off.
     @State private var isOn: Bool = false
+    
+    /// A Boolean value indicating whether a value for the input is required.
+    @State private var isRequired = false
     
     /// The value represented by the switch.
     @State private var selectedValue: Bool?

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -24,7 +24,7 @@ struct SwitchInput: View {
     
     // State properties for element events.
     
-    @State private var isRequired: Bool = false
+    @State private var isRequired = false
     
     /// A Boolean value indicating whether the current value doesn't exist as an option in the domain.
     ///

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -36,7 +36,7 @@ struct SwitchInput: View {
     /// The value represented by the switch.
     @State private var selectedValue: Bool?
     
-    /// The field's parent element.
+    /// The element the input belongs to.
     private let element: FieldFormElement
     
     /// The input configuration of the field.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -23,7 +23,6 @@ struct SwitchInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
-    
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -24,6 +24,7 @@ struct SwitchInput: View {
     
     // State properties for element events.
     
+    /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
     /// A Boolean value indicating whether the current value doesn't exist as an option in the domain.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -22,7 +22,6 @@ struct SwitchInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    // State properties for element events.
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -28,7 +28,7 @@ struct SwitchInput: View {
     @State private var fallbackToComboBox = false
     
     /// A Boolean value indicating whether the switch is toggled on or off.
-    @State private var isOn: Bool = false
+    @State private var isOn = false
     
     /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -20,7 +20,6 @@ struct TextInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
     
-    // State properties for element events.
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -23,14 +23,8 @@ struct TextInput: View {
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
     
-    /// A Boolean value indicating whether a value for the input is required.
-    @State private var isRequired = false
-    
     /// The formatted version of the element's current value.
     @State private var formattedValue = ""
-    
-    /// The current text value.
-    @State private var text = ""
     
     /// A Boolean value indicating whether placeholder text is shown, thereby indicating the
     /// presence of a value.
@@ -42,6 +36,12 @@ struct TextInput: View {
     ///
     /// Once iOS 16.0 is the minimum supported platform this property can be removed.
     @State private var isPlaceholder = false
+    
+    /// A Boolean value indicating whether a value for the input is required.
+    @State private var isRequired = false
+    
+    /// The current text value.
+    @State private var text = ""
     
     /// The input's parent element.
     private let element: FieldFormElement

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -26,6 +26,7 @@ struct TextInput: View {
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
     
+    /// A Boolean value indicating whether a value for the input is required.
     @State private var isRequired = false
     
     /// The formatted version of the element's current value.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -21,8 +21,6 @@ struct TextInput: View {
     @EnvironmentObject var model: FormViewModel
     
     // State properties for element events.
-    
-    
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
     
@@ -31,6 +29,7 @@ struct TextInput: View {
     
     /// The formatted version of the element's current value.
     @State private var formattedValue = ""
+    
     /// The current text value.
     @State private var text = ""
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -22,12 +22,12 @@ struct TextInput: View {
     
     // State properties for element events.
     
-    @State private var isRequired: Bool = false
     @State private var formattedValue: String = ""
     
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
     
+    @State private var isRequired = false
     /// The current text value.
     @State private var text = ""
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -22,12 +22,12 @@ struct TextInput: View {
     
     // State properties for element events.
     
-    @State private var formattedValue: String = ""
     
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
     
     @State private var isRequired = false
+    @State private var formattedValue = ""
     /// The current text value.
     @State private var text = ""
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -43,7 +43,7 @@ struct TextInput: View {
     /// The current text value.
     @State private var text = ""
     
-    /// The input's parent element.
+    /// The element the input belongs to.
     private let element: FieldFormElement
     
     /// Creates a view for text input spanning multiple lines.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/TextInput.swift
@@ -27,6 +27,8 @@ struct TextInput: View {
     @FocusState private var isFocused: Bool
     
     @State private var isRequired = false
+    
+    /// The formatted version of the element's current value.
     @State private var formattedValue = ""
     /// The current text value.
     @State private var text = ""

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import SwiftUI
 
-/// - Since: 200.4
 @MainActor class FormViewModel: ObservableObject {
     /// The current focused element, if one exists.
     @Published var focusedElement: FormElement? {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
@@ -17,9 +17,6 @@ import SwiftUI
 
 /// - Since: 200.4
 @MainActor class FormViewModel: ObservableObject {
-    /// The feature form.
-    private(set) var featureForm: FeatureForm
-    
     /// The current focused element, if one exists.
     @Published var focusedElement: FormElement? {
         didSet {
@@ -29,17 +26,20 @@ import SwiftUI
         }
     }
     
-    /// The expression evaluation task.
-    private var evaluateTask: Task<Void, Never>?
-    
-    /// The visibility tasks group.
-    private var isVisibleTask: Task<Void, Never>?
+    /// The set of all elements which previously held focus.
+    @Published var previouslyFocusedElements = [FormElement]()
     
     /// The list of visible form elements.
     @Published var visibleElements = [FormElement]()
     
-    /// The set of all elements which previously held focus.
-    @Published var previouslyFocusedElements = [FormElement]()
+    /// The expression evaluation task.
+    private var evaluateTask: Task<Void, Never>?
+    
+    /// The feature form.
+    private(set) var featureForm: FeatureForm
+    
+    /// The visibility tasks group.
+    private var isVisibleTask: Task<Void, Never>?
     
     /// Initializes a form view model.
     /// - Parameter featureForm: The feature form defining the editing experience.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
@@ -17,17 +17,17 @@ import SwiftUI
 
 /// Displays a group form element and manages the visibility of the elements within the group.
 struct GroupView<Content>: View where Content: View {
-    /// A Boolean value indicating whether the group is expanded or collapsed.
-    @State private var isExpanded: Bool
-    
-    /// The list of visible group elements.
-    @State private  var visibleElements = [FormElement]()
-    
     /// The group form element.
     @State private var element: GroupFormElement
     
+    /// A Boolean value indicating whether the group is expanded or collapsed.
+    @State private var isExpanded: Bool
+    
     /// The group of visibility tasks.
     @State private var isVisibleTasks = [Task<Void, Never>]()
+    
+    /// The list of visible group elements.
+    @State private  var visibleElements = [FormElement]()
     
     /// The method to build an element in the group.
     private let viewCreator: (FieldFormElement) -> Content

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/GroupView.swift
@@ -96,18 +96,18 @@ extension GroupView {
                 // a view, so conditionally check for an empty title and description.
                 if !element.label.isEmpty {
                     Text(element.label)
+                        .accessibilityIdentifier("\(element.label)")
                         .multilineTextAlignment(.leading)
                         .font(.title2)
                         .foregroundColor(.primary)
-                        .accessibilityIdentifier("\(element.label)")
                 }
                 
                 if !element.description.isEmpty {
                     Text(element.description)
+                        .accessibilityIdentifier("\(element.label) Description")
                         .multilineTextAlignment(.leading)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
-                        .accessibilityIdentifier("\(element.label) Description")
                 }
             }
 #if targetEnvironment(macCatalyst)


### PR DESCRIPTION
Additional debt cleanup in preparation of merge:
- Removes an accidental line addition in `UtilityNetworkTraceExampleView`, currently causing a warning
- Fixes a few inconsistencies in where the `accessibilityIdentifier` modifier is placed
- Applies common ordering for property declarations (attributed properties in alphabetical order followed by `let`s in alphabetical order)
- Removes types from property declarations where it is easily inferred from the initial value
- Synchronizes doc for all `element`, `formattedValue`, `isRequired`, and `value` properties
- Removes the since tag on `FormViewModel` which is no longer public
- Remove the 2nd `InputHeader` initializer, resolving a bug where a `DateTimeInput`'s header wouldn't properly update when the field became required
- Removes 3 lines from the 2nd `ComboBoxInput` initializer setting the initial values of some state properties, which shouldn't be done from an initializer