### PR TITLE
`FeatureFormView` - Centralize header/footer injection

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -130,11 +130,11 @@ extension FeatureFormView {
     /// Makes UI for a field form element including a divider beneath it.
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func makeFieldElement(_ element: FieldFormElement) -> some View {
-        InputWrapper(element: element)
         // BarcodeScannerFormInput is not currently supported
         if element.isVisible,
            !(element.input is BarcodeScannerFormInput),
            !(element.input is UnsupportedFormInput) {
+            InputWrapper(element: element)
             Divider()
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -130,7 +130,7 @@ extension FeatureFormView {
     /// Makes UI for a field form element including a divider beneath it.
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func makeFieldElement(_ element: FieldFormElement) -> some View {
-        EditableStateInputWrapper(element: element)
+        InputWrapper(element: element)
         // BarcodeScannerFormInput is not currently supported
         if element.isVisible,
            !(element.input is BarcodeScannerFormInput),

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ComboBoxInput.swift
@@ -67,7 +67,6 @@ struct ComboBoxInput: View {
             element.input is ComboBoxFormInput,
             "\(Self.self).\(#function) element's input must be \(ComboBoxFormInput.self)."
         )
-        
         self.element = element
         let input = element.input as! ComboBoxFormInput
         self.noValueLabel = input.noValueLabel
@@ -86,42 +85,36 @@ struct ComboBoxInput: View {
     }
     
     var body: some View {
-        VStack(alignment: .leading) {
-            InputHeader(label: element.label, isRequired: isRequired)
-            
-            HStack {
-                Text(selectedValue?.name ?? placeholderValue)
-                    .accessibilityIdentifier("\(element.label) Combo Box Value")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .foregroundColor(selectedValue != nil ? .primary : .secondary)
-                if selectedValue != nil, !isRequired {
-                    // Only show clear button if we have a value
-                    // and we're not required. (i.e., Don't show clear if
-                    // the field is required.)
-                    ClearButton {
-                        model.focusedElement = element
-                        defer { model.focusedElement = nil }
-                        selectedValue = nil
-                    }
-                    .accessibilityIdentifier("\(element.label) Clear Button")
-                } else {
-                    // Otherwise, always show list icon.
-                    Image(systemName: "list.bullet")
-                        .accessibilityIdentifier("\(element.label) Options Button")
-                        .foregroundColor(.secondary)
+        HStack {
+            Text(selectedValue?.name ?? placeholderValue)
+                .accessibilityIdentifier("\(element.label) Combo Box Value")
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundColor(selectedValue != nil ? .primary : .secondary)
+            if selectedValue != nil, !isRequired {
+                // Only show clear button if we have a value
+                // and we're not required. (i.e., Don't show clear if
+                // the field is required.)
+                ClearButton {
+                    model.focusedElement = element
+                    defer { model.focusedElement = nil }
+                    selectedValue = nil
                 }
+                .accessibilityIdentifier("\(element.label) Clear Button")
+            } else {
+                // Otherwise, always show list icon.
+                Image(systemName: "list.bullet")
+                    .accessibilityIdentifier("\(element.label) Options Button")
+                    .foregroundColor(.secondary)
             }
-            .formInputStyle()
-            // Pass `matchingValues` via a capture list so that the sheet receives up-to-date values.
-            .sheet(isPresented: $isPresented) { [matchingValues] in
-                makePicker(for: matchingValues)
-            }
-            .onTapGesture {
-                model.focusedElement = element
-                isPresented = true
-            }
-            
-            InputFooter(element: element)
+        }
+        .formInputStyle()
+        // Pass `matchingValues` via a capture list so that the sheet receives up-to-date values.
+        .sheet(isPresented: $isPresented) { [matchingValues] in
+            makePicker(for: matchingValues)
+        }
+        .onTapGesture {
+            model.focusedElement = element
+            isPresented = true
         }
         .onChange(of: selectedValue) { selectedValue in
             element.updateValue(selectedValue?.code)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/DateTimeInput.swift
@@ -46,38 +46,31 @@ struct DateTimeInput: View {
             element.input is DateTimePickerFormInput,
             "\(Self.self).\(#function) element's input must be \(DateTimePickerFormInput.self)."
         )
-        
         self.element = element
         self.input = element.input as! DateTimePickerFormInput
     }
     
     var body: some View {
-        Group {
-            InputHeader(label: element.label, isRequired: isRequired)
-            
-            dateEditor
-            
-            InputFooter(element: element)
-        }
-        .onChange(of: model.focusedElement) { focusedElement in
-            isEditing = focusedElement == element
-        }
-        .onChange(of: date) { date in
-            element.updateValue(date)
-            formattedValue = element.formattedValue
-            model.evaluateExpressions()
-        }
-        .onValueChange(of: element) { newValue, newFormattedValue in
-            if newFormattedValue.isEmpty {
-                date = nil
-            } else {
-                date = newValue as? Date
+        dateEditor
+            .onChange(of: model.focusedElement) { focusedElement in
+                isEditing = focusedElement == element
             }
-            formattedValue = newFormattedValue
-        }
-        .onIsRequiredChange(of: element) { newIsRequired in
-            isRequired = newIsRequired
-        }
+            .onChange(of: date) { date in
+                element.updateValue(date)
+                formattedValue = element.formattedValue
+                model.evaluateExpressions()
+            }
+            .onValueChange(of: element) { newValue, newFormattedValue in
+                if newFormattedValue.isEmpty {
+                    date = nil
+                } else {
+                    date = newValue as? Date
+                }
+                formattedValue = newFormattedValue
+            }
+            .onIsRequiredChange(of: element) { newIsRequired in
+                isRequired = newIsRequired
+            }
     }
     
     /// Controls for modifying the date selection.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputHeader.swift
@@ -12,34 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import ArcGIS
+import SwiftUI
 
 /// A view shown at the top of a field element in a form.
 struct InputHeader: View {
     @Environment(\.formElementPadding) var elementPadding
     
-    /// The name of the form element.
-    let label: String
+    /// A Boolean value indicating whether the input is editable.
+    @State private var isEditable = false
     
     /// A Boolean value indicating whether a value for the input is required.
-    let isRequired: Bool
+    @State private var isRequired = false
     
-    /// - Parameters:
-    ///   - label: The name of the form element.
-    ///   - isRequired: A Boolean value indicating whether the a value for the input is required.
-    init(label: String, isRequired: Bool) {
-        self.label = label
-        self.isRequired = isRequired
-    }
+    /// The element the input belongs to.
+    let element: FieldFormElement
     
     var body: some View {
         HStack {
-            Text(verbatim: "\(label + (isRequired ? " *" : ""))")
+            Text(verbatim: "\(element.label + (isEditable && isRequired ? " *" : ""))")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
             Spacer()
         }
         .padding(.top, elementPadding)
+        .onIsEditableChange(of: element) { newIsEditable in
+            isEditable = newIsEditable
+        }
+        .onIsRequiredChange(of: element) { newIsRequired in
+            isRequired = newIsRequired
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputWrapper.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/InputWrapper.swift
@@ -17,9 +17,9 @@ import SwiftUI
 
 /// A view which wraps the creation of a view for the underlying field form element.
 ///
-/// This view specifically handles the logic of monitoring whether a field form element is editable and choosing
-/// the correct Toolkit input view based on the element's input type.
-struct EditableStateInputWrapper: View {
+/// This view injects a header and footer. It also monitors whether a field form element is editable and
+/// chooses the correct input view based on the input type.
+struct InputWrapper: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
     
@@ -27,7 +27,8 @@ struct EditableStateInputWrapper: View {
     let element: FieldFormElement
     
     var body: some View {
-        Group {
+        VStack(alignment: .leading) {
+            InputHeader(element: element)
             if isEditable {
                 switch element.input {
                 case is ComboBoxFormInput:
@@ -46,9 +47,7 @@ struct EditableStateInputWrapper: View {
             } else {
                 ReadOnlyInput(element: element)
             }
-        }
-        .onAppear {
-            isEditable = element.isEditable
+            InputFooter(element: element)
         }
         .onIsEditableChange(of: element) { newIsEditable in
             isEditable = newIsEditable

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/RadioButtonsInput.swift
@@ -26,9 +26,6 @@ struct RadioButtonsInput: View {
     /// This will be `true` if the current value doesn't exist as an option in the domain
     @State private var fallbackToComboBox = false
     
-    /// A Boolean value indicating whether a value for the input is required.
-    @State private var isRequired = false
-    
     /// The selected option.
     @State private var selectedValue: CodedValue?
     
@@ -49,7 +46,6 @@ struct RadioButtonsInput: View {
             element.input is RadioButtonsFormInput,
             "\(Self.self).\(#function) element's input must be \(RadioButtonsFormInput.self)."
         )
-        
         self.element = element
         self.input = element.input as! RadioButtonsFormInput
     }
@@ -62,38 +58,32 @@ struct RadioButtonsInput: View {
                 noValueOption: input.noValueOption
             )
         } else {
-            Group {
-                InputHeader(label: element.label, isRequired: isRequired)
-                
-                VStack(alignment: .leading, spacing: .zero) {
-                    if input.noValueOption == .show {
-                        makeRadioButtonRow(
-                            placeholderValue,
-                            selectedValue == nil,
-                            !element.codedValues.isEmpty,
-                            useNoValueStyle: true
-                        ) {
-                            selectedValue = nil
-                        }
-                    }
-                    ForEach(element.codedValues, id: \.self) { codedValue in
-                        makeRadioButtonRow(
-                            codedValue.name,
-                            codedValue == selectedValue,
-                            codedValue != element.codedValues.last
-                        ) {
-                            selectedValue = codedValue
-                        }
+            VStack(alignment: .leading, spacing: .zero) {
+                if input.noValueOption == .show {
+                    makeRadioButtonRow(
+                        placeholderValue,
+                        selectedValue == nil,
+                        !element.codedValues.isEmpty,
+                        useNoValueStyle: true
+                    ) {
+                        selectedValue = nil
                     }
                 }
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(Color(uiColor: .tertiarySystemFill))
-                )
-                .frame(maxWidth: .infinity, alignment: .leading)
-                
-                InputFooter(element: element)
+                ForEach(element.codedValues, id: \.self) { codedValue in
+                    makeRadioButtonRow(
+                        codedValue.name,
+                        codedValue == selectedValue,
+                        codedValue != element.codedValues.last
+                    ) {
+                        selectedValue = codedValue
+                    }
+                }
             }
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(uiColor: .tertiarySystemFill))
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
             .onAppear {
                 if let selectedValue = element.codedValues.first(where: {
                     $0.name == element.formattedValue
@@ -112,9 +102,6 @@ struct RadioButtonsInput: View {
             .onValueChange(of: element) { newValue, newFormattedValue in
                 value = newValue
                 selectedValue = element.codedValues.first { $0.name == newFormattedValue }
-            }
-            .onIsRequiredChange(of: element) { newIsRequired in
-                isRequired = newIsRequired
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/ReadOnlyInput.swift
@@ -25,8 +25,6 @@ struct ReadOnlyInput: View {
     
     var body: some View {
         Group {
-            InputHeader(label: element.label, isRequired: false)
-            
             if element.isMultiline {
                 textReader
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -35,9 +33,7 @@ struct ReadOnlyInput: View {
                     textReader
                 }
             }
-            InputFooter(element: element)
         }
-        .accessibilityIdentifier("\(element.label) Read Only Input")
         .onAppear {
             formattedValue = element.formattedValue
         }
@@ -49,6 +45,7 @@ struct ReadOnlyInput: View {
     /// The body of the text input when the element is non-editable.
     var textReader: some View {
         Text(formattedValue.isEmpty ? "--" : formattedValue)
+            .accessibilityIdentifier("\(element.label) Read Only Input")
             .lineLimit(element.isMultiline ? nil : 1)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -30,9 +30,6 @@ struct SwitchInput: View {
     /// A Boolean value indicating whether the switch is toggled on or off.
     @State private var isOn = false
     
-    /// A Boolean value indicating whether a value for the input is required.
-    @State private var isRequired = false
-    
     /// The value represented by the switch.
     @State private var selectedValue: Bool?
     
@@ -63,21 +60,15 @@ struct SwitchInput: View {
                 noValueOption: .show
             )
         } else {
-            Group {
-                InputHeader(label: element.label, isRequired: isRequired)
-                
-                HStack {
-                    Text(isOn ? input.onValue.name : input.offValue.name)
-                        .accessibilityIdentifier("\(element.label) Switch Label")
-                    Spacer()
-                    Toggle("", isOn: $isOn)
-                        .accessibilityIdentifier("\(element.label) Switch")
-                        .toggleStyle(.switch)
-                }
-                .formInputStyle()
-                
-                InputFooter(element: element)
+            HStack {
+                Text(isOn ? input.onValue.name : input.offValue.name)
+                    .accessibilityIdentifier("\(element.label) Switch Label")
+                Spacer()
+                Toggle("", isOn: $isOn)
+                    .accessibilityIdentifier("\(element.label) Switch")
+                    .toggleStyle(.switch)
             }
+            .formInputStyle()
             .onAppear {
                 if element.formattedValue.isEmpty {
                     fallbackToComboBox = true
@@ -90,9 +81,6 @@ struct SwitchInput: View {
             }
             .onValueChange(of: element) { newValue, newFormattedValue in
                 isOn = newFormattedValue == input.onValue.name
-            }
-            .onIsRequiredChange(of: element) { newIsRequired in
-                isRequired = newIsRequired
             }
         }
     }


### PR DESCRIPTION
Refactors `EditableStateInputWrapper` into `InputWrapper` which injects the header and footer for each input all from one single location now.