### PR TITLE
`FeatureFormView` - Fix `SwitchInput` auto focus

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -27,9 +27,6 @@ struct SwitchInput: View {
     /// In this scenario a ``ComboBoxInput`` should be used instead.
     @State private var fallbackToComboBox = false
     
-    /// A Boolean value indicating whether the initial run of the `onChange` modifier has completed.
-    @State private var initialChangeHasCompleted = false
-    
     /// A Boolean value indicating whether the switch is toggled on or off.
     @State private var isOn = false
     
@@ -78,10 +75,12 @@ struct SwitchInput: View {
                 }
             }
             .onChange(of: isOn) { isOn in
-                if initialChangeHasCompleted { model.focusedElement = element }
                 element.updateValue(isOn ? input.onValue.code : input.offValue.code)
                 model.evaluateExpressions()
-                initialChangeHasCompleted = true
+            }
+            .onTapGesture {
+                isOn.toggle()
+                model.focusedElement = element
             }
             .onValueChange(of: element) { newValue, newFormattedValue in
                 isOn = newFormattedValue == input.onValue.name

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputs/SwitchInput.swift
@@ -27,6 +27,9 @@ struct SwitchInput: View {
     /// In this scenario a ``ComboBoxInput`` should be used instead.
     @State private var fallbackToComboBox = false
     
+    /// A Boolean value indicating whether the initial run of the `onChange` modifier has completed.
+    @State private var initialChangeHasCompleted = false
+    
     /// A Boolean value indicating whether the switch is toggled on or off.
     @State private var isOn = false
     
@@ -75,9 +78,10 @@ struct SwitchInput: View {
                 }
             }
             .onChange(of: isOn) { isOn in
-                model.focusedElement = element
+                if initialChangeHasCompleted { model.focusedElement = element }
                 element.updateValue(isOn ? input.onValue.code : input.offValue.code)
                 model.evaluateExpressions()
+                initialChangeHasCompleted = true
             }
             .onValueChange(of: element) { newValue, newFormattedValue in
                 isOn = newFormattedValue == input.onValue.name


### PR DESCRIPTION
Presently a `SwitchInput` in a form sets itself as the focused element upon initializing causing the form to unexpectedly scroll to the switch upon opening.