### PR TITLE
`FeatureFormView` - Resolve unused warnings

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
@@ -74,7 +74,7 @@ import SwiftUI
     
     /// Performs an initial evaluation of all form expressions.
     func initialEvaluation() async {
-        try? await featureForm.evaluateExpressions()
+        _ = try? await featureForm.evaluateExpressions()
         initializeIsVisibleTasks()
     }
     
@@ -82,7 +82,7 @@ import SwiftUI
     func evaluateExpressions() {
         evaluateTask?.cancel()
         evaluateTask = Task {
-            try? await featureForm.evaluateExpressions()
+            _ = try? await featureForm.evaluateExpressions()
         }
     }
 }


### PR DESCRIPTION
Despite `evaluateExpressions` being marked `@discardableResult`, because it's reverted to throwing, the unused warning has resurfaced.

Ref apple/swift#45672 