### PR TITLE
AR: Rename modifier to `onCalibratingChanged`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -222,8 +222,8 @@ public struct WorldScaleSceneView: View {
         return view
     }
     
-    /// Sets a closure to perform when the calibration view visibility changes.
-    /// - Parameter action: The closure to perform when the calibration view visibility has changed.
+    /// Sets a closure to perform when calibration begins or ends.
+    /// - Parameter action: The closure to perform when calibration begins or ends.
     public func onCalibratingChanged(
         perform action: @escaping (
             _ isPresented: Bool

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -46,8 +46,8 @@ public struct WorldScaleSceneView: View {
     @State private var error: Error?
     /// The closure to call upon a single tap.
     private var onSingleTapGestureAction: ((CGPoint, Point?) -> Void)? = nil
-    /// The closure to perform when the calibration view visibility changes.
-    private var onCalibrationViewVisibilityChangedAction: ((Bool) -> Void)?
+    /// The closure to perform when the `isCalibrating` property has changed.
+    private var onCalibratingChangedAction: ((Bool) -> Void)?
     /// The closure to perform when the camera tracking state changes.
     private var onCameraTrackingStateChangedAction: ((ARCamera.TrackingState) -> Void)?
     /// The closure to perform when the geo tracking status changes.
@@ -151,7 +151,7 @@ public struct WorldScaleSceneView: View {
         }
         .animation(.default.speed(0.25), value: initialCameraIsSet)
         .onChange(of: isCalibrating) { value in
-            onCalibrationViewVisibilityChangedAction?(value)
+            onCalibratingChangedAction?(value)
         }
     }
     
@@ -224,13 +224,13 @@ public struct WorldScaleSceneView: View {
     
     /// Sets a closure to perform when the calibration view visibility changes.
     /// - Parameter action: The closure to perform when the calibration view visibility has changed.
-    public func onCalibrationViewVisibilityChanged(
+    public func onCalibratingChanged(
         perform action: @escaping (
             _ isPresented: Bool
         ) -> Void
     ) -> Self {
         var view = self
-        view.onCalibrationViewVisibilityChangedAction = action
+        view.onCalibratingChangedAction = action
         return view
     }
     


### PR DESCRIPTION
This PR renames a modifier from `onCalibrationViewVisibilityChanged` to `onCalibratingChanged`.