### PR TITLE
`FeatureFormView` - Remove character indicator from numeric text fields

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
@@ -200,6 +200,7 @@ extension InputFooter {
     /// A Boolean value which indicates whether or not the character indicator is showing in the footer.
     var isShowingCharacterIndicator: Bool {
         model.focusedElement == element
+        && !(element.fieldType?.isNumeric ?? false)
         && (element.input is TextAreaFormInput || element.input is TextBoxFormInput)
         && (element.description.isEmpty || primaryError != nil)
     }


### PR DESCRIPTION
Numeric text fields shouldn't get the character count indicator. This is likely a regression from when we merged text area & box or switched to the unified `InputFooter`.