### PR TITLE
Fix `WorldScaleSceneView` safe area bug

### DIFF
--- a/Examples/Examples/WorldScaleExampleView.swift
+++ b/Examples/Examples/WorldScaleExampleView.swift
@@ -63,7 +63,6 @@ struct WorldScaleExampleView: View {
         .onSingleTapGesture { _, scenePoint in
             graphicsOverlay.addGraphic(Graphic(geometry: scenePoint))
         }
-        .ignoresSafeArea(edges: [.horizontal, .bottom])
         .task {
             // Request when-in-use location authorization.
             // This is necessary for 2 reasons:

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -122,6 +122,7 @@ public struct WorldScaleSceneView: View {
                 self.error = error
             }
         }
+        .ignoresSafeArea(.container, edges: [.horizontal])
         .overlay(alignment: calibrationButtonAlignment) {
             if !calibrationViewIsHidden && !isCalibrating {
                 Button {


### PR DESCRIPTION
This fixes a bug I noticed where the camera view did not extend into the safe area.

Before | ![Screenshot 2024-04-01 at 11 46 13](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/2257493/ec0834f3-a5b2-43c0-817e-e5f159de5773)
--- | ---
After | ![Screenshot 2024-04-01 at 11 48 24](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/2257493/415cbf52-de79-4c66-af29-70668d01dac7)