### PR TITLE
Make `WorldScaleSceneView` ignore bottom safe area

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -122,7 +122,7 @@ public struct WorldScaleSceneView: View {
                 self.error = error
             }
         }
-        .ignoresSafeArea(.container, edges: [.horizontal])
+        .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .overlay(alignment: calibrationButtonAlignment) {
             if !calibrationViewIsHidden && !isCalibrating {
                 Button {


### PR DESCRIPTION
That way it extends behind the home indicator, just like `SceneView` does.