### PR TITLE
`FeatureFormView` - Stabilize test case 1.4

### DIFF
--- a/Test Runner/UI Tests/FormViewTests.swift
+++ b/Test Runner/UI Tests/FormViewTests.swift
@@ -333,7 +333,7 @@ final class FeatureFormViewTests: XCTestCase {
             for: NSPredicate(format: "label == \"Range domain 2-5\""),
             evaluatedWith: footer
         )
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
         
         // Highlight/select the current value and replace it
         textField.doubleTap()


### PR DESCRIPTION
This case has failed twice at this point over the last two days.

Bumping to 10 seconds has worked elsewhere in these tests.