### PR TITLE
`UtilityNetworkTrace` - Example/tutorial revisions

### DIFF
--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -19,23 +19,22 @@ import SwiftUI
 /// A demonstration of the utility network trace tool which runs traces on a web map published with
 /// a utility network and trace configurations.
 struct UtilityNetworkTraceExampleView: View {
-    @Environment(\.isPortraitOrientation)
-    private var isPortraitOrientation
-    
-    /// The map with the utility networks.
-    @State private var map = makeMap()
+    @Environment(\.isPortraitOrientation) private var isPortraitOrientation
     
     /// The current detent of the floating panel presenting the trace tool.
     @State private var activeDetent: FloatingPanelDetent = .half
     
+    /// The map with the utility networks.
+    @State private var map = makeMap()
+    
     /// Provides the ability to detect tap locations in the context of the map view.
     @State private var mapPoint: Point?
     
-    /// Provides the ability to detect tap locations in the context of the screen.
-    @State private var screenPoint: CGPoint?
-    
     /// A container for graphical trace results.
     @State private var resultGraphicsOverlay = GraphicsOverlay()
+    
+    /// Provides the ability to detect tap locations in the context of the screen.
+    @State private var screenPoint: CGPoint?
     
     /// The map viewpoint used by the `UtilityNetworkTrace` to pan/zoom the map to selected features.
     @State private var viewpoint: Viewpoint?

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep1.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep1.swift
@@ -7,9 +7,9 @@ struct UtilityNetworkTraceExampleView: View {
     
     @State private var mapPoint: Point?
     
-    @State private var screenPoint: CGPoint?
-    
     @State private var resultGraphicsOverlay = GraphicsOverlay()
+    
+    @State private var screenPoint: CGPoint?
     
     @State private var viewpoint: Viewpoint?
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep2.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep2.swift
@@ -7,9 +7,9 @@ struct UtilityNetworkTraceExampleView: View {
     
     @State private var mapPoint: Point?
     
-    @State private var screenPoint: CGPoint?
-    
     @State private var resultGraphicsOverlay = GraphicsOverlay()
+    
+    @State private var screenPoint: CGPoint?
     
     @State private var viewpoint: Viewpoint?
     
@@ -33,5 +33,17 @@ struct UtilityNetworkTraceExampleView: View {
             id: Item.ID(rawValue: "471eb0bf37074b1fbb972b1da70fb310")!
         )
         return Map(item: portalItem)
+    }
+}
+
+private extension ArcGISCredential {
+    static var publicSample: ArcGISCredential {
+        get async throws {
+            try await TokenCredential.credential(
+                for: URL(string: "https://sampleserver7.arcgisonline.com/portal/sharing/rest")!,
+                username: "viewer01",
+                password: "I68VGU^nMurF"
+            )
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep3.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep3.swift
@@ -7,9 +7,9 @@ struct UtilityNetworkTraceExampleView: View {
     
     @State private var mapPoint: Point?
     
-    @State private var screenPoint: CGPoint?
-    
     @State private var resultGraphicsOverlay = GraphicsOverlay()
+    
+    @State private var screenPoint: CGPoint?
     
     @State private var viewpoint: Viewpoint?
     
@@ -36,5 +36,17 @@ struct UtilityNetworkTraceExampleView: View {
             id: Item.ID(rawValue: "471eb0bf37074b1fbb972b1da70fb310")!
         )
         return Map(item: portalItem)
+    }
+}
+
+private extension ArcGISCredential {
+    static var publicSample: ArcGISCredential {
+        get async throws {
+            try await TokenCredential.credential(
+                for: URL(string: "https://sampleserver7.arcgisonline.com/portal/sharing/rest")!,
+                username: "viewer01",
+                password: "I68VGU^nMurF"
+            )
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep4.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep4.swift
@@ -7,9 +7,9 @@ struct UtilityNetworkTraceExampleView: View {
     
     @State private var mapPoint: Point?
     
-    @State private var screenPoint: CGPoint?
-    
     @State private var resultGraphicsOverlay = GraphicsOverlay()
+    
+    @State private var screenPoint: CGPoint?
     
     @State private var viewpoint: Viewpoint?
     
@@ -40,5 +40,17 @@ struct UtilityNetworkTraceExampleView: View {
             id: Item.ID(rawValue: "471eb0bf37074b1fbb972b1da70fb310")!
         )
         return Map(item: portalItem)
+    }
+}
+
+private extension ArcGISCredential {
+    static var publicSample: ArcGISCredential {
+        get async throws {
+            try await TokenCredential.credential(
+                for: URL(string: "https://sampleserver7.arcgisonline.com/portal/sharing/rest")!,
+                username: "viewer01",
+                password: "I68VGU^nMurF"
+            )
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep5.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/UtilityNetworkTrace/UtilityNetworkTraceStep5.swift
@@ -3,15 +3,15 @@ import ArcGISToolkit
 import SwiftUI
 
 struct UtilityNetworkTraceExampleView: View {
-    @State private var map = makeMap()
-    
     @State private var activeDetent: FloatingPanelDetent = .half
+    
+    @State private var map = makeMap()
     
     @State private var mapPoint: Point?
     
-    @State private var screenPoint: CGPoint?
-    
     @State private var resultGraphicsOverlay = GraphicsOverlay()
+    
+    @State private var screenPoint: CGPoint?
     
     @State private var viewpoint: Viewpoint?
     
@@ -58,5 +58,17 @@ struct UtilityNetworkTraceExampleView: View {
             id: Item.ID(rawValue: "471eb0bf37074b1fbb972b1da70fb310")!
         )
         return Map(item: portalItem)
+    }
+}
+
+private extension ArcGISCredential {
+    static var publicSample: ArcGISCredential {
+        get async throws {
+            try await TokenCredential.credential(
+                for: URL(string: "https://sampleserver7.arcgisonline.com/portal/sharing/rest")!,
+                username: "viewer01",
+                password: "I68VGU^nMurF"
+            )
+        }
     }
 }


### PR DESCRIPTION
In response to [this feedback](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/392#discussion_r1295073941)

- Adds missing `publicSample` member in tutorial steps
- Alphabetizes properties

Related #406 