### PR TITLE
Switch tutorial links to doc references

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -49,7 +49,7 @@ import CryptoTokenKit
 ///
 /// To see the `Authenticator` in action, check out the [Authentication Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/AuthenticationExample)
 /// and refer to [AuthenticationApp.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/AuthenticationExample/AuthenticationExample/AuthenticationApp.swift).
-/// To learn more about using the `Authenticator`, see the [Authenticator Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/authenticatortutorial).
+/// To learn more about using the `Authenticator`, see the <doc:AuthenticatorTutorial>.
 @MainActor
 public final class Authenticator: ObservableObject {
     /// A value indicating whether we should prompt the user when encountering an untrusted host.

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
@@ -51,7 +51,7 @@ import ArcGIS
 ///
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [BasemapGalleryExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/BasemapGalleryExampleView.swift)
-/// in the project. To learn more about using the `BasemapGallery` see the [BasemapGallery Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/basemapgallerytutorial).
+/// in the project. To learn more about using the `BasemapGallery` see the <doc:BasemapGalleryTutorial>.
 public struct BasemapGallery: View {
     /// The view style of the gallery.
     public enum Style {

--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -44,7 +44,7 @@ import SwiftUI
 ///
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [BookmarksExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/BookmarksExampleView.swift)
-/// in the project. To learn more about using the `Bookmarks` component see the [Bookmarks Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/bookmarkstutorial).
+/// in the project. To learn more about using the `Bookmarks` component see the <doc:BookmarksTutorial>.
 public struct Bookmarks: View {
     /// A list of selectable bookmarks.
     @State private var bookmarks: [Bookmark]

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -29,7 +29,7 @@ import SwiftUI
 ///
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [CompassExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/CompassExampleView.swift)
-/// in the project. To learn more about using the `Compass` see the [Compass Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/compasstutorial).
+/// in the project. To learn more about using the `Compass` see the <doc:CompassTutorial>.
 public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -61,7 +61,7 @@ import SwiftUI
 ///
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [FloorFilterExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/FloorFilterExampleView.swift)
-/// in the project. To learn more about using the `FloorFilter` see the [FloorFilter Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/floorfiltertutorial).
+/// in the project. To learn more about using the `FloorFilter` see the <doc:FloorFilterTutorial>.
 public struct FloorFilter: View {
     @Environment(\.horizontalSizeClass)
     private var horizontalSizeClass: UserInterfaceSizeClass?

--- a/Sources/ArcGISToolkit/Components/OverviewMap.swift
+++ b/Sources/ArcGISToolkit/Components/OverviewMap.swift
@@ -46,7 +46,7 @@ import SwiftUI
 /// To see the `OverviewMap` in action, and for examples of `OverviewMap` customization, check out
 /// the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [OverviewMapExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/OverviewMapExampleView.swift)
-/// in the project. To learn more about using the `OverviewMap` see the [OverviewMap Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/overviewmaptutorial).
+/// in the project. To learn more about using the `OverviewMap` see the <doc:OverviewMapTutorial>.
 public struct OverviewMap: View {
     /// The `Viewpoint` of the main `GeoView`.
     let viewpoint: Viewpoint?

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -50,7 +50,7 @@ import ArcGIS
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to
 /// [PopupExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/PopupExampleView.swift)
-/// in the project. To learn more about using the `PopupView` see the [PopupView Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/popupviewtutorial).
+/// in the project. To learn more about using the `PopupView` see the <doc:PopupViewTutorial>.
 public struct PopupView: View {
     /// Creates a `PopupView` with the given popup.
     /// - Parameters

--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -48,7 +48,7 @@ import SwiftUI
 ///
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [ScalebarExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/ScalebarExampleView.swift) 
-/// in the project. To learn more about using the `Scalebar` see the [Scalebar Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/scalebartutorial).
+/// in the project. To learn more about using the `Scalebar` see the <doc:ScalebarTutorial>.
 public struct Scalebar: View {
     // - MARK: Internal/Private vars
     

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -59,7 +59,7 @@ import ArcGIS
 ///
 /// To see the `SearchView` in action, and for examples of `Search` customization, check out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [SearchExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/SearchExampleView.swift)
-/// in the project. To learn more about using the `SearchView` see the [SearchView Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/searchviewtutorial).
+/// in the project. To learn more about using the `SearchView` see the <doc:SearchViewTutorial>.
 public struct SearchView: View {
     /// Creates a `SearchView`.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -60,7 +60,7 @@ import SwiftUI
 ///
 /// To see the `UtilityNetworkTrace` in action, check out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [UtilityNetworkTraceExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/UtilityNetworkTraceExampleView.swift)
-/// in the project. To learn more about using the `UtilityNetworkTrace` see the [UtilityNetworkTrace Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/utilitynetworktracetutorial).
+/// in the project. To learn more about using the `UtilityNetworkTrace` see the <doc:UtilityNetworkTraceTutorial>.
 public struct UtilityNetworkTrace: View {
     /// The proxy to provide access to map view operations.
     private var mapViewProxy: MapViewProxy?

--- a/Sources/ArcGISToolkit/Documentation.docc/AugmentedReality.md
+++ b/Sources/ArcGISToolkit/Documentation.docc/AugmentedReality.md
@@ -10,20 +10,17 @@ reality experiences for common AR patterns including Flyover, TableTop, and Worl
 `FlyoverSceneView` provides an augmented reality flyover experience that allows you to 
 explore a scene using your device as a window into the virtual world. The experience begins
 with the ArcGIS Scene's camera positioned over an area of interest. Walk around and reorient
-the device to focus on specific content in the scene. To learn more about using the FlyoverSceneView see the 
- [FlyoverSceneView Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/flyoversceneviewtutorial).
+the device to focus on specific content in the scene. To learn more about using the FlyoverSceneView see the <doc:FlyoverSceneViewTutorial>.
 
 **TableTopSceneView**
 
 `TableTopSceneView` provides an augmented reality table top experience where ArcGIS Scene content
-is anchored to a physical surface. To learn more about using the TableTopSceneView see the 
-[TableTopSceneView Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/tabletopsceneviewtutorial).
+is anchored to a physical surface. To learn more about using the TableTopSceneView see the <doc:TableTopSceneViewTutorial>.
 
 **WorldScaleSceneView**
 
 `WorldScaleSceneView` provides an augmented reality world scale experience where ArcGIS Scene content
-is integrated with the real world. To learn more about using the WorldScaleSceneView see the 
-[WorldScaleSceneView Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/worldscalesceneviewtutorial).
+is integrated with the real world. To learn more about using the WorldScaleSceneView see the <doc:WorldScaleSceneViewTutorial>.
 
 ###### Requirements
 * Set the following properties in the app's **info.plist**:

--- a/Sources/ArcGISToolkit/Documentation.docc/FloatingPanel.md
+++ b/Sources/ArcGISToolkit/Documentation.docc/FloatingPanel.md
@@ -45,5 +45,4 @@ properties, including:
 
 To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 and refer to [FloatingPanelExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/FloatingPanelExampleView.swift)
-in the project. To learn more about using the Floating Panel see the 
-[FloatingPanel Tutorial](https://developers.arcgis.com/swift/toolkit-api-reference/tutorials/arcgistoolkit/floatingpaneltutorial).
+in the project. To learn more about using the Floating Panel see the <doc:FloatingPanelTutorial>.


### PR DESCRIPTION
Related #393 

Using local references improves the developer experience when using the local documentation viewer. Instead of opening the link in a browser this'll allow the tutorial to open right within the viewer.

Additionally, if the document title ever changes we'll get a warning.