### PR TITLE
`FloatingPanel` - Followup doc changes

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -15,13 +15,7 @@
 import SwiftUI
 
 /// A floating panel is a view that overlays a view and supplies view-related
-/// content. A map view, for instance, could display a legend, bookmarks, search results, etc..
-///
-/// Floating panels are non-modal and can be transient, only displaying
-/// information for a short period of time like identify results,
-/// or persistent, where the information is always displayed, for example a
-/// dedicated search panel. They will also be primarily simple containers
-/// that clients will fill with their own content.
+/// content. For more information see <doc:FloatingPanel>.
 struct FloatingPanel<Content>: View where Content: View {
     /// The height of a geo-view's attribution bar.
     ///

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
@@ -16,17 +16,7 @@ import SwiftUI
 
 public extension View {
     /// A floating panel is a view that overlays a view and supplies view-related
-    /// content. For a map view, for instance, it could display a legend, bookmarks, search results, etc..
-    /// Apple Maps, Google Maps, Windows 10, and Collector have floating panel
-    /// implementations, sometimes referred to as a "bottom sheet".
-    ///
-    /// Floating panels are non-modal and can be transient, only displaying
-    /// information for a short period of time like identify results,
-    /// or persistent, where the information is always displayed, for example a
-    /// dedicated search panel. They will also be primarily simple containers
-    /// that clients will fill with their own content.
-    ///
-    /// The floating panel allows for interaction with background contents, unlike native sheets or popovers.
+    /// content. For more information see <doc:FloatingPanel>.
     ///
     /// - Parameters:
     ///   - attributionBarHeight: The height of a geo-view's attribution bar.

--- a/Sources/ArcGISToolkit/Documentation.docc/FloatingPanel.md
+++ b/Sources/ArcGISToolkit/Documentation.docc/FloatingPanel.md
@@ -17,7 +17,8 @@ The following images are of a simple list of numbers in a floating panel.
 | iPhone | iPad |
 | ------ | ---- |
 | ![image](https://user-images.githubusercontent.com/3998072/202795901-b86d6d26-3572-4c88-8f6e-84473ce57002.png) | ![image](https://user-images.githubusercontent.com/3998072/202796009-92e3b5c3-d88b-4124-8d9f-bad6df445f02.png) |
-- Note: The Floating Panel is exposed as a view modifier.
+
+- Note: The Floating Panel is exposed as a view modifier. See ``SwiftUI/View/floatingPanel(attributionBarHeight:backgroundColor:selectedDetent:horizontalAlignment:isPresented:maxWidth:_:)``
 
 **Features**
 


### PR DESCRIPTION
`FloatingPanel.swift` and `FloatingPanelModifier.swift` contain doc redundant to content in `FloatingPanel.md`. I noticed that some of the content in `FloatingPanelModifier.swift` fell out of sync after changes in #682. Therefore this PR: 
- Simplifies and syncs the doc in `FloatingPanel.swift` and `FloatingPanelModifier.swift`, adding a reference back to `FloatingPanel.md`.
- Adds a reference to the modifier in `FloatingPanel.md`, improving discoverability.