### PR TITLE
Add expected failures in `CertificatePickerViewModelTests.testViewModel()`

### DIFF
--- a/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
@@ -31,6 +31,10 @@ final class CertificatePickerViewModelTests: XCTestCase {
         model.proceedToPicker()
         
         // Have to wait here because the proceed function is delayed to avoid a bug.
+        XCTExpectFailure(
+            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0 CLI tools. Ref Toolkit #699",
+            options: .nonStrict()
+        )
         await fulfillment(
             of: [
                 expectation(
@@ -48,6 +52,10 @@ final class CertificatePickerViewModelTests: XCTestCase {
         
         model.proceedToUseCertificate(withPassword: "1234")
         
+        XCTExpectFailure(
+            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0 CLI tools. Ref Toolkit #699",
+            options: .nonStrict()
+        )
         await fulfillment(
             of: [
                 expectation(

--- a/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
@@ -32,7 +32,7 @@ final class CertificatePickerViewModelTests: XCTestCase {
         
         // Have to wait here because the proceed function is delayed to avoid a bug.
         XCTExpectFailure(
-            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0 CLI tools. Ref Toolkit #699",
+            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0. Ref Toolkit #699",
             options: .nonStrict()
         )
         await fulfillment(
@@ -53,7 +53,7 @@ final class CertificatePickerViewModelTests: XCTestCase {
         model.proceedToUseCertificate(withPassword: "1234")
         
         XCTExpectFailure(
-            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0 CLI tools. Ref Toolkit #699",
+            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0. Ref Toolkit #699",
             options: .nonStrict()
         )
         await fulfillment(


### PR DESCRIPTION
This test has been failing consistently in daily runs as the runner uses Xcode 15.0.

The test works as expected when using 15.3 so the failure has been marked as non strict.

Related #699 