### PR TITLE
Address Main actor warnings

### DIFF
--- a/Tests/ArcGISToolkitTests/ARTests.swift
+++ b/Tests/ArcGISToolkitTests/ARTests.swift
@@ -17,7 +17,7 @@ import SwiftUI
 import XCTest
 @testable import ArcGISToolkit
 
-@MainActor final class ARTests: XCTestCase {
+final class ARTests: XCTestCase {
     func testFlyoverLocationInitWithDefaults() throws {
         let view = FlyoverSceneView(
             initialLocation: .init(

--- a/Tests/ArcGISToolkitTests/AuthenticationManagerTests.swift
+++ b/Tests/ArcGISToolkitTests/AuthenticationManagerTests.swift
@@ -16,7 +16,8 @@ import XCTest
 import ArcGIS
 @testable import ArcGISToolkit
 
-@MainActor final class AuthenticationManagerTests: XCTestCase {
+final class AuthenticationManagerTests: XCTestCase {
+    @MainActor
     func testHandleChallengesUsingAuthenticator() {
         addTeardownBlock {
             ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler = nil

--- a/Tests/ArcGISToolkitTests/AuthenticatorTests.swift
+++ b/Tests/ArcGISToolkitTests/AuthenticatorTests.swift
@@ -17,7 +17,8 @@ import XCTest
 import ArcGIS
 import Combine
 
-@MainActor final class AuthenticatorTests: XCTestCase {
+final class AuthenticatorTests: XCTestCase {
+    @MainActor
     func testInit() {
         let config = OAuthUserConfiguration(
             portalURL: URL(string:"www.arcgis.com")!,

--- a/Tests/ArcGISToolkitTests/BasemapGalleryItemTests.swift
+++ b/Tests/ArcGISToolkitTests/BasemapGalleryItemTests.swift
@@ -25,7 +25,6 @@ import Combine
 // as the 'loadBasemapError' and 'spatialReferenceStatus' properties than
 // the 'BasemapGallery' design specifies. Tests not present in the
 // test design have been added to accommodate those differences.
-@MainActor
 final class BasemapGalleryItemTests: XCTestCase {
     override func setUp() async throws {
         ArcGISEnvironment.apiKey = .default

--- a/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
@@ -25,7 +25,6 @@ import Combine
 // as 'geoModel.actualSpatialReference') than the 'BasemapGallery' design
 // specifies. Tests not present in the test design have been added to
 // accommodate those differences.
-@MainActor
 class BasemapGalleryViewModelTests: XCTestCase {
     override func setUp() async throws {
         ArcGISEnvironment.apiKey = .default
@@ -53,6 +52,7 @@ class BasemapGalleryViewModelTests: XCTestCase {
     ]
     
     /// Test the various constructor methods.
+    @MainActor
     func testInit() async throws {
         // Note:  this is a good candidate for mocking portal data.
         // This would allow the test to check for a specific number of items.
@@ -168,6 +168,7 @@ class BasemapGalleryViewModelTests: XCTestCase {
     }
     
     /// Test the `currentItem` property including valid and invalid basemaps.
+    @MainActor
     func testCurrentItem() async throws {
         let basemap = Basemap(style: .arcGISStreets)
         let geoModel = Map(basemap: basemap)
@@ -229,6 +230,7 @@ class BasemapGalleryViewModelTests: XCTestCase {
     }
     
     /// Test setting the portal after the model has been created.
+    @MainActor
     func testUpdatePortal() async throws {
         // Create a model with a default list of items.
         let viewModel = BasemapGalleryViewModel(

--- a/Tests/ArcGISToolkitTests/FloorFilterViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FloorFilterViewModelTests.swift
@@ -18,9 +18,9 @@ import SwiftUI
 import XCTest
 @testable import ArcGISToolkit
 
-@MainActor
 final class FloorFilterViewModelTests: XCTestCase {
     /// Confirms that the selected site/facility/level properties and the viewpoint are correctly updated.
+    @MainActor
     func testAutoSelectAlways() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -52,6 +52,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the selected site/facility/level properties and the viewpoint are correctly updated.
+    @MainActor
     func testAutoSelectAlwaysNotClearing() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -79,6 +80,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the selected site/facility/level properties and the viewpoint are correctly updated.
+    @MainActor
     func testAutoSelectNever() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -104,6 +106,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Tests that a `FloorFilterViewModel` successfully initializes.
+    @MainActor
     func testInitWithFloorManagerAndViewpoint() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -118,6 +121,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the proper level is visible and all others are hidden.
+    @MainActor
     func testLevelVisibility() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -139,6 +143,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the selected site/facility/level properties are correctly updated.
+    @MainActor
     func testSelectedProperties() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -174,6 +179,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the selection property indicates the correct facility (and therefore level) value.
+    @MainActor
     func testSelectionOfFacility() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -191,6 +197,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the selection property indicates the correct level value.
+    @MainActor
     func testSelectionOfLevel() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -207,6 +214,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the selection property indicates the correct site value.
+    @MainActor
     func testSelectionOfSite() async throws {
         let floorManager = try await floorManager(
             forWebMapWithIdentifier: .testMap
@@ -223,6 +231,7 @@ final class FloorFilterViewModelTests: XCTestCase {
     }
     
     /// Confirms that the  viewpoint is correctly updated.
+    @MainActor
     func testViewpointUpdates() async throws {
         var _viewpoint: Viewpoint? = .researchAnnexLattice
         let viewpoint = Binding(get: { _viewpoint }, set: { _viewpoint = $0 })

--- a/Tests/ArcGISToolkitTests/NetworkChallengeContinuationTests.swift
+++ b/Tests/ArcGISToolkitTests/NetworkChallengeContinuationTests.swift
@@ -16,13 +16,15 @@ import SwiftUI
 import XCTest
 @testable import ArcGISToolkit
 
-@MainActor final class NetworkChallengeContinuationTests: XCTestCase {
+final class NetworkChallengeContinuationTests: XCTestCase {
+    @MainActor
     func testInit() {
         let challenge = NetworkChallengeContinuation(host: "host.com", kind: .serverTrust)
         XCTAssertEqual(challenge.host, "host.com")
         XCTAssertEqual(challenge.kind, .serverTrust)
     }
     
+    @MainActor
     func testResumeAndComplete() async {
         let challenge = NetworkChallengeContinuation(host: "host.com", kind: .serverTrust)
         challenge.resume(with: .continueWithCredential(.serverTrust))

--- a/Tests/ArcGISToolkitTests/ScalebarTests.swift
+++ b/Tests/ArcGISToolkitTests/ScalebarTests.swift
@@ -18,7 +18,6 @@ import SwiftUI
 import XCTest
 @testable import ArcGISToolkit
 
-@MainActor
 class ScalebarTests: XCTestCase {
     struct ScalebarTestCase {
         let x: Double
@@ -66,6 +65,7 @@ class ScalebarTests: XCTestCase {
         ScalebarTestCase(x: esriRedlands.x, y: esriRedlands.y, style: .alternatingBar, maxWidth: 175, units: .metric, scale: 80_000_000, unitsPerPoint: 21166.666666643807,  displayLength: 143, labels: ["0", "1,250", "2,500 km"])
     ]}
     
+    @MainActor
     func testAllCases() {
         for test in testCases {
             let viewpoint = Viewpoint(

--- a/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
@@ -16,8 +16,8 @@ import XCTest
 import ArcGIS
 @testable import ArcGISToolkit
 
-@MainActor
 class SearchViewModelTests: XCTestCase {
+    @MainActor
     func testAcceptSuggestion() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         model.currentQuery = "Magers & Quinn Booksellers"
@@ -38,6 +38,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(result.first, model.selectedResult)
     }
     
+    @MainActor
     func testCommitSearch() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         
@@ -88,6 +89,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertNil(model.selectedResult)
     }
     
+    @MainActor
     func testCurrentQuery() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         
@@ -124,6 +126,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertNil(model.selectedResult)
     }
     
+    @MainActor
     func testIsEligibleForRequery() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         
@@ -184,6 +187,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertTrue(model.isEligibleForRequery)
     }
     
+    @MainActor
     func testQueryArea() async throws {
         let source = LocatorSearchSource()
         source.maximumResults = .max
@@ -237,6 +241,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
     
+    @MainActor
     func testQueryCenter() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         
@@ -294,6 +299,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertLessThan(geodeticDistance.distance.value,  100)
     }
     
+    @MainActor
     func testRepeatSearch() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         
@@ -337,6 +343,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
     
+    @MainActor
     func testSearchResultMode() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         XCTAssertEqual(model.resultMode, .automatic)
@@ -383,6 +390,7 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
     
+    @MainActor
     func testUpdateSuggestions() async throws {
         let model = SearchViewModel(sources: [LocatorSearchSource()])
         

--- a/Tests/ArcGISToolkitTests/TokenChallengeContinuationTests.swift
+++ b/Tests/ArcGISToolkitTests/TokenChallengeContinuationTests.swift
@@ -16,7 +16,8 @@ import SwiftUI
 import XCTest
 @testable import ArcGISToolkit
 
-@MainActor final class TokenChallengeContinuationTests: XCTestCase {
+final class TokenChallengeContinuationTests: XCTestCase {
+    @MainActor
     func testInit() {
         let challenge = TokenChallengeContinuation(host: "host.com") { _ in
             fatalError()
@@ -26,6 +27,7 @@ import XCTest
         XCTAssertNotNil(challenge.tokenCredentialProvider)
     }
     
+    @MainActor
     func testResumeWithLogin() async {
         struct MockError: Error {}
         
@@ -38,6 +40,7 @@ import XCTest
         XCTAssertTrue(result.error is MockError)
     }
     
+    @MainActor
     func testCancel() async {
         let challenge = TokenChallengeContinuation(host: "host.com") { _ in
             fatalError()

--- a/Tests/ArcGISToolkitTests/TrustHostViewModifierTests.swift
+++ b/Tests/ArcGISToolkitTests/TrustHostViewModifierTests.swift
@@ -15,7 +15,8 @@
 import XCTest
 @testable import ArcGISToolkit
 
-@MainActor final class TrustHostViewModifierTests: XCTestCase {
+final class TrustHostViewModifierTests: XCTestCase {
+    @MainActor
     func testInit() {
         let challenge = NetworkChallengeContinuation(host: "host.com", kind: .serverTrust)
         // Tests the initial state.

--- a/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import ArcGISToolkit
 
-@MainActor final class UtilityNetworkTraceViewModelTests: XCTestCase {
+final class UtilityNetworkTraceViewModelTests: XCTestCase {
     override func setUp() async throws {
         ArcGISEnvironment.apiKey = .default
         
@@ -35,6 +35,7 @@ import XCTest
     }
     
     /// Test `UtilityNetworkTraceViewModel` on a map that does not contain a utility network.
+    @MainActor
     func testCase_1_1() async throws {
         let viewModel = UtilityNetworkTraceViewModel(
             map: try await makeMap(),
@@ -53,6 +54,7 @@ import XCTest
     }
     
     /// Test `UtilityNetworkTraceViewModel` on a map that contains a utility network.
+    @MainActor
     func testCase_1_4() async throws {
         let map = try await makeMapWithPortalItem()
         
@@ -74,6 +76,7 @@ import XCTest
     }
     
     /// Test initializing a `UtilityNetworkTraceViewModel` with starting points.
+    @MainActor
     func testCase_2_1() async throws {
         let map = try await makeMapWithPortalItem()
         
@@ -117,6 +120,7 @@ import XCTest
     
     /// Test modifying the terminal configuration of a utility element that supports terminal
     /// configuration.
+    @MainActor
     func testCase_2_2() async throws {
         let map = try await makeMapWithPortalItem()
         
@@ -169,6 +173,7 @@ import XCTest
     }
     
     /// Test modifying the fractional starting point along an edge based utility element.
+    @MainActor
     func testCase_2_3() async throws {
         let map = try await makeMapWithPortalItem()
         
@@ -211,6 +216,7 @@ import XCTest
     }
     
     // Test an upstream trace and validate a function result.
+    @MainActor
     func testCase_3_1() async throws {
         let map = try await makeMapWithPortalItem()
         

--- a/Tests/ArcGISToolkitTests/ValueContinuationTests.swift
+++ b/Tests/ArcGISToolkitTests/ValueContinuationTests.swift
@@ -15,7 +15,8 @@
 import XCTest
 @testable import ArcGISToolkit
 
-@MainActor final class ValueContinuationTests: XCTestCase {
+final class ValueContinuationTests: XCTestCase {
+    @MainActor
     func testValueContinuation() async {
         // Tests setting value before awaiting.
         let valueContinuation = ValueContinuation<String>()


### PR DESCRIPTION
Resolves the "Main actor-isolated class has different actor isolation from nonisolated superclass 'XCTestCase'; this is an error in Swift 6" warnings.

See also Swift 5188, 5218