### PR TITLE
Use correct attachment thumbnail size

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentModel.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentModel.swift
@@ -43,16 +43,17 @@ import SwiftUI
     }
     
     /// The pixel density of the display on the intended device.
-    private var displayScale: CGFloat
+    private let displayScale: CGFloat
     
-    /// The desired size of the thumbnail images.
-    var thumbnailSize: CGSize
-
+    /// The desired size of the thumbnail image.
+    let thumbnailSize: CGSize
+    
     /// Creates a view model representing the combination of a `FeatureAttachment` and
     /// an associated `UIImage` used as a thumbnail.
     /// - Parameters:
     ///   - attachment: The `FeatureAttachment`.
     ///   - displayScale: The pixel density of the display on the intended device.
+    ///   - thumbnailSize: The desired size of the thumbnail image.
     init(
         attachment: FeatureAttachment,
         displayScale: CGFloat,
@@ -61,7 +62,7 @@ import SwiftUI
         self.attachment = attachment
         self.displayScale = displayScale
         self.thumbnailSize = thumbnailSize
-
+        
         switch attachment.featureAttachmentKind {
         case .image:
             systemImageName = "photo"

--- a/Sources/ArcGISToolkit/Common/AttachmentModel.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentModel.swift
@@ -45,15 +45,23 @@ import SwiftUI
     /// The pixel density of the display on the intended device.
     private var displayScale: CGFloat
     
+    /// The desired size of the thumbnail images.
+    var thumbnailSize: CGSize
+
     /// Creates a view model representing the combination of a `FeatureAttachment` and
     /// an associated `UIImage` used as a thumbnail.
     /// - Parameters:
     ///   - attachment: The `FeatureAttachment`.
     ///   - displayScale: The pixel density of the display on the intended device.
-    init(attachment: FeatureAttachment, displayScale: CGFloat) {
+    init(
+        attachment: FeatureAttachment,
+        displayScale: CGFloat,
+        thumbnailSize: CGSize
+    ) {
         self.attachment = attachment
         self.displayScale = displayScale
-        
+        self.thumbnailSize = thumbnailSize
+
         switch attachment.featureAttachmentKind {
         case .image:
             systemImageName = "photo"
@@ -68,7 +76,7 @@ import SwiftUI
     
     /// Loads the attachment and generates a thumbnail image.
     /// - Parameter thumbnailSize: The size for the generated thumbnail.
-    func load(thumbnailSize: CGSize = CGSize(width: 40, height: 40)) {
+    func load() {
         Task {
             loadStatus = .loading
             try await attachment.load()

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -116,14 +116,14 @@ struct AttachmentPreview: View {
                             attachmentModel: attachmentModel,
                             size: attachmentModel.usingSystemImage ?
                             CGSize(width: 36, height: 36) :
-                                CGSize(width: 120, height: 120)
+                                attachmentModel.thumbnailSize
                         )
                         if attachmentModel.loadStatus == .loaded {
                             VStack {
                                 Spacer()
                                 ThumbnailViewFooter(
                                     attachmentModel: attachmentModel,
-                                    size: CGSize(width: 120, height: 120)
+                                    size: attachmentModel.thumbnailSize
                                 )
                             }
                         }
@@ -167,7 +167,7 @@ struct AttachmentPreview: View {
                     url = tmpURL
                 } else if attachmentModel.attachment.loadStatus == .notLoaded {
                     // Load the attachment model with the given size.
-                    attachmentModel.load(thumbnailSize: CGSize(width: 120, height: 120))
+                    attachmentModel.load()
                 }
             }
             .quickLookPreview($url)

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -30,6 +30,26 @@ struct AttachmentsFeatureElementView: View {
         !isPortraitOrientation
     }
     
+    var thumbnailSize: CGSize {
+        // Set thumbnail size
+        let thumbnailSize: CGSize
+        switch featureElement.attachmentDisplayType {
+        case .list:
+            thumbnailSize = CGSize(width: 40, height: 40)
+        case .preview:
+            thumbnailSize = CGSize(width: 120, height: 120)
+        case .auto:
+            if isRegularWidth {
+                thumbnailSize = CGSize(width: 120, height: 120)
+            } else {
+                thumbnailSize = CGSize(width: 40, height: 40)
+            }
+        @unknown default:
+            thumbnailSize = CGSize(width: 120, height: 120)
+        }
+        return thumbnailSize
+    }
+    
     /// The states of loading attachments.
     private enum AttachmentLoadingState {
         /// Attachments have not been loaded.
@@ -85,7 +105,13 @@ struct AttachmentsFeatureElementView: View {
             let attachments = (try? await featureElement.featureAttachments) ?? []
             
             var attachmentModels = attachments
-                .map { AttachmentModel(attachment: $0, displayScale: displayScale) }
+                .map {
+                    AttachmentModel(
+                        attachment: $0,
+                        displayScale: displayScale,
+                        thumbnailSize: thumbnailSize
+                    )
+                }
             
             if editControlsDisabled {
                 // Reverse attachment models array if we're not editing.
@@ -145,7 +171,11 @@ struct AttachmentsFeatureElementView: View {
     @MainActor
     func onAdd(attachment: FeatureAttachment) -> Void {
         guard case .loaded(var models) = attachmentLoadingState else { return }
-        let newModel = AttachmentModel(attachment: attachment, displayScale: displayScale)
+        let newModel = AttachmentModel(
+            attachment: attachment,
+            displayScale: displayScale,
+            thumbnailSize: thumbnailSize
+        )
         newModel.load()
         models.insert(newModel, at: 0)
         attachmentLoadingState = .loaded(models)

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -30,26 +30,6 @@ struct AttachmentsFeatureElementView: View {
         !isPortraitOrientation
     }
     
-    var thumbnailSize: CGSize {
-        // Set thumbnail size
-        let thumbnailSize: CGSize
-        switch featureElement.attachmentDisplayType {
-        case .list:
-            thumbnailSize = CGSize(width: 40, height: 40)
-        case .preview:
-            thumbnailSize = CGSize(width: 120, height: 120)
-        case .auto:
-            if isRegularWidth {
-                thumbnailSize = CGSize(width: 120, height: 120)
-            } else {
-                thumbnailSize = CGSize(width: 40, height: 40)
-            }
-        @unknown default:
-            thumbnailSize = CGSize(width: 120, height: 120)
-        }
-        return thumbnailSize
-    }
-    
     /// The states of loading attachments.
     private enum AttachmentLoadingState {
         /// Attachments have not been loaded.
@@ -222,5 +202,27 @@ extension AttachmentsFeatureElementView {
         var copy = self
         copy.editControlsDisabled = newEditControlsDisabled
         return copy
+    }
+    
+    /// The size of thumbnail images, based on the attachment display type
+    /// and the current size class of the view.
+    var thumbnailSize: CGSize {
+        // Set thumbnail size
+        let thumbnailSize: CGSize
+        switch featureElement.attachmentDisplayType {
+        case .list:
+            thumbnailSize = CGSize(width: 40, height: 40)
+        case .preview:
+            thumbnailSize = CGSize(width: 120, height: 120)
+        case .auto:
+            if isRegularWidth {
+                thumbnailSize = CGSize(width: 120, height: 120)
+            } else {
+                thumbnailSize = CGSize(width: 40, height: 40)
+            }
+        @unknown default:
+            thumbnailSize = CGSize(width: 120, height: 120)
+        }
+        return thumbnailSize
     }
 }


### PR DESCRIPTION
This moves the calculation and setting of the thumbnail size for attachments to the `AttachmentFeatureElementView` class and adds a `thumbnailSize` argument to the `AttachmentModel` constructor, instead of having it on the `load()` method.

Note this branch is based on the [FeatureFormView - Refresh attachment display on add](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/704) PR, so that should be merged first.