### PR TITLE
`FeatureFormView` - Improve new attachment button

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -82,6 +82,7 @@ struct AttachmentImportMenu: View {
         } label: {
             Image(systemName: "plus")
                 .font(.title2)
+                .padding(5)
         }
 #if targetEnvironment(macCatalyst)
         .menuStyle(.borderlessButton)


### PR DESCRIPTION
Early feedback indicated it's difficult to hit the new attachment button

Before
<img width="40%" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/5f2405b6-938b-4cfe-84b4-c90e3fffaaa1">


After
<img width="40%" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/71c42bf6-1325-4dfd-8e64-4ce06102adfa">
