### PR TITLE
Apple Edits fix for geodatabase/table

### DIFF
--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -199,10 +199,15 @@ class Model: ObservableObject {
             return
         }
         
-        let results = try? await database.applyEdits()
-        
-        if results?.first?.editResults.first?.didCompleteWithErrors ?? false {
-            print("An error occurred while submitting the changes.")
+        do {
+            if let serviceInfo = database.serviceInfo,
+               serviceInfo.canUseServiceGeodatabaseApplyEdits {
+                _ = try await database.applyEdits()
+            } else {
+                _ = try await table.applyEdits()
+            }
+        } catch {
+            submissionError = Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)")
         }
         
         self.featureForm = nil

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
@@ -134,12 +134,17 @@ struct FeatureFormExampleView: View {
         }
         
         // Apply the changes.
-        let results = try? await database.applyEdits()
-        
-        if results?.first?.editResults.first?.didCompleteWithErrors ?? false {
-            print("An error occurred while submitting the changes.")
+        do {
+            if let serviceInfo = database.serviceInfo,
+               serviceInfo.canUseServiceGeodatabaseApplyEdits {
+                _ = try await database.applyEdits()
+            } else {
+                _ = try await table.applyEdits()
+            }
+        } catch {
+            submissionError = Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)")
         }
-        
+
         // Clear the feature form
         self.featureForm = nil
     }


### PR DESCRIPTION
Added a check for `geodatabase.serviceInfo.canUseServiceGeodatabaseApplyEdits` to determine if we can use `applyEdits()` on the geodatabase or if we need to call it on the `table`.

Moved that code into a do-catch block and set an error if `applyEdits()` fails.

Updated the Tutorial as well.