### PR TITLE
Add support for `AttachmentFormElement.isEditable`.

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -28,10 +28,6 @@ struct AttachmentsFeatureElementView: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
     
-    /// A Boolean value indicating whether the feature Element
-    /// is an `AttachmentFormElement`.
-    private var isShowingAttachmentFormElement = false
-
     /// A Boolean value denoting if the view should be shown as regular width.
     var isRegularWidth: Bool {
         !isPortraitOrientation
@@ -54,7 +50,6 @@ struct AttachmentsFeatureElementView: View {
     /// - Parameter featureElement: The `AttachmentsFeatureElement`.
     init(featureElement: AttachmentsFeatureElement) {
         self.featureElement = featureElement
-        isShowingAttachmentFormElement = featureElement is AttachmentFormElement
     }
     
     /// A Boolean value denoting whether the Disclosure Group is expanded.
@@ -100,8 +95,9 @@ struct AttachmentsFeatureElementView: View {
                     )
                 }
             
-            if isShowingAttachmentFormElement {
-                // Reverse attachment models array if we're not editing.
+            if !isShowingAttachmentFormElement {
+                // Reverse attachment models array if we're not displaying
+                // via an AttachmentFormElement.
                 // This allows attachments in a non-editing context to
                 // display in the same order as the online Map Viewer.
                 attachmentModels = attachmentModels.reversed()
@@ -226,6 +222,12 @@ extension AttachmentsFeatureElementView {
             thumbnailSize = CGSize(width: 120, height: 120)
         }
         return thumbnailSize
+    }
+    
+    /// A Boolean value indicating whether the feature Element
+    /// is an `AttachmentFormElement`.
+    var isShowingAttachmentFormElement: Bool {
+        featureElement is AttachmentFormElement
     }
 }
 

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -61,8 +61,6 @@ struct AttachmentsFeatureElementView: View {
     @State private var isExpanded = true
     
     var body: some View {
-        Toggle(isOn: $isEditable) {}
-            .toggleStyle(.switch)
         Group {
             switch attachmentLoadingState {
             case .notLoaded, .loading:

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -230,11 +230,11 @@ extension AttachmentsFeatureElementView {
 }
 
 extension View {
-    /// Applies the given transform if the given condition evaluates to `true`.
+    /// Modifier for watching ``AttachmentFormElement.isEditableChanged`` events.
     /// - Parameters:
-    ///   - condition: The condition to evaluate.
-    ///   - transform: The transform to apply to the source `View`.
-    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
+    ///   - element: The attachment form element to watch for changes on.
+    ///   - action: The action which watches for changes.
+    /// - Returns: The modified view.
     @ViewBuilder func onAttachmentIsEditableChange(
         of element: AttachmentsFeatureElement,
         action: @escaping (_ newIsEditable: Bool) -> Void

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -116,7 +116,6 @@ extension FeatureFormView {
         switch element {
         case let attachmentElement as AttachmentFormElement:
             AttachmentsFeatureElementView(featureElement: attachmentElement)
-                .editControlsDisabled(false)
         case let element as FieldFormElement:
             makeFieldElement(element)
         case let element as GroupFormElement:


### PR DESCRIPTION
This adds support for `AttachmentFormElement.isEditable`, which is a `@Streamed` property that can change based on an expression evaluation.  This PR:

- Removes `editControlsDisabled` modifier
- Uses `@State isEditable` property to control showing/hiding edit controls
- Adds a new modifier `onAttachmentIsEditableChange` event for watching for `isEditable` changes on `AttachmentFormElement`
- Adds a new `isShowingAttachmentFormElement` property

The `isEditable` bit can be tested by putting the following code at the top of the Group in `AttachmentFeatureElementView`:

```
        Toggle(isOn: $isEditable) {}
            .toggleStyle(.switch)
```