### PR TITLE
`FeatureFormView` - More performance improvements for multiline text

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -185,7 +185,7 @@ private extension TextInput {
                 .buttonStyle(.plain)
                 .foregroundColor(.accentColor)
             }
-            RepresentedUITextView(text: $text) { text in
+            RepresentedUITextView(initialText: text) { text in
                 element.convertAndUpdateValue(text)
                 model.evaluateExpressions()
             } onTextViewDidEndEditing: { text in

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -225,7 +225,7 @@ private extension FieldFormElement {
 }
 
 private extension View {
-    /// Wraps  `onValueChange(of:action:)` with an additional boolean property that when false will
+    /// Wraps `onValueChange(of:action:)` with an additional boolean property that when false will
     /// not monitor value changes.
     /// - Parameters:
     ///   - element: The form element to watch for changes on.

--- a/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
+++ b/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
@@ -19,10 +19,15 @@ import SwiftUI
 /// A `UITextView` has noticeably better performance over a SwiftUI `TextField` when dealing with
 /// large input (e.g. thousands of characters).
 struct RepresentedUITextView: UIViewRepresentable {
+    /// The text view's text.
     @Binding var text: String
     
+    /// The action to perform when the text view's text changes.
+    ///
+    /// If this is left nil the bound text is updated instead.
     var onTextViewDidChange: ((String) -> Void)? = nil
     
+    /// The action to perform when text editing ends.
     var onTextViewDidEndEditing: ((String) -> Void)? = nil
     
     func makeUIView(context: Context) -> UITextView {
@@ -40,10 +45,15 @@ struct RepresentedUITextView: UIViewRepresentable {
     }
     
     class Coordinator: NSObject, UITextViewDelegate {
+        /// The text view's text.
         var text: Binding<String>
         
+        /// The action to perform when the text view's text changes.
+        ///
+        /// If this is left nil the bound text is updated instead.
         var onTextViewDidChange: ((String) -> Void)?
         
+        /// The action to perform when text editing ends.
         var onTextViewDidEndEditing: ((String) -> Void)?
         
         init(text: Binding<String>, onTextViewDidChange: ((String) -> Void)? = nil, onTextViewDidEndEditing: ((String) -> Void)? = nil) {

--- a/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
+++ b/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
@@ -20,15 +20,16 @@ import SwiftUI
 /// large input (e.g. thousands of characters).
 struct RepresentedUITextView: UIViewRepresentable {
     /// The text view's text.
-    @Binding var text: String
+    private var boundText: Binding<String>?
+    
+    /// The text initially provided to the view.
+    private let initialText: String
     
     /// The action to perform when the text view's text changes.
-    ///
-    /// If this is left nil the bound text is updated instead.
-    var onTextViewDidChange: ((String) -> Void)? = nil
+    private var onTextViewDidChange: ((String) -> Void)? = nil
     
     /// The action to perform when text editing ends.
-    var onTextViewDidEndEditing: ((String) -> Void)? = nil
+    private var onTextViewDidEndEditing: ((String) -> Void)? = nil
     
     func makeUIView(context: Context) -> UITextView {
         let uiTextView = UITextView()
@@ -37,49 +38,88 @@ struct RepresentedUITextView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiTextView: UITextView, context: Context) {
-        uiTextView.text = text
+        if let boundText {
+            uiTextView.text = boundText.wrappedValue
+        } else {
+            uiTextView.text = initialText
+        }
     }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(
-            text: $text,
-            onTextViewDidChange: onTextViewDidChange,
-            onTextViewDidEndEditing: onTextViewDidEndEditing
-        )
+        if let boundText {
+            Coordinator(
+                text: boundText,
+                onTextViewDidChange: nil,
+                onTextViewDidEndEditing: nil
+            )
+        } else {
+            Coordinator(
+                text: nil,
+                onTextViewDidChange: onTextViewDidChange,
+                onTextViewDidEndEditing: onTextViewDidEndEditing
+            )
+        }
     }
     
     class Coordinator: NSObject, UITextViewDelegate {
         /// The text view's text.
-        var text: Binding<String>
+        var boundText: Binding<String>?
         
         /// The action to perform when the text view's text changes.
-        ///
-        /// If this is left nil the bound text is updated instead.
         var onTextViewDidChange: ((String) -> Void)?
         
         /// The action to perform when text editing ends.
         var onTextViewDidEndEditing: ((String) -> Void)?
         
         init(
-            text: Binding<String>, 
+            text: Binding<String>?,
             onTextViewDidChange: ((String) -> Void)? = nil,
             onTextViewDidEndEditing: ((String) -> Void)? = nil
         ) {
-            self.text = text
+            self.boundText = text
             self.onTextViewDidChange = onTextViewDidChange
             self.onTextViewDidEndEditing = onTextViewDidEndEditing
         }
         
         func textViewDidChange(_ textView: UITextView) {
-            if let onTextViewDidChange {
-                onTextViewDidChange(textView.text)
+            if let boundText {
+                boundText.wrappedValue = textView.text
             } else {
-                text.wrappedValue = textView.text
+                onTextViewDidChange?(textView.text)
             }
         }
         
         func textViewDidEndEditing(_ textView: UITextView) {
             onTextViewDidEndEditing?(textView.text)
         }
+    }
+}
+
+extension RepresentedUITextView {
+    /// Creates a `UITextView` bound to the provided text.
+    /// - Parameter text: The text to bind to.
+    init(text: Binding<String>) {
+        self.init(
+            boundText: text,
+            initialText: text.wrappedValue,
+            onTextViewDidChange: nil,
+            onTextViewDidEndEditing: nil
+        )
+    }
+    
+    /// Creates a `UITextView` initialized with the provided text.
+    ///
+    /// Monitor changes to the text with the `onTextViewDidChange` and `onTextViewDidEndEditing` properties.
+    /// - Parameters:
+    ///   - initialText: The view's initial text.
+    ///   - onTextViewDidChange: The action to perform when the text did change.
+    ///   - onTextViewDidEndEditing: The action to perform when editing did end.
+    init(initialText: String, onTextViewDidChange: ((String) -> Void)?, onTextViewDidEndEditing: ((String) -> Void)? = nil) {
+        self.init(
+            boundText: nil,
+            initialText: initialText,
+            onTextViewDidChange: onTextViewDidChange,
+            onTextViewDidEndEditing: onTextViewDidEndEditing
+        )
     }
 }

--- a/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
+++ b/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
@@ -21,6 +21,10 @@ import SwiftUI
 struct RepresentedUITextView: UIViewRepresentable {
     @Binding var text: String
     
+    var onTextViewDidChange: ((String) -> Void)? = nil
+    
+    var onTextViewDidEndEditing: ((String) -> Void)? = nil
+    
     func makeUIView(context: Context) -> UITextView {
         let uiTextView = UITextView()
         uiTextView.delegate = context.coordinator
@@ -32,18 +36,32 @@ struct RepresentedUITextView: UIViewRepresentable {
     }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(text: $text, onTextViewDidChange: onTextViewDidChange, onTextViewDidEndEditing: onTextViewDidEndEditing)
     }
     
     class Coordinator: NSObject, UITextViewDelegate {
         var text: Binding<String>
         
-        init(text: Binding<String>) {
+        var onTextViewDidChange: ((String) -> Void)?
+        
+        var onTextViewDidEndEditing: ((String) -> Void)?
+        
+        init(text: Binding<String>, onTextViewDidChange: ((String) -> Void)? = nil, onTextViewDidEndEditing: ((String) -> Void)? = nil) {
             self.text = text
+            self.onTextViewDidChange = onTextViewDidChange
+            self.onTextViewDidEndEditing = onTextViewDidEndEditing
         }
         
         func textViewDidChange(_ textView: UITextView) {
-            text.wrappedValue = textView.text
+            if let onTextViewDidChange {
+                onTextViewDidChange(textView.text)
+            } else {
+                text.wrappedValue = textView.text
+            }
+        }
+        
+        func textViewDidEndEditing(_ textView: UITextView) {
+            onTextViewDidEndEditing?(textView.text)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
+++ b/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
@@ -41,7 +41,11 @@ struct RepresentedUITextView: UIViewRepresentable {
     }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, onTextViewDidChange: onTextViewDidChange, onTextViewDidEndEditing: onTextViewDidEndEditing)
+        Coordinator(
+            text: $text,
+            onTextViewDidChange: onTextViewDidChange,
+            onTextViewDidEndEditing: onTextViewDidEndEditing
+        )
     }
     
     class Coordinator: NSObject, UITextViewDelegate {
@@ -56,7 +60,11 @@ struct RepresentedUITextView: UIViewRepresentable {
         /// The action to perform when text editing ends.
         var onTextViewDidEndEditing: ((String) -> Void)?
         
-        init(text: Binding<String>, onTextViewDidChange: ((String) -> Void)? = nil, onTextViewDidEndEditing: ((String) -> Void)? = nil) {
+        init(
+            text: Binding<String>, 
+            onTextViewDidChange: ((String) -> Void)? = nil,
+            onTextViewDidEndEditing: ((String) -> Void)? = nil
+        ) {
             self.text = text
             self.onTextViewDidChange = onTextViewDidChange
             self.onTextViewDidEndEditing = onTextViewDidEndEditing

--- a/Test Runner/Test Runner.xcodeproj/project.pbxproj
+++ b/Test Runner/Test Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		8A1562F52B86896300000DD6 /* UI Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F42B86896300000DD6 /* UI Tests.xctestplan */; };
 		8A1562F72B86896C00000DD6 /* Unit Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F62B86896C00000DD6 /* Unit Tests.xctestplan */; };
 		8A9F898F2B5B4F0A0027215E /* FeatureFormTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */; };
+		8AEE704A2BEEC18000C9949C /* RepresentedUITextViewTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 		8A1562F42B86896300000DD6 /* UI Tests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "UI Tests.xctestplan"; sourceTree = "<group>"; };
 		8A1562F62B86896C00000DD6 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
 		8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureFormTestView.swift; sourceTree = "<group>"; };
+		8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepresentedUITextViewTestView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */,
+				8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */,
 				75B236682A5CB49B00AEFACE /* BasemapGalleryTestView.swift */,
 				7584B7532B1A798B00772AB7 /* BookmarksTestViews */,
 				75B2366C2A5CC78C00AEFACE /* FloorFilterTestView.swift */,
@@ -292,6 +295,7 @@
 				75384C112B2D1BD800D97E6C /* BookmarksTestCase5View.swift in Sources */,
 				7552A7622A573D810023DA5A /* BookmarksTestCase1View.swift in Sources */,
 				7584B7592B1A817A00772AB7 /* BookmarksTestCase3View.swift in Sources */,
+				8AEE704A2BEEC18000C9949C /* RepresentedUITextViewTestView.swift in Sources */,
 				7584B7572B1A7AF100772AB7 /* BookmarksTestCase2View.swift in Sources */,
 				8A9F898F2B5B4F0A0027215E /* FeatureFormTestView.swift in Sources */,
 				8A1138132BC7407D007E0BFB /* BookmarksTestCase6View.swift in Sources */,

--- a/Test Runner/Test Runner.xcodeproj/project.pbxproj
+++ b/Test Runner/Test Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		8A1562F52B86896300000DD6 /* UI Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F42B86896300000DD6 /* UI Tests.xctestplan */; };
 		8A1562F72B86896C00000DD6 /* Unit Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F62B86896C00000DD6 /* Unit Tests.xctestplan */; };
 		8A9F898F2B5B4F0A0027215E /* FeatureFormTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */; };
+		8AEE70482BEEC0B400C9949C /* RepresentedUITextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE70472BEEC0B400C9949C /* RepresentedUITextViewTests.swift */; };
 		8AEE704A2BEEC18000C9949C /* RepresentedUITextViewTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */; };
 /* End PBXBuildFile section */
 
@@ -66,6 +67,7 @@
 		8A1562F42B86896300000DD6 /* UI Tests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "UI Tests.xctestplan"; sourceTree = "<group>"; };
 		8A1562F62B86896C00000DD6 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
 		8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureFormTestView.swift; sourceTree = "<group>"; };
+		8AEE70472BEEC0B400C9949C /* RepresentedUITextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepresentedUITextViewTests.swift; sourceTree = "<group>"; };
 		8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepresentedUITextViewTestView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -144,6 +146,7 @@
 				7552A76B2A573DFB0023DA5A /* BookmarksTests.swift */,
 				75B2366E2A5CCADC00AEFACE /* FloorFilterTests.swift */,
 				75022F952A7AC9A0000ED7B7 /* FormViewTests.swift */,
+				8AEE70472BEEC0B400C9949C /* RepresentedUITextViewTests.swift */,
 			);
 			path = "UI Tests";
 			sourceTree = "<group>";
@@ -311,6 +314,7 @@
 				75022F962A7AC9A0000ED7B7 /* FormViewTests.swift in Sources */,
 				75B2366F2A5CCADC00AEFACE /* FloorFilterTests.swift in Sources */,
 				75B2366B2A5CB8CE00AEFACE /* BasemapGalleryTests.swift in Sources */,
+				8AEE70482BEEC0B400C9949C /* RepresentedUITextViewTests.swift in Sources */,
 				7552A76C2A573DFB0023DA5A /* BookmarksTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
+++ b/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
@@ -60,6 +60,7 @@ extension RepresentedUITextViewTestView {
             Button("End Editing") {
                 isFocused = false
             }
+            .buttonStyle(.plain)
             RepresentedUITextView(initialText: text) { text in
                 self.text = text
             } onTextViewDidEndEditing: { text in

--- a/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
+++ b/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
@@ -1,0 +1,70 @@
+// Copyright 2023 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import ArcGISToolkit
+import SwiftUI
+
+struct RepresentedUITextViewTestView: View {
+    var body: some View {
+        List {
+            NavigationLink("TestInit", destination: TestInit())
+            NavigationLink("TestInitWithActions", destination: TestInitWithActions())
+        }
+    }
+}
+
+extension RepresentedUITextViewTestView {
+    struct TestInit: View {
+        @State private var text = "Hello, World!"
+        
+        var body: some View {
+            HStack(alignment: .center) {
+                Text("Bound Value:")
+                Text(text)
+                    .accessibilityIdentifier("Bound Value")
+            }
+            RepresentedUITextView(text: $text)
+        }
+    }
+    
+    struct TestInitWithActions: View {
+        @State private var text = "Hello, World!"
+        
+        @State private var endValue = ""
+        
+        @FocusState var isFocused
+        
+        var body: some View {
+            HStack(alignment: .center) {
+                Text("Bound Value:")
+                Text(text)
+                    .accessibilityIdentifier("Bound Value")
+            }
+            HStack(alignment: .center) {
+                Text("End Value:")
+                Text(endValue)
+                    .accessibilityIdentifier("End Value")
+            }
+            Button("End Editing") {
+                isFocused = false
+            }
+            RepresentedUITextView(initialText: text) { text in
+                self.text = text
+            } onTextViewDidEndEditing: { text in
+                endValue = text
+            }
+            .focused($isFocused)
+        }
+    }
+}

--- a/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
+++ b/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
@@ -1,4 +1,4 @@
-// Copyright 2023 Esri
+// Copyright 2024 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
+++ b/Test Runner/Test Runner/TestViews/RepresentedUITextViewTestView.swift
@@ -26,7 +26,7 @@ struct RepresentedUITextViewTestView: View {
 
 extension RepresentedUITextViewTestView {
     struct TestInit: View {
-        @State private var text = "Hello, World!"
+        @State private var text = "World!"
         
         var body: some View {
             HStack(alignment: .center) {
@@ -35,11 +35,12 @@ extension RepresentedUITextViewTestView {
                     .accessibilityIdentifier("Bound Value")
             }
             RepresentedUITextView(text: $text)
+                .accessibilityIdentifier("Text View")
         }
     }
     
     struct TestInitWithActions: View {
-        @State private var text = "Hello, World!"
+        @State private var text = "World!"
         
         @State private var endValue = ""
         
@@ -64,6 +65,7 @@ extension RepresentedUITextViewTestView {
             } onTextViewDidEndEditing: { text in
                 endValue = text
             }
+            .accessibilityIdentifier("Text View")
             .focused($isFocused)
         }
     }

--- a/Test Runner/Test Runner/Tests.swift
+++ b/Test Runner/Test Runner/Tests.swift
@@ -22,6 +22,7 @@ struct Tests: View {
                 NavigationLink("Bookmarks Tests", destination: BookmarksTestViews())
                 NavigationLink("Feature Form Tests", destination: FeatureFormTestView())
                 NavigationLink("Floor Filter Tests", destination: FloorFilterTestView())
+                NavigationLink("RepresentedUITextView Tests", destination: RepresentedUITextViewTestView())
             }
         }
     }

--- a/Test Runner/UI Tests/RepresentedUITextViewTests.swift
+++ b/Test Runner/UI Tests/RepresentedUITextViewTests.swift
@@ -1,0 +1,22 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import ArcGISToolkit
+import SwiftUI
+import XCTest
+
+final class RepresentedUITextViewTests: XCTestCase {
+    func testInit() {
+    }
+}

--- a/Test Runner/UI Tests/RepresentedUITextViewTests.swift
+++ b/Test Runner/UI Tests/RepresentedUITextViewTests.swift
@@ -18,5 +18,42 @@ import XCTest
 
 final class RepresentedUITextViewTests: XCTestCase {
     func testInit() {
+        let app = XCUIApplication()
+        let boundValue = app.staticTexts["Bound Value"]
+        let textView = app.textViews["Text View"]
+        
+        app.launch()
+        app.buttons["RepresentedUITextView Tests"].tap()
+        app.buttons["TestInit"].tap()
+        
+        XCTAssertEqual(boundValue.label, "World!")
+        
+        textView.tap()
+        textView.typeText("Hello, ")
+        
+        XCTAssertEqual(boundValue.label, "Hello, World!")
+    }
+    
+    func testInitWithActions() {
+        let app = XCUIApplication()
+        let boundValue = app.staticTexts["Bound Value"]
+        let endValue = app.staticTexts["End Value"]
+        let textView = app.textViews["Text View"]
+        
+        app.launch()
+        app.buttons["RepresentedUITextView Tests"].tap()
+        app.buttons["TestInitWithActions"].tap()
+        
+        XCTAssertEqual(boundValue.label, "World!")
+        
+        textView.tap()
+        textView.typeText("Hello, ")
+        
+        XCTAssertEqual(boundValue.label, "Hello, World!")
+        XCTAssertEqual(endValue.label, "")
+        
+        app.buttons["End Editing"].tap()
+        
+        XCTAssertEqual(endValue.label, "Hello, World!")
     }
 }


### PR DESCRIPTION
Ref Apollo 649

This is a follow-up to #722. 

It creates a second initializer for `RepresentedUITextView`, so we now have an initializer that takes a bound string and another that takes two callbacks (text changed and editing ended). Using the callback initializer, we can directly update the element's value, bypassing slow updates to the bound SwiftUI property.