### PR TITLE
Rename classes as appropriate and include new API.

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -68,7 +68,7 @@ struct AttachmentsFeatureElementView: View {
                 ProgressView()
                     .padding()
             case .loaded(let attachmentModels):
-                if isShowingAttachmentFormElement {
+                if isShowingAttachmentsFormElement {
                     // If showing a form element, don't show attachments in
                     // a disclosure group, but also ALWAYS show
                     // the list of attachments, even if there are none.
@@ -101,9 +101,9 @@ struct AttachmentsFeatureElementView: View {
                     )
                 }
             
-            if !isShowingAttachmentFormElement {
+            if !isShowingAttachmentsFormElement {
                 // Reverse attachment models array if we're not displaying
-                // via an AttachmentFormElement.
+                // via an AttachmentsFormElement.
                 // This allows attachments in a non-editing context to
                 // display in the same order as the online Map Viewer.
                 attachmentModels = attachmentModels.reversed()
@@ -113,7 +113,7 @@ struct AttachmentsFeatureElementView: View {
     }
     
     @ViewBuilder private func attachmentBody(attachmentModels: [AttachmentModel]) -> some View {
-        switch featureElement.attachmentDisplayType {
+        switch featureElement.attachmentsDisplayType {
         case .list:
             AttachmentList(attachmentModels: attachmentModels)
         case .preview:
@@ -149,7 +149,7 @@ struct AttachmentsFeatureElementView: View {
             )
             Spacer()
             if isEditable,
-               let element = featureElement as? AttachmentFormElement {
+               let element = featureElement as? AttachmentsFormElement {
                 AttachmentImportMenu(element: element, onAdd: onAdd)
             }
         }
@@ -177,7 +177,7 @@ struct AttachmentsFeatureElementView: View {
     ///   - newAttachmentName: The new attachment name.
     @MainActor
     func onRename(attachmentModel: AttachmentModel, newAttachmentName: String) async throws -> Void {
-        if let element = featureElement as? AttachmentFormElement,
+        if let element = featureElement as? AttachmentsFormElement,
            let attachment = attachmentModel.attachment as? FormAttachment {
             try await element.renameAttachment(attachment, name: newAttachmentName)
             attachmentModel.sync()
@@ -190,7 +190,7 @@ struct AttachmentsFeatureElementView: View {
     ///   - attachmentModel: The model for the attachment to delete.
     @MainActor
     func onDelete(attachmentModel: AttachmentModel) async throws -> Void {
-        if let element = featureElement as? AttachmentFormElement,
+        if let element = featureElement as? AttachmentsFormElement,
            let attachment = attachmentModel.attachment as? FormAttachment {
             try await element.deleteAttachment(attachment)
             guard case .loaded(var models) = attachmentLoadingState else { return }
@@ -218,7 +218,7 @@ extension AttachmentsFeatureElementView {
     var thumbnailSize: CGSize {
         // Set thumbnail size
         let thumbnailSize: CGSize
-        switch featureElement.attachmentDisplayType {
+        switch featureElement.attachmentsDisplayType {
         case .list:
             thumbnailSize = CGSize(width: 40, height: 40)
         case .preview:
@@ -236,14 +236,14 @@ extension AttachmentsFeatureElementView {
     }
     
     /// A Boolean value indicating whether the feature Element
-    /// is an `AttachmentFormElement`.
-    var isShowingAttachmentFormElement: Bool {
-        featureElement is AttachmentFormElement
+    /// is an `AttachmentsFormElement`.
+    var isShowingAttachmentsFormElement: Bool {
+        featureElement is AttachmentsFormElement
     }
 }
 
 extension View {
-    /// Modifier for watching ``AttachmentFormElement.isEditableChanged`` events.
+    /// Modifier for watching ``AttachmentsFormElement.isEditableChanged`` events.
     /// - Parameters:
     ///   - element: The attachment form element to watch for changes on.
     ///   - action: The action which watches for changes.
@@ -252,10 +252,10 @@ extension View {
         of element: AttachmentsFeatureElement,
         action: @escaping (_ newIsEditable: Bool) -> Void
     ) -> some View {
-        if let attachmentFormElement = element as? AttachmentFormElement {
+        if let attachmentsFormElement = element as? AttachmentsFormElement {
             self
-                .task(id: ObjectIdentifier(attachmentFormElement)) {
-                    for await isEditable in attachmentFormElement.$isEditable {
+                .task(id: ObjectIdentifier(attachmentsFormElement)) {
+                    for await isEditable in attachmentsFormElement.$isEditable {
                         action(isEditable)
                     }
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -49,8 +49,8 @@ struct AttachmentImportMenu: View {
     /// The action to perform when an attachment is added.
     let onAdd: ((FeatureAttachment) async throws -> Void)?
     
-    fileprivate func takePhotoOrVideoButton() -> Button<some View> {
-        return Button {
+    private func takePhotoOrVideoButton() -> Button<some View> {
+       Button {
             cameraIsShowing = true
         } label: {
             Label {
@@ -66,8 +66,8 @@ struct AttachmentImportMenu: View {
         }
     }
     
-    fileprivate func chooseFromLibraryButton() -> Button<some View> {
-        return Button {
+    private func chooseFromLibraryButton() -> Button<some View> {
+       Button {
             photoPickerIsPresented = true
         } label: {
             Label {
@@ -83,8 +83,8 @@ struct AttachmentImportMenu: View {
         }
     }
     
-    fileprivate func chooseFromFilesButton() -> Button<some View> {
-        return Button {
+    private func chooseFromFilesButton() -> Button<some View> {
+       Button {
             fileImporterIsShowing = true
         } label: {
             Label {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -21,12 +21,12 @@ import UniformTypeIdentifiers
 struct AttachmentImportMenu: View {
     
     /// The attachment form element displaying the menu.
-    private let element: AttachmentFormElement
+    private let element: AttachmentsFormElement
     
     /// Creates an `AttachmentImportMenu`
     /// - Parameter element: The attachment form element displaying the menu.
     /// - Parameter onAdd: The action to perform when an attachment is added.
-    init(element: AttachmentFormElement, onAdd: ((FeatureAttachment) async throws -> Void)? = nil) {
+    init(element: AttachmentsFormElement, onAdd: ((FeatureAttachment) async throws -> Void)? = nil) {
         self.element = element
         self.onAdd = onAdd
     }
@@ -49,50 +49,67 @@ struct AttachmentImportMenu: View {
     /// The action to perform when an attachment is added.
     let onAdd: ((FeatureAttachment) async throws -> Void)?
     
+    fileprivate func takePhotoOrVideoButton() -> Button<some View> {
+        return Button {
+            cameraIsShowing = true
+        } label: {
+            Label {
+                Text(
+                    "Take Photo or Video",
+                    bundle: .toolkitModule,
+                    comment: "A label for a button to capture a new photo or video."
+                )
+            } icon: {
+                Image(systemName: "camera")
+            }
+            .labelStyle(.titleAndIcon)
+        }
+    }
+    
+    fileprivate func chooseFromLibraryButton() -> Button<some View> {
+        return Button {
+            photoPickerIsPresented = true
+        } label: {
+            Label {
+                Text(
+                    "Choose From Library",
+                    bundle: .toolkitModule,
+                    comment: "A label for a button to choose a photo or video from the user's photo library."
+                )
+            } icon: {
+                Image(systemName: "photo")
+            }
+            .labelStyle(.titleAndIcon)
+        }
+    }
+    
+    fileprivate func chooseFromFilesButton() -> Button<some View> {
+        return Button {
+            fileImporterIsShowing = true
+        } label: {
+            Label {
+                Text(
+                    "Choose From Files",
+                    bundle: .toolkitModule,
+                    comment: "A label for a button to choose an file from the user's files."
+                )
+            } icon: {
+                Image(systemName: "folder")
+            }
+            .labelStyle(.titleAndIcon)
+        }
+    }
+    
     var body: some View {
         Menu {
-            Button {
-                cameraIsShowing = true
-            } label: {
-                Label {
-                    Text(
-                        "Take Photo or Video",
-                        bundle: .toolkitModule,
-                        comment: "A label for a button to capture a new photo or video."
-                    )
-                } icon: {
-                    Image(systemName: "camera")
-                }
-                .labelStyle(.titleAndIcon)
+            if element.input is AnyAttachmentsFormInput {
+                // Show photo/video and library picker if
+                // we're allowing all input types.
+                takePhotoOrVideoButton()
+                chooseFromLibraryButton()
             }
-            Button {
-                photoPickerIsPresented = true
-            } label: {
-                Label {
-                    Text(
-                        "Choose From Library",
-                        bundle: .toolkitModule,
-                        comment: "A label for a button to choose a photo or video from the user's photo library."
-                    )
-                } icon: {
-                    Image(systemName: "photo")
-                }
-                .labelStyle(.titleAndIcon)
-            }
-            Button {
-                fileImporterIsShowing = true
-            } label: {
-                Label {
-                    Text(
-                        "Choose From Files",
-                        bundle: .toolkitModule,
-                        comment: "A label for a button to choose an file from the user's files."
-                    )
-                } icon: {
-                    Image(systemName: "folder")
-                }
-                .labelStyle(.titleAndIcon)
-            }
+            // Always show file picker, no matter the input type.
+            chooseFromFilesButton()
         } label: {
             Image(systemName: "plus")
                 .font(.title2)
@@ -133,7 +150,7 @@ struct AttachmentImportMenu: View {
             newAttachmentImportData = AttachmentImportData(data: data, contentType: "image/png")
             self.capturedImage = nil
         }
-        .fileImporter(isPresented: $fileImporterIsShowing, allowedContentTypes: [.content]) { result in
+        .fileImporter(isPresented: $fileImporterIsShowing, allowedContentTypes: [.item]) { result in
             switch result {
             case .success(let url):
                 // gain access to the url resource and verify there's data.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -114,8 +114,8 @@ extension FeatureFormView {
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func makeElement(_ element: FormElement) -> some View {
         switch element {
-        case let attachmentElement as AttachmentFormElement:
-            AttachmentsFeatureElementView(featureElement: attachmentElement)
+        case let attachmentsElement as AttachmentsFormElement:
+            AttachmentsFeatureElementView(featureElement: attachmentsElement)
         case let element as FieldFormElement:
             makeFieldElement(element)
         case let element as GroupFormElement:

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFeatureElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFeatureElement.swift
@@ -28,7 +28,7 @@ public enum AttachmentsFeatureElementDisplayType {
 /// Common properties for elements which display feature attachments.
 public protocol AttachmentsFeatureElement {
     /// Indicates how to display the attachments.
-    var attachmentDisplayType: AttachmentsFeatureElementDisplayType { get }
+    var attachmentsDisplayType: AttachmentsFeatureElementDisplayType { get }
     
     /// A string value describing the element in detail. Can be an empty string.
     var description: String { get }

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
@@ -14,9 +14,9 @@
 
 import ArcGIS
 
-extension AttachmentFormElement : AttachmentsFeatureElement {
+extension AttachmentsFormElement : AttachmentsFeatureElement {
     /// Indicates how to display the attachments.
-    public var attachmentDisplayType: AttachmentsFeatureElementDisplayType {
+    public var attachmentsDisplayType: AttachmentsFeatureElementDisplayType {
         // Currently, Attachment Form Elements only support `Preview`.
         AttachmentsFeatureElementDisplayType.preview
     }

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsPopupElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsPopupElement.swift
@@ -16,7 +16,7 @@ import ArcGIS
 
 extension AttachmentsPopupElement : AttachmentsFeatureElement {
     /// Indicates how to display the attachments.
-    public var attachmentDisplayType: AttachmentsFeatureElementDisplayType {
+    public var attachmentsDisplayType: AttachmentsFeatureElementDisplayType {
         AttachmentsFeatureElementDisplayType(kind: displayType)
     }
     

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
@@ -17,14 +17,16 @@ import UIKit
 
 /// The type of an attachment in a FeatureAttachment.
 public enum FeatureAttachmentKind {
+    /// An attachment of another type.
+    case other
     /// An image.
     case image
     /// A video.
     case video
     /// A document.
     case document
-    /// An attachment of another type.
-    case other
+    /// An audio file.
+    case audio
 }
 
 public protocol FeatureAttachment: Loadable {
@@ -86,15 +88,20 @@ extension FeatureAttachmentKind {
         }
     }
     
-    /// Creates a feature attachment kind from a MIME type.
-    /// - Parameter contentType: The content type to convert.
-    init(contentType: String) {
-        if contentType.contains("image") {
+    /// Creates a feature attachment kind from a popup attachment kind.
+    /// - Parameter kind: The popup attachment kind.
+    init(kind: FormAttachment.Kind) {
+        switch kind {
+        case .other:
+            self = .other
+        case .image:
             self = .image
-        } else if contentType.contains("video") {
+        case .video:
             self = .video
-        } else {
+        case .document:
             self = .document
+        case .audio:
+            self = .audio
         }
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FormAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FormAttachment.swift
@@ -17,6 +17,6 @@ import ArcGIS
 extension FormAttachment : FeatureAttachment {
     /// The type of the attachment.
     public var featureAttachmentKind: FeatureAttachmentKind {
-        FeatureAttachmentKind(contentType: contentType)
+        FeatureAttachmentKind(kind: kind)
     }
 }


### PR DESCRIPTION
This updates the Toolkit to consume the latest set of Attachment API enhancements. It also adds support for the `AnyAttachmentInputType` in `AttachmentImportMenu`, which will form the bases for other attachment input types going forward.