### PR TITLE
`FeatureFormView` - Stabilize test case 1.4

### DIFF
--- a/Test Runner/UI Tests/FormViewTests.swift
+++ b/Test Runner/UI Tests/FormViewTests.swift
@@ -288,6 +288,7 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_1_4() {
         let app = XCUIApplication()
+        let clearButton = app.buttons["numbers Clear Button"]
         let footer = app.staticTexts["numbers Footer"]
         let formTitle = app.staticTexts["Domain"]
         let formViewTestsButton = app.buttons["Feature Form Tests"]
@@ -325,9 +326,9 @@ final class FeatureFormViewTests: XCTestCase {
             "Enter value from 2.0 to 5.0"
         )
         
-        // Highlight/select the current value and replace it
-        textField.doubleTap()
-        textField.typeText("2.1")
+        clearButton.tap()
+        
+        textField.typeText("3")
         
         expectation(
             for: NSPredicate(format: "label == \"Range domain 2-5\""),
@@ -335,9 +336,9 @@ final class FeatureFormViewTests: XCTestCase {
         )
         waitForExpectations(timeout: 10, handler: nil)
         
-        // Highlight/select the current value and replace it
-        textField.doubleTap()
-        textField.typeText("5.1")
+        clearButton.tap()
+        
+        textField.typeText("6")
         
         XCTAssertEqual(
             footer.label,

--- a/Test Runner/UI Tests/FormViewTests.swift
+++ b/Test Runner/UI Tests/FormViewTests.swift
@@ -288,7 +288,6 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_1_4() {
         let app = XCUIApplication()
-        let clearButton = app.buttons["numbers Clear Button"]
         let footer = app.staticTexts["numbers Footer"]
         let formTitle = app.staticTexts["Domain"]
         let formViewTestsButton = app.buttons["Feature Form Tests"]
@@ -326,8 +325,8 @@ final class FeatureFormViewTests: XCTestCase {
             "Enter value from 2.0 to 5.0"
         )
         
-        clearButton.tap()
-        
+        // Highlight/select the current value and replace it
+        textField.doubleTap()
         textField.typeText("3")
         
         expectation(
@@ -336,8 +335,8 @@ final class FeatureFormViewTests: XCTestCase {
         )
         waitForExpectations(timeout: 10, handler: nil)
         
-        clearButton.tap()
-        
+        // Highlight/select the current value and replace it
+        textField.doubleTap()
         textField.typeText("6")
         
         XCTAssertEqual(


### PR DESCRIPTION
This test has proven to be flaky. I've noticed in some instances `typeText("2.1")` doesn't always successfully hit the decimal.

With these changes, I can run 10x on device without failure.