### PR TITLE
Use `FeatureForm.defaultAttachmentElement`.

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -91,6 +91,9 @@ public struct FeatureFormView: View {
                         ForEach(model.visibleElements, id: \.self) { element in
                             makeElement(element)
                         }
+                        if let attachmentElement = model.featureForm.defaultAttachmentElement {
+                            makeElement(attachmentElement)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Apollo 688. Instead of including the `AttachmentsFormElement` in the list of feature form elements authored by an environment that doesn't support attachments, the SDK now uses the `defaultAttachmentElement` property.