### PR TITLE
Create protocol for allowing us to mock for testing and potentially previews

### DIFF
--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
@@ -35,7 +35,7 @@ public struct PreplannedListItemView: View {
     }
     
     @ViewBuilder private var thumbnailView: some View {
-        if let thumbnail = model.preplannedMapArea.portalItem.thumbnail {
+        if let thumbnail = model.preplannedMapArea.thumbnail {
             LoadableImageView(loadableImage: thumbnail)
                 .frame(width: 64, height: 44)
                 .clipShape(.rect(cornerRadius: 2))
@@ -43,7 +43,7 @@ public struct PreplannedListItemView: View {
     }
     
     @ViewBuilder private var titleView: some View {
-        Text(model.preplannedMapArea.portalItem.title)
+        Text(model.preplannedMapArea.title)
             .font(.body)
     }
     
@@ -58,8 +58,8 @@ public struct PreplannedListItemView: View {
     }
     
     @ViewBuilder private var descriptionView: some View {
-        if !model.preplannedMapArea.portalItem.description.isEmpty {
-            Text(model.preplannedMapArea.portalItem.description)
+        if !model.preplannedMapArea.description.isEmpty {
+            Text(model.preplannedMapArea.description)
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
@@ -98,4 +98,17 @@ public struct PreplannedListItemView: View {
         .font(.caption2)
         .foregroundStyle(.tertiary)
     }
+}
+
+#Preview {
+    PreplannedListItemView(model: PreplannedMapModel(preplannedMapArea: MockPreplanneddMapArea()))
+}
+
+private struct MockPreplanneddMapArea: PreplannedMapAreaProtocol {
+    var packagingStatus: ArcGIS.PreplannedMapArea.PackagingStatus? = .complete
+    var title: String = "Mock Preaplanned Map Area"
+    var description: String = "This is the description text"
+    var thumbnail: ArcGIS.LoadableImage? = nil
+    
+    func retryLoad() async throws { }
 }

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
@@ -101,7 +101,10 @@ public struct PreplannedListItemView: View {
 }
 
 #Preview {
-    PreplannedListItemView(model: PreplannedMapModel(preplannedMapArea: MockPreplanneddMapArea()))
+    PreplannedListItemView(
+        model: PreplannedMapModel(preplannedMapArea: MockPreplanneddMapArea())
+    )
+    .padding()
 }
 
 private struct MockPreplanneddMapArea: PreplannedMapAreaProtocol {

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
@@ -41,8 +41,8 @@ class PreplannedMapModel: ObservableObject, Identifiable {
             // legacy webmaps that have incomplete metadata.
             // If the area loads, then you know for certain the status is complete.
             updateStatus(for: preplannedMapArea.packagingStatus ?? .complete)
-        } catch is IllegalStateError {
-            // Load will throw an illegal state error if not complete,
+        } catch MappingError.packagingNotComplete {
+            // Load will throw an `MappingError.packagingNotComplete` error if not complete,
             // this case is not a normal load failure.
             updateStatus(for: preplannedMapArea.packagingStatus ?? .failed)
         } catch {

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
@@ -19,17 +19,12 @@ import ArcGIS
 @MainActor
 class PreplannedMapModel: ObservableObject, Identifiable {
     /// The preplanned map area.
-    let preplannedMapArea: PreplannedMapArea
-    
-    /// The result of the download job. When the result is `.success` the mobile map package is returned.
-    /// If the result is `.failure` then the error is returned. The result will be `nil` when the preplanned
-    /// map area is still packaging or loading.
-    @Published private(set) var result: Result<MobileMapPackage, Error>?
+    let preplannedMapArea: any PreplannedMapAreaProtocol
     
     /// The combined status of the preplanned map area.
     @Published private(set) var status: Status = .notLoaded
     
-    init(preplannedMapArea: PreplannedMapArea) {
+    init(preplannedMapArea: PreplannedMapAreaProtocol) {
         self.preplannedMapArea = preplannedMapArea
         
         // Kick off a load of the map area.
@@ -102,5 +97,30 @@ extension PreplannedMapModel {
         case downloaded
         /// Preplanned map area failed to download.
         case downloadFailure(Error)
+    }
+}
+
+/// A type that acts as a preplanned map area.
+protocol PreplannedMapAreaProtocol {
+    func retryLoad() async throws
+    
+    var packagingStatus: PreplannedMapArea.PackagingStatus? { get }
+    var title: String { get }
+    var description: String { get }
+    var thumbnail: LoadableImage? { get }
+}
+
+/// Extend `PreplannedMapArea` to conform to `PreplannedMapAreaProtocol`.
+extension PreplannedMapArea: PreplannedMapAreaProtocol {
+    var title: String {
+        portalItem.title
+    }
+    
+    var thumbnail: LoadableImage? {
+        portalItem.thumbnail
+    }
+    
+    var description: String {
+        portalItem.description
     }
 }


### PR DESCRIPTION
That will allow you to write mocks that you can use in integration or unit tests against the view model. For example, the view model can be seeded with different mocks that have different behavior for retryLoad and report different packagingStatus. And with that, you can verify that the resulting model status is what you expect.

We should be writing these tests as we go and not wait until the end.