### PR TITLE
Offline: Add unit tests for `PreplannedMapModel`

### DIFF
--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -1,0 +1,201 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import ArcGIS
+@testable import ArcGISToolkit
+
+private extension PreplannedMapAreaProtocol {
+    var packagingStatus: PreplannedMapArea.PackagingStatus? { nil }
+    var title: String { "Mock Preplanned Map Area" }
+    var description: String { "This is the description text" }
+    var thumbnail: ArcGIS.LoadableImage? { nil }
+}
+
+class PreplannedMapModelTests: XCTestCase {
+    private static var sleepNanoseconds: UInt64 { 100_000 }
+    
+    @MainActor
+    func testInitialStatus() {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            func retryLoad() async throws { }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        guard case .notLoaded = model.status else {
+            XCTFail("PreplannedMapModel initial status is not \".notLoaded\".")
+            return
+        }
+        
+        XCTAssertFalse(model.canDownload)
+    }
+    
+    @MainActor
+    func testLoadingStatus() async throws {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            func retryLoad() async throws {
+                // Delay `retryLoad` method to slow down the model's private async
+                // `load` method, so the model status stays at "loading".
+                try await Task.sleep(nanoseconds: 2 * PreplannedMapModelTests.sleepNanoseconds)
+            }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        try await Task.sleep(nanoseconds: PreplannedMapModelTests.sleepNanoseconds)
+        guard case .loading = model.status else {
+            XCTFail("PreplannedMapModel status is not \".loading\".")
+            return
+        }
+        
+        XCTAssertFalse(model.canDownload)
+    }
+    
+    @MainActor
+    func testNilPackagingStatus() async throws {
+        struct MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            func retryLoad() async throws { }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        
+        // Packaging status is `nil` for compatibility with legacy webmaps
+        // when they have packaged areas but have incomplete metadata.
+        // When the preplanned map area finishes loading, if its
+        // packaging status is `nil`, we consider it as completed.
+        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        guard case .packaged = model.status else {
+            XCTFail("PreplannedMapModel status is not \".packaged\".")
+            return
+        }
+        
+        // In this case, the areas can be downloaded.
+        XCTAssertTrue(model.canDownload)
+    }
+    
+    @MainActor
+    func testLoadFailureStatus() async throws {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            func retryLoad() async throws {
+                // Throws an error other than `MappingError.packagingNotComplete`
+                // to indicate the area fails to load in the first place.
+                throw MappingError.notLoaded(details: "")
+            }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        
+        guard case .loadFailure = model.status else {
+            XCTFail("PreplannedMapModel status is not \".loadFailure\".")
+            return
+        }
+        
+        XCTAssertFalse(model.canDownload)
+    }
+    
+    @MainActor
+    func testPackagingStatus() async throws {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            var packagingStatus: PreplannedMapArea.PackagingStatus? = nil
+            
+            func retryLoad() async throws {
+                packagingStatus = .processing
+            }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        
+        guard case .packaging = model.status else {
+            XCTFail("PreplannedMapModel status is not \".packaging\".")
+            return
+        }
+        
+        XCTAssertFalse(model.canDownload)
+    }
+    
+    @MainActor
+    func testPackagedStatus() async throws {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            var packagingStatus: PreplannedMapArea.PackagingStatus? = nil
+            
+            func retryLoad() async throws {
+                packagingStatus = .complete
+            }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        
+        guard case .packaged = model.status else {
+            XCTFail("PreplannedMapModel status is not \".packaged\".")
+            return
+        }
+        
+        XCTAssertTrue(model.canDownload)
+    }
+    
+    @MainActor
+    func testPackageFailureStatus() async throws {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            var packagingStatus: PreplannedMapArea.PackagingStatus? = nil
+            
+            func retryLoad() async throws {
+                // The webmap metadata indicates the area fails to package.
+                packagingStatus = .failed
+            }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        
+        guard case .packageFailure = model.status else {
+            XCTFail("PreplannedMapModel status is not \".packageFailure\".")
+            return
+        }
+        
+        XCTAssertFalse(model.canDownload)
+    }
+    
+    @MainActor
+    func testPackagingNotCompletePackageFailureStatus() async throws {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            var packagingStatus: PreplannedMapArea.PackagingStatus? = nil
+            
+            func retryLoad() async throws {
+                // Throws an error to indicate the area loaded successfully,
+                // but is still packaging.
+                throw MappingError.packagingNotComplete(details: "")
+            }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        
+        guard case .packageFailure = model.status else {
+            XCTFail("PreplannedMapModel status is not \".loadFailure\".")
+            return
+        }
+        
+        XCTAssertFalse(model.canDownload)
+    }
+}

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -24,7 +24,7 @@ private extension PreplannedMapAreaProtocol {
 }
 
 class PreplannedMapModelTests: XCTestCase {
-    private static var sleepNanoseconds: UInt64 { 100_000 }
+    private static var sleepNanoseconds: UInt64 { 1_000_000 }
     
     @MainActor
     func testInit() {

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -51,20 +51,22 @@ class PreplannedMapModelTests: XCTestCase {
         }
         
         XCTAssertFalse(model.canDownload)
+        XCTAssertTrue(model.status.needsToBeLoaded)
     }
     
     @MainActor
     func testLoadingStatus() async throws {
         class MockPreplannedMapArea: PreplannedMapAreaProtocol {
             func retryLoad() async throws {
-                // Delay `retryLoad` method to slow down the model's private async
-                // `load` method, so the model status stays at "loading".
+                // In `retryLoad` method, simulate a time-consuming `load` method,
+                // so the model status stays at "loading".
                 try await Task.sleep(nanoseconds: 2 * PreplannedMapModelTests.sleepNanoseconds)
             }
         }
         
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        Task { await model.load() }
         try await Task.sleep(nanoseconds: PreplannedMapModelTests.sleepNanoseconds)
         guard case .loading = model.status else {
             XCTFail("PreplannedMapModel status is not \".loading\".")
@@ -72,6 +74,7 @@ class PreplannedMapModelTests: XCTestCase {
         }
         
         XCTAssertFalse(model.canDownload)
+        XCTAssertFalse(model.status.needsToBeLoaded)
     }
     
     @MainActor
@@ -87,7 +90,7 @@ class PreplannedMapModelTests: XCTestCase {
         // when they have packaged areas but have incomplete metadata.
         // When the preplanned map area finishes loading, if its
         // packaging status is `nil`, we consider it as completed.
-        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        await model.load()
         guard case .packaged = model.status else {
             XCTFail("PreplannedMapModel status is not \".packaged\".")
             return
@@ -95,6 +98,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         // In this case, the areas can be downloaded.
         XCTAssertTrue(model.canDownload)
+        XCTAssertFalse(model.status.needsToBeLoaded)
     }
     
     @MainActor
@@ -109,7 +113,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel(preplannedMapArea: mockArea)
-        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        await model.load()
         
         guard case .loadFailure = model.status else {
             XCTFail("PreplannedMapModel status is not \".loadFailure\".")
@@ -117,6 +121,7 @@ class PreplannedMapModelTests: XCTestCase {
         }
         
         XCTAssertFalse(model.canDownload)
+        XCTAssertTrue(model.status.needsToBeLoaded)
     }
     
     @MainActor
@@ -131,7 +136,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel(preplannedMapArea: mockArea)
-        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        await model.load()
         
         guard case .packaging = model.status else {
             XCTFail("PreplannedMapModel status is not \".packaging\".")
@@ -139,6 +144,7 @@ class PreplannedMapModelTests: XCTestCase {
         }
         
         XCTAssertFalse(model.canDownload)
+        XCTAssertFalse(model.status.needsToBeLoaded)
     }
     
     @MainActor
@@ -153,7 +159,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel(preplannedMapArea: mockArea)
-        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        await model.load()
         
         guard case .packaged = model.status else {
             XCTFail("PreplannedMapModel status is not \".packaged\".")
@@ -161,6 +167,7 @@ class PreplannedMapModelTests: XCTestCase {
         }
         
         XCTAssertTrue(model.canDownload)
+        XCTAssertFalse(model.status.needsToBeLoaded)
     }
     
     @MainActor
@@ -176,7 +183,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel(preplannedMapArea: mockArea)
-        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        await model.load()
         
         guard case .packageFailure = model.status else {
             XCTFail("PreplannedMapModel status is not \".packageFailure\".")
@@ -184,6 +191,7 @@ class PreplannedMapModelTests: XCTestCase {
         }
         
         XCTAssertFalse(model.canDownload)
+        XCTAssertTrue(model.status.needsToBeLoaded)
     }
     
     @MainActor
@@ -200,7 +208,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel(preplannedMapArea: mockArea)
-        try await Task.sleep(nanoseconds: Self.sleepNanoseconds)
+        await model.load()
         
         guard case .packageFailure = model.status else {
             XCTFail("PreplannedMapModel status is not \".loadFailure\".")
@@ -208,5 +216,6 @@ class PreplannedMapModelTests: XCTestCase {
         }
         
         XCTAssertFalse(model.canDownload)
+        XCTAssertTrue(model.status.needsToBeLoaded)
     }
 }

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -27,6 +27,17 @@ class PreplannedMapModelTests: XCTestCase {
     private static var sleepNanoseconds: UInt64 { 100_000 }
     
     @MainActor
+    func testInit() {
+        class MockPreplannedMapArea: PreplannedMapAreaProtocol {
+            func retryLoad() async throws { }
+        }
+        
+        let mockArea = MockPreplannedMapArea()
+        let model = PreplannedMapModel(preplannedMapArea: mockArea)
+        XCTAssertIdentical(model.preplannedMapArea as? MockPreplannedMapArea, mockArea)
+    }
+    
+    @MainActor
     func testInitialStatus() {
         class MockPreplannedMapArea: PreplannedMapAreaProtocol {
             func retryLoad() async throws { }


### PR DESCRIPTION
See `swift/issues/5414`

This PR adds the unit tests for `PreplannedMapModel`.

Code coverage:

<img width="871" alt="image" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/9660181/960f0c91-0034-4930-a6c6-80cbb3b48b3c">

- Omitted unknown default
- Omitted the extended protocol strings for title, description, and thumbnail
- The download related states will be tested in a follow up PR