### PR TITLE
Guard expected failures in `CertificatePickerViewModelTests`

### DIFF
--- a/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
@@ -30,6 +30,12 @@ final class CertificatePickerViewModelTests: XCTestCase {
         
         model.proceedToPicker()
         
+#if swift(<5.10)
+        XCTExpectFailure(
+            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Swift 5.9. Ref Toolkit #699",
+            options: .nonStrict()
+        )
+#endif
         // Have to wait here because the proceed function is delayed to avoid a bug.
         await fulfillment(
             of: [
@@ -48,6 +54,12 @@ final class CertificatePickerViewModelTests: XCTestCase {
         
         model.proceedToUseCertificate(withPassword: "1234")
         
+#if swift(<5.10)
+        XCTExpectFailure(
+            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Swift 5.9. Ref Toolkit #699",
+            options: .nonStrict()
+        )
+#endif
         await fulfillment(
             of: [
                 expectation(

--- a/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
@@ -31,10 +31,6 @@ final class CertificatePickerViewModelTests: XCTestCase {
         model.proceedToPicker()
         
         // Have to wait here because the proceed function is delayed to avoid a bug.
-        XCTExpectFailure(
-            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0. Ref Toolkit #699",
-            options: .nonStrict()
-        )
         await fulfillment(
             of: [
                 expectation(
@@ -52,10 +48,6 @@ final class CertificatePickerViewModelTests: XCTestCase {
         
         model.proceedToUseCertificate(withPassword: "1234")
         
-        XCTExpectFailure(
-            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Xcode 15.0. Ref Toolkit #699",
-            options: .nonStrict()
-        )
         await fulfillment(
             of: [
                 expectation(


### PR DESCRIPTION
Related #699 

The test runner uses Xcode 15.4 / Swift 5.10 now.