### PR TITLE
Offline: Remove detached task from model and call `load()` in the view

### DIFF
--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/OfflineMapAreasView.swift
@@ -73,9 +73,6 @@ public struct OfflineMapAreasView: View {
             if mapViewModel.hasPreplannedMapAreas {
                 List(models) { preplannedMapModel in
                     PreplannedListItemView(model: preplannedMapModel)
-                        .task {
-                            await preplannedMapModel.load()
-                        }
                 }
             } else {
                 emptyPreplannedMapAreasView

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/OfflineMapAreasView.swift
@@ -73,6 +73,9 @@ public struct OfflineMapAreasView: View {
             if mapViewModel.hasPreplannedMapAreas {
                 List(models) { preplannedMapModel in
                     PreplannedListItemView(model: preplannedMapModel)
+                        .task {
+                            await preplannedMapModel.load()
+                        }
                 }
             } else {
                 emptyPreplannedMapAreasView
@@ -139,14 +142,6 @@ public extension OfflineMapAreasView {
             }
             if let models = try? preplannedMapModels!.get() {
                 hasPreplannedMapAreas = !models.isEmpty
-                // Kick off loading the map areas.
-                await withTaskGroup(of: Void.self) { group in
-                    for model in models {
-                        group.addTask {
-                            await model.load()
-                        }
-                    }
-                }
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/OfflineMapAreasView.swift
@@ -139,6 +139,14 @@ public extension OfflineMapAreasView {
             }
             if let models = try? preplannedMapModels!.get() {
                 hasPreplannedMapAreas = !models.isEmpty
+                // Kick off loading the map areas.
+                await withTaskGroup(of: Void.self) { group in
+                    for model in models {
+                        group.addTask {
+                            await model.load()
+                        }
+                    }
+                }
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
@@ -32,6 +32,9 @@ public struct PreplannedListItemView: View {
                 statusView
             }
         }
+        .task {
+            await model.load()
+        }
     }
     
     @ViewBuilder private var thumbnailView: some View {
@@ -100,13 +103,9 @@ public struct PreplannedListItemView: View {
 }
 
 #Preview {
-    let model = PreplannedMapModel(preplannedMapArea: MockPreplannedMapArea())
-    return PreplannedListItemView(
-        model: model
+    PreplannedListItemView(
+        model: PreplannedMapModel(preplannedMapArea: MockPreplannedMapArea())
     )
-    .task {
-        await model.load()
-    }
     .padding()
 }
 

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
@@ -101,10 +101,12 @@ public struct PreplannedListItemView: View {
 
 #Preview {
     let model = PreplannedMapModel(preplannedMapArea: MockPreplannedMapArea())
-    Task.detached { await model.load() }
     return PreplannedListItemView(
         model: model
     )
+    .task {
+        await model.load()
+    }
     .padding()
 }
 

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
@@ -101,13 +101,11 @@ public struct PreplannedListItemView: View {
 
 #Preview {
     let model = PreplannedMapModel(preplannedMapArea: MockPreplannedMapArea())
+    Task.detached { await model.load() }
     return PreplannedListItemView(
         model: model
     )
     .padding()
-    .task {
-        await model.load()
-    }
 }
 
 private struct MockPreplannedMapArea: PreplannedMapAreaProtocol {

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedListItemView.swift
@@ -100,10 +100,14 @@ public struct PreplannedListItemView: View {
 }
 
 #Preview {
-    PreplannedListItemView(
-        model: PreplannedMapModel(preplannedMapArea: MockPreplannedMapArea())
+    let model = PreplannedMapModel(preplannedMapArea: MockPreplannedMapArea())
+    return PreplannedListItemView(
+        model: model
     )
     .padding()
+    .task {
+        await model.load()
+    }
 }
 
 private struct MockPreplannedMapArea: PreplannedMapAreaProtocol {

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
@@ -30,8 +30,7 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     
     /// Loads the preplanned map area and updates the status.
     func load() async {
-        if case .packaged = status { return }
-        if case .downloaded = status { return }
+        guard status.needsToBeLoaded else { return }
         do {
             // Load preplanned map area to obtain packaging status.
             status = .loading
@@ -98,6 +97,17 @@ extension PreplannedMapModel {
         case downloaded
         /// Preplanned map area failed to download.
         case downloadFailure(Error)
+        
+        /// A Boolean value indicating whether the model is in a state
+        /// where it needs to be loaded or reloaded.
+        var needsToBeLoaded: Bool {
+            switch self {
+            case .loading, .packaging, .packaged, .downloading, .downloaded:
+                false
+            default:
+                true
+            }
+        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
@@ -30,7 +30,8 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     
     /// Loads the preplanned map area and updates the status.
     func load() async {
-        if case .packaged = status, case .downloaded = status { return }
+        if case .packaged = status { return }
+        if case .downloaded = status { return }
         do {
             // Load preplanned map area to obtain packaging status.
             status = .loading

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
@@ -30,6 +30,7 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     
     /// Loads the preplanned map area and updates the status.
     func load() async {
+        if case .packaged = status, case .downloaded = status { return }
         do {
             // Load preplanned map area to obtain packaging status.
             status = .loading

--- a/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/OfflineMapAreasView/PreplannedMapModel.swift
@@ -26,13 +26,10 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     
     init(preplannedMapArea: PreplannedMapAreaProtocol) {
         self.preplannedMapArea = preplannedMapArea
-        
-        // Kick off a load of the map area.
-        Task.detached { await self.load() }
     }
     
     /// Loads the preplanned map area and updates the status.
-    private func load() async {
+    func load() async {
         do {
             // Load preplanned map area to obtain packaging status.
             status = .loading


### PR DESCRIPTION
Instead of calling `Task.detached { await self.load() }` in the view model's initializer, call it in the task modifier so it is easier to unit test the method.