### PR TITLE
`FeatureFormView` - Use `finishEditing`

### DIFF
--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -294,7 +294,7 @@ class Model: ObservableObject {
     
     // MARK: Private methods
     
-    /// Apply edits to the service.
+    /// Applies edits to the service.
     private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -283,7 +283,7 @@ class Model: ObservableObject {
     /// Submit the changes made to the form.
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
         
         guard case let .validating(featureForm) = state else { return }
         await finishEditing(featureForm)
@@ -340,7 +340,7 @@ class Model: ObservableObject {
     }
     
     /// Checks the feature form for the presence of any validation errors.
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
         if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -325,7 +325,6 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            // Additionally, you could display the errors to the user using `resultErrors`.
             state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -375,3 +375,19 @@ private extension FeatureForm {
         feature.table?.layer as? FeatureLayer
     }
 }
+
+private extension Array where Element == FeatureEditResult {
+    /// Examines all feature edit results (and their inner attachment results) for any errors.
+    var errors: [Error] {
+        var errors = [Error]()
+        forEach { featureEditResult in
+            if let editResultError = featureEditResult.error { errors.append(editResultError) }
+            featureEditResult.attachmentResults.forEach { attachmentResult in
+                if let error = attachmentResult.error {
+                    errors.append(error)
+                }
+            }
+        }
+        return errors
+    }
+}

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -356,7 +356,7 @@ private extension FeatureForm {
 }
 
 private extension Array where Element == FeatureEditResult {
-    /// Examines all feature edit results (and their inner attachment results) for any errors.
+    ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
         compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -329,7 +329,7 @@ class Model: ObservableObject {
         }
     }
     
-    /// Commits changes to the features and its attachments to the database.
+    /// Commits feature edits to the local geodatabase.
     private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         do {

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -294,7 +294,7 @@ class Model: ObservableObject {
     
     // MARK: Private methods
     
-    /// Applies edits to the service.
+    /// Applies edits to the remote service.
     private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -359,15 +359,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     /// Examines all feature edit results (and their inner attachment results) for any errors.
     var errors: [Error] {
-        var errors = [Error]()
-        forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -125,7 +125,7 @@ struct FeatureFormExampleView: View {
                             Button("Submit") {
                                 validationErrorVisibility = .visible
                                 Task {
-                                    await model.submitChanges()
+                                    await model.submitEdits()
                                 }
                             }
                             .disabled(model.formControlsAreDisabled)
@@ -281,7 +281,7 @@ class Model: ObservableObject {
     }
     
     /// Submit the changes made to the form.
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -326,7 +326,7 @@ class Model: ObservableObject {
             state = .idle
         } else {
             // Additionally, you could display the errors to the user using `resultErrors`.
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     
@@ -336,7 +336,7 @@ class Model: ObservableObject {
         do {
             try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text(error.localizedDescription))
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
@@ -118,7 +118,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
@@ -116,7 +116,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
@@ -170,13 +170,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
@@ -161,24 +161,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
@@ -161,19 +161,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -207,5 +194,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -191,13 +191,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -137,7 +137,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -139,7 +139,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -182,19 +182,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -228,5 +215,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -148,8 +148,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -162,12 +166,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -176,7 +178,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -182,24 +182,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -153,7 +153,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -198,19 +198,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -244,5 +231,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -155,7 +155,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -207,13 +207,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -198,24 +198,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -164,8 +164,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -178,12 +182,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -192,7 +194,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -167,7 +167,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -178,8 +178,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -192,12 +196,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -206,7 +208,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -212,19 +212,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -258,5 +245,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -212,24 +212,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -221,13 +221,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -169,7 +169,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -218,24 +218,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -218,19 +218,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -264,5 +251,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -227,13 +227,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -173,7 +173,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -175,7 +175,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -184,8 +184,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -198,12 +202,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -212,7 +214,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -199,7 +199,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -208,8 +208,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -222,12 +226,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -236,7 +238,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -251,13 +251,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -242,19 +242,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -288,5 +275,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -197,7 +197,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -242,24 +242,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -260,13 +260,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -251,24 +251,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -83,7 +83,7 @@ struct FeatureFormExampleView: View {
                                 Button("Submit") {
                                     validationErrorVisibility = .visible
                                     Task {
-                                        await model.submitChanges()
+                                        await model.submitEdits()
                                     }
                                 }
                                 .disabled(model.formControlsAreDisabled)
@@ -206,7 +206,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -217,8 +217,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -231,12 +235,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -245,7 +247,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -208,7 +208,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -251,19 +251,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -297,5 +284,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -259,24 +259,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -91,7 +91,7 @@ struct FeatureFormExampleView: View {
                                 Button("Submit") {
                                     validationErrorVisibility = .visible
                                     Task {
-                                        await model.submitChanges()
+                                        await model.submitEdits()
                                     }
                                 }
                                 .disabled(model.formControlsAreDisabled)
@@ -214,7 +214,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -259,19 +259,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -305,5 +292,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -268,13 +268,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -216,7 +216,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -225,8 +225,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -239,12 +243,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -253,7 +255,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -274,19 +274,6 @@ class Model: ObservableObject {
         }
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -320,5 +307,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -231,7 +231,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -283,13 +283,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -274,24 +274,13 @@ class Model: ObservableObject {
         }
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -240,8 +240,12 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func applyEdits(_ featureForm: FeatureForm, _ table: ServiceFeatureTable) async {
+    private func applyEdits(_ featureForm: FeatureForm) async {
         state = .applyingEdits(featureForm)
+        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
+            state = .generalError(featureForm, Text("Error resolving feature table."))
+            return
+        }
         guard let database = table.serviceGeodatabase else {
             state = .generalError(featureForm, Text("No geodatabase found."))
             return
@@ -254,12 +258,10 @@ class Model: ObservableObject {
         do {
             if let serviceInfo = database.serviceInfo, serviceInfo.canUseServiceGeodatabaseApplyEdits {
                 let featureTableEditResults = try await database.applyEdits()
-                resultErrors = featureTableEditResults.flatMap { featureTableEditResult in
-                    checkFeatureEditResults(featureForm, featureTableEditResult.editResults)
-                }
+                resultErrors = featureTableEditResults.flatMap { $0.editResults.errors }
             } else {
                 let featureEditResults = try await table.applyEdits()
-                resultErrors = checkFeatureEditResults(featureForm, featureEditResults)
+                resultErrors = featureEditResults.errors
             }
         } catch {
             state = .generalError(featureForm, Text("The changes could not be applied to the database or table.\n\n\(error.localizedDescription)"))
@@ -268,7 +270,7 @@ class Model: ObservableObject {
         if resultErrors.isEmpty {
             state = .idle
         } else {
-            state = .generalError(featureForm, Text("Changes were not applied."))
+            state = .generalError(featureForm, Text("Apply edits failed with ^[\(resultErrors.count) error](inflect: true)."))
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -106,7 +106,7 @@ struct FeatureFormExampleView: View {
                                 Button("Submit") {
                                     validationErrorVisibility = .visible
                                     Task {
-                                        await model.submitChanges()
+                                        await model.submitEdits()
                                     }
                                 }
                                 .disabled(model.formControlsAreDisabled)
@@ -229,7 +229,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep6.swift
@@ -116,7 +116,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep6.swift
@@ -118,7 +118,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
@@ -116,7 +116,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
@@ -127,13 +127,11 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
@@ -118,7 +118,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
@@ -136,13 +136,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
@@ -127,24 +127,13 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
@@ -116,7 +116,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
@@ -118,7 +118,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func finishEdits(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
@@ -136,13 +136,11 @@ class Model: ObservableObject {
         }
     }
     
-    private func validateChanges(_ featureForm: FeatureForm) async {
+    private func validateChanges(_ featureForm: FeatureForm) {
         state = .validating(featureForm)
-        guard featureForm.validationErrors.isEmpty else {
+        if !featureForm.validationErrors.isEmpty {
             state = .generalError(featureForm, Text("The form has ^[\(featureForm.validationErrors.count) validation error](inflect: true)."))
-            return
         }
-        await finishEdits(featureForm)
     }
 }
 

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
@@ -127,24 +127,13 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func finishEdits(_ featureForm: FeatureForm) async {
+    private func finishEditing(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
-        guard let table = featureForm.feature.table as? ServiceFeatureTable else {
-            state = .generalError(featureForm, Text("Error resolving feature table."))
-            return
-        }
-        guard table.isEditable else {
-            state = .generalError(featureForm, Text("The feature table isn't editable."))
-            return
-        }
         do {
-            state = .finishingEdits(featureForm)
-            try await table.update(featureForm.feature)
+            try await featureForm.finishEditing()
         } catch {
-            state = .generalError(featureForm, Text("The feature update failed."))
-            return
+            state = .generalError(featureForm, Text("Finish editing failed.\n\n\(error.localizedDescription)"))
         }
-        await applyEdits(featureForm, table)
     }
     
     private func validateChanges(_ featureForm: FeatureForm) async {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
@@ -118,7 +118,13 @@ class Model: ObservableObject {
     
     func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
-        await validateChanges(featureForm)
+        validateChanges(featureForm)
+        
+        guard case let .validating(featureForm) = state else { return }
+        await finishEditing(featureForm)
+        
+        guard case let .finishingEdits(featureForm) = state else { return }
+        await applyEdits(featureForm)
     }
     
     private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
@@ -116,7 +116,7 @@ class Model: ObservableObject {
         state = .idle
     }
     
-    func submitChanges() async {
+    func submitEdits() async {
         guard case let .editing(featureForm) = state else { return }
         await validateChanges(featureForm)
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
@@ -127,19 +127,6 @@ class Model: ObservableObject {
         await applyEdits(featureForm)
     }
     
-    private func checkFeatureEditResults(_ featureForm: FeatureForm, _ featureEditResults: [FeatureEditResult]) -> [Error] {
-        var errors = [Error]()
-        featureEditResults.forEach { featureEditResult in
-            if let editResultError = featureEditResult.error { errors.append(editResultError) }
-            featureEditResult.attachmentResults.forEach { attachmentResult in
-                if let error = attachmentResult.error {
-                    errors.append(error)
-                }
-            }
-        }
-        return errors
-    }
-    
     private func finishEdits(_ featureForm: FeatureForm) async {
         state = .finishingEdits(featureForm)
         guard let table = featureForm.feature.table as? ServiceFeatureTable else {
@@ -173,5 +160,12 @@ class Model: ObservableObject {
 private extension FeatureForm {
     var featureLayer: FeatureLayer? {
         feature.table?.layer as? FeatureLayer
+    }
+}
+
+private extension Array where Element == FeatureEditResult {
+    ///  Any errors from the edit results and their inner attachment results.
+    var errors: [Error] {
+        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FeatureFormViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FeatureFormViewTutorial.tutorial
@@ -27,7 +27,7 @@
             }
             
             @Step {
-                Add a `featureLayer` property to the `FeatureForm`.
+                Extend `FeatureForm` with a `featureLayer` property.
                 
                 This small extension will help in multiple places in the upcoming steps.
                 @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep3)
@@ -48,7 +48,7 @@
             }
             
             @Step {
-                Add a `discardEdits` and `submitChanges` method to the model.
+                Add a `discardEdits` and `submitEdits` method to the model.
                 
                 These methods will be used in buttons added later to the view.
                 @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep6)
@@ -62,21 +62,21 @@
             }
             
             @Step {
-                After checking for validation errors, update the table with the edited feature.
+                After checking for validation errors, finish editing the feature form.
                 @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep8)
             }
             
             @Step {
                 When edits are applied to the database, some errors may be returned.
                 
-                Add a method `checkFeatureEditResults` to iterate through feature edit results, checking for the existence of any errors.
+                Extend arrays containing `FeatureEditResult`s with an `errors` property to check for the existence of any errors.
                 @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep9)
             }
             
             @Step {
                 After the table has been updated, apply edits to the database.
                 
-                Use the method `checkFeatureEditResults` from the previous step to check for errors.
+                Use the `errors` property from the previous step to collect any errors.
                 @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep10)
             }
             
@@ -118,7 +118,7 @@
             @Step {
                 Add a second button ("Submit") to the toolbar. 
                 
-                When this button is pressed, set `validationErrorVisibility` to ``FeatureFormView/ValidationErrorVisibility/visible``. This will cause any fields that never received focus but are considered invalid to show errors. This button should also call `submitChanges` on the model.
+                When this button is pressed, set `validationErrorVisibility` to ``FeatureFormView/ValidationErrorVisibility/visible``. This will cause any fields that never received focus but are considered invalid to show errors. This button should also call `submitEdits` on the model.
                 @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep16)
             }
             


### PR DESCRIPTION
Related Apollo 703

1. `submitChanges()` -> `submitEdits()` to balance with `discardEdits()`
1. `finishEdits()` -> `finishEditing()` to match the function it wraps (`FeatureForm.finishEditing()`)
1. `checkFeatureEditResults()` -> `[FeatureEditResult].errors`
1. `submitEdits()` coordinates the full workflow now (as opposed to the chain pattern of submit calling validation, validation calling finish, finish calling apply)
