### PR TITLE
`FeatureFormView` - Disable attachment name auto correction

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -107,6 +107,7 @@ struct AttachmentPreview: View {
                     comment: "A label in reference to the new name of a file, shown in a file rename interface."
                 )
             }
+            .autocorrectionDisabled()
             Button("Cancel", role: .cancel) { }
             Button("OK") {
                 Task {


### PR DESCRIPTION
Autocorrection can make renaming difficult if the user is following a unique naming pattern