### PR TITLE
Fix tutorial step code highlighting

### DIFF
--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/AuthenticatorTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/AuthenticatorTutorial.tutorial
@@ -15,23 +15,23 @@
                 Declare and initialize an `Authenticator` member in your app.
                 
                 For OAuth implementations use `Authenticator(oAuthUserConfigurations:)`.
-                @Code(name: "ExampleApp.swift", file: AuthenticatorStep1)
+                @Code(name: "ExampleApp.swift", file: AuthenticatorStep1.swift)
             }
             
             @Step {
                 Declare the app's body, placing the `Authenticator` into the hierarchy.
-                @Code(name: "ExampleApp.swift", file: AuthenticatorStep2)
+                @Code(name: "ExampleApp.swift", file: AuthenticatorStep2.swift)
             }
             
             @Step {
                 Set the `Authenticator` to handle challenges.
                 Set up credential persistence.
-                @Code(name: "ExampleApp.swift", file: AuthenticatorStep3)
+                @Code(name: "ExampleApp.swift", file: AuthenticatorStep3.swift)
             }
             
             @Step {
                 During sign-out, use these `AuthenticationManager` methods.
-                @Code(name: "SignOutView.swift", file: AuthenticatorStep4)
+                @Code(name: "SignOutView.swift", file: AuthenticatorStep4.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/BasemapGalleryTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/BasemapGalleryTutorial.tutorial
@@ -16,27 +16,27 @@
                 Initialize a map with a basemap style and an initial viewpoint. 
                 Create a member variable to control when the gallery is shown or hidden.
                 Finally, add a `MapView` to the body of view, passing in the map.
-                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep1)
+                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep1.swift)
             }
             
             @Step {
                 Create a list of items to be shown in the gallery.
-                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep2)
+                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep2.swift)
             }
             
             @Step {
                 Host the BasemapGallery on top of the `MapView` in a sheet, passing in the list of basemap gallery items and the map.
-                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep3)
+                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep3.swift)
             }
             
             @Step {
                 Place a button in the navigation bar to open the gallery.
-                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep4)
+                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep4.swift)
             }
             
             @Step {
                 Place a done button in the sheet to close the gallery.
-                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep5)
+                @Code(name: "BasemapGalleryExampleView.swift", file: BasemapGalleryStep5.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/BookmarksTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/BookmarksTutorial.tutorial
@@ -16,28 +16,28 @@
                 Initialize a map that contains preset bookmarks.
                 Add a `MapView` to the body of the view, passing in the map.
                 Wrap the `MapView` in a `MapViewReader` to obtain a `MapViewProxy`.
-                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep1)
+                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep1.swift)
             }
             
             @Step {
                 Add a button within a toolbar to present the `Bookmarks` component.
                 
                 The property `bookmarksIsPresented` will control when the `Bookmarks` component is shown or hidden.
-                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep2)
+                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep2.swift)
             }
             
             @Step {
                 Host the `Bookmarks` component inside of a popover.
                 
                 Create a new property named `selection` to hold the selected bookmark.
-                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep3)
+                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep3.swift)
             }
             
             @Step {
                 Enable automatic pan and zoom to the selected bookmark.
                 
                 Pass the `MapViewProxy` from Step 1 into the `Bookmarks` initializer.
-                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep4)
+                @Code(name: "BookmarksExampleView.swift", file: BookmarksStep4.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/CompassTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/CompassTutorial.tutorial
@@ -12,17 +12,17 @@
         @Steps {
             @Step {
                 Create a new view with a `MapViewReader` and `MapView`.
-                @Code(name: "CompassExampleView.swift", file: CompassStep1)
+                @Code(name: "CompassExampleView.swift", file: CompassStep1.swift)
             }
             
             @Step {
                 Add a property to track viewpoint changes with `.onViewpointChanged(kind:)`
-                @Code(name: "CompassExampleView.swift", file: CompassStep2)
+                @Code(name: "CompassExampleView.swift", file: CompassStep2.swift)
             }
             
             @Step {
                 Add an overlay to the `MapView` with `Compass` as the content.
-                @Code(name: "CompassExampleView.swift", file: CompassStep3) {
+                @Code(name: "CompassExampleView.swift", file: CompassStep3.swift) {
                     @Image(
                         source: CompassComplete, 
                         alt: "An image of the compass component overlaid on a map view."
@@ -32,12 +32,12 @@
             
             @Step {
                 Optionally specify a size and padding.
-                @Code(name: "CompassExampleView.swift", file: CompassStep4)
+                @Code(name: "CompassExampleView.swift", file: CompassStep4.swift)
             }
             
             @Step {
                 Optionally prevent the compass from hiding.
-                @Code(name: "CompassExampleView.swift", file: CompassStep5)
+                @Code(name: "CompassExampleView.swift", file: CompassStep5.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FeatureFormViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FeatureFormViewTutorial.tutorial
@@ -14,39 +14,39 @@
         @Steps {
             @Step {
                 Initialize data containing feature forms.
-                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep1)
+                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep1.swift)
             }
             
             @Step {
                 Track important information like the last selected screen point and the current
                 `Feature`.
-                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep2)
+                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep2.swift)
             }
             
             @Step {
                 Add the `MapView` with the `FeatureForm` data.
-                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep3)
+                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep3.swift)
             }
             
             @Step {
                 Track any tap gestures on the `MapView`.
-                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep4)
+                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep4.swift)
             }
             
             @Step {
                 Perform an identify operation whenever the map is tapped and grab the `FeatureForm` data
                 if present.
-                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep5)
+                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep5.swift)
             }
             
             @Step {
                 Show the `FeatureFormView` in a `FloatingPanel`.
-                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep6)
+                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep6.swift)
             }
             
             @Step {
                 Add the ability to submit or cancel edits made with the `FeatureForm`.
-                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep7)
+                @Code(name: "FeatureFormExampleView.swift", file: FeatureFormViewStep7.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FloatingPanelTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FloatingPanelTutorial.tutorial
@@ -14,24 +14,24 @@
                 To begin, set up the parent view.
                 A floating panel can host content over a `MapView`, `SceneView`, or some other view.
                 Add a simple gradient to the body of the view.
-                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep1)
+                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep1.swift)
             }
             
             @Step {
                 Add a `FloatingPanelDetent` property to control the height of the panel. 
                 In this case we will use a named value (`.half`), but a custom value can also be used.
                 Add a Boolean property to control when the panel is shown or hidden.
-                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep2)
+                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep2.swift)
             }
             
             @Step {
                 Add the Floating Panel into the hierarchy, passing in values for `selectedDetent` and `isPresented`.
-                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep3)
+                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep3.swift)
             }
             
             @Step {
                 Add the desired content to the body of the Floating Panel.
-                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep4)
+                @Code(name: "FloatingPanelExampleView.swift", file: FloatingPanelStep4.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FloorFilterTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FloorFilterTutorial.tutorial
@@ -15,28 +15,28 @@
                 To begin, set up the parent view.
                 Add a map with floor aware data, a property to track the current viewpoint and place
                 a `MapView` into the body using these properties.
-                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep1)
+                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep1.swift)
             }
             
             @Step {
                 Add an alignment property so that the Floor Filter can properly display its internal views.
-                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep2)
+                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep2.swift)
             }
             
             @Step {
                 Add logic to load the map and handle any resulting errors when the view loads.
-                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep3)
+                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep3.swift)
             }
             
             @Step {
                 Track when the user is navigating the map with `.onNavigatingChanged` and also keep
                 track of the latest viewpoint with `onViewpointChanged`.
-                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep4)
+                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep4.swift)
             }
             
             @Step {
                 Overlay the map with the Floor Filter, optionally adding UI to handle any loading errors.
-                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep5)
+                @Code(name: "FloorFilterExampleView.swift", file: FloorFilterStep5.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FlyoverSceneViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/FlyoverSceneViewTutorial.tutorial
@@ -14,14 +14,14 @@
                 Initialize a `FlyoverSceneView`. Specify the initial latitude, longitude, and altitude 
                 of the scene view's camera and the translation factor. The translation factor determines
                 how many meters the scene view translates as the device moves in the AR experience.
-                @Code(name: "FlyoverExampleView.swift", file: FlyoverSceneViewStep1)
+                @Code(name: "FlyoverExampleView.swift", file: FlyoverSceneViewStep1.swift)
             }
             
             @Step {
                 Add a `SceneView` to the `FlyoverSceneView` closure. The closure builds and overlays 
                 the scene view on top of the augmented reality video feed. Specify the `scene` state 
                 variable.
-                @Code(name: "FlyoverExampleView.swift", file: FlyoverSceneViewStep2)
+                @Code(name: "FlyoverExampleView.swift", file: FlyoverSceneViewStep2.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/JobManagerTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/JobManagerTutorial.tutorial
@@ -17,7 +17,7 @@
                 
                 Begin by adding a JobManager property as an observed object. Add state properties for `job`, `error`, and a boolean that you'll use to show progress when adding a job. Start the UI by adding a button to take a map offline and a progress indicator to show that the job is being added. This will be the UI before a job has been added (`job == nil`).
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep1) {
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep1.swift) {
                     @Image(source: JobManagerTakeMapOfflineButton, alt: "An Image of an iPhone app with a Take Map Offline button.")
                 }
             }
@@ -27,7 +27,7 @@
                 
                 The function makes a map from a URL, then uses a task to make the generate offline map job.
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep2, previousFile: JobManagerViewStep1)
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep2.swift, previousFile: JobManagerViewStep1.swift)
             }
             
             @Step {
@@ -35,7 +35,7 @@
                 
                 To begin, add a state variable for the job status. Just after the check to see if we have a job, add a progress view that will show the progress of the job. Next, add a button to remove the job from the job manager and start over; give it the title "Start New Job". Last add a task to keep track of the job status in the status state variable.
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep3, previousFile: JobManagerViewStep2) {
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep3.swift, previousFile: JobManagerViewStep2.swift) {
                     @Image(source: JobManagerTutorial, alt: "An Image of an iPhone app with a progress bar and Start New Job button.")
                 }
             }
@@ -69,7 +69,7 @@
                 
                 Once an API key has been added the project can be built and run. Tap the "Take Map Offline" button to add the job to the job manager and start the job. The offline map will be generated and downloaded. As long as the tutorial app is running in the foreground the job will finish and we'll get the mobile map package. However, we know that people don't use their devices like that. What we want is for people to be able to start a job, do other things on their device while the job runs and get a notification when the job finishes. In the next steps you will add the code to handle the app being backgrounded or terminated.
                 
-                @Code(name: "JobManagerTutorialApp.swift", file: JobManagerAppStep1)
+                @Code(name: "JobManagerTutorialApp.swift", file: JobManagerAppStep1.swift)
             }
             
             @Step {
@@ -93,7 +93,7 @@
                 
                 Add an init to JobManagerTutorialView. In the init, use `preferredBackgroundStatusCheckSchedule` on the job manager to set the job manager to request to be woken up every 30 seconds. This setting along with the two project settings complete the set up necessary for the job manager to check the status of jobs when the app is backgrounded.
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep4, previousFile: JobManagerViewStep3)
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep4.swift, previousFile: JobManagerViewStep3.swift)
             }
             
             @Step {
@@ -101,7 +101,7 @@
                 
                 Add a backgroundTask that responds to the URLSession that gets set up by the SDK in the ArcGISEnvironment. This is the task that will run if the URL session completes a download after the app has been terminated. In the background task, handle the background URL session events. Also, resume any jobs that have been paused; this will also recreate any URL sessions that finished while the app was in the background. Note: background operation only works on a device not connected to the debugger.
                 
-                @Code(name: "JobManagerTutorialApp.swift", file: JobManagerAppStep2, previousFile: JobManagerAppStep1)
+                @Code(name: "JobManagerTutorialApp.swift", file: JobManagerAppStep2.swift, previousFile: JobManagerAppStep1.swift)
             }
             
             @Step {
@@ -109,13 +109,13 @@
                 
                 At the end of the `body` property, add an `onAppear` modifier and in the closure request authorization to send the user notifications.
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep5, previousFile: JobManagerViewStep4)
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep5.swift, previousFile: JobManagerViewStep4.swift)
             }
             
             @Step {
                 After the `body` property add a method to construct and send a notification.
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep6, previousFile: JobManagerViewStep5)
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep6.swift, previousFile: JobManagerViewStep5.swift)
             }
             
             @Step {
@@ -123,7 +123,7 @@
                 
                 Find the task in the body property that is awaiting changes to the job status. Add the code to call `notifyJobCompleted` when the job status becomes `failed` or `succeeded`.
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep7, previousFile: JobManagerViewStep6)
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep7.swift, previousFile: JobManagerViewStep6.swift)
             }
             
             @Step {
@@ -131,7 +131,7 @@
                 
                 Add code in `onAppear` to populate the job property.
                 
-                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep8, previousFile: JobManagerViewStep7)
+                @Code(name: "JobManagerTutorialView.swift", file: JobManagerViewStep8.swift, previousFile: JobManagerViewStep7.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/OverviewMapTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/OverviewMapTutorial.tutorial
@@ -15,17 +15,17 @@
             @Step {
                 To begin, set up the parent view.
                 Initialize a map and pass it to a `MapView` in the view's body.
-                @Code(name: "OverviewMapForMapView.swift", file: OverviewMapForMapStep1)
+                @Code(name: "OverviewMapForMapView.swift", file: OverviewMapForMapStep1.swift)
             }
             
             @Step {
                 When using an overview map with a map we need to track the current viewpoint and visible area.
-                @Code(name: "OverviewMapForMapView.swift", file: OverviewMapForMapStep2)
+                @Code(name: "OverviewMapForMapView.swift", file: OverviewMapForMapStep2.swift)
             }
             
             @Step {
                 Overlay the `OverviewMap` using ``OverviewMap/forMapView(with:visibleArea:map:)``.
-                @Code(name: "OverviewMapForMapView.swift", file: OverviewMapForMapStep3)
+                @Code(name: "OverviewMapForMapView.swift", file: OverviewMapForMapStep3.swift)
             }
         }
     }
@@ -39,17 +39,17 @@
             @Step {
                 To begin, set up the parent view.
                 Initialize a scene and pass it to a `SceneView` in the view's body.
-                @Code(name: "OverviewMapForSceneView.swift", file: OverviewMapForSceneStep1)
+                @Code(name: "OverviewMapForSceneView.swift", file: OverviewMapForSceneStep1.swift)
             }
             
             @Step {
                 When using an overview map with a scene we need to track the current viewpoint.
-                @Code(name: "OverviewMapForSceneView.swift", file: OverviewMapForSceneStep2)
+                @Code(name: "OverviewMapForSceneView.swift", file: OverviewMapForSceneStep2.swift)
             }
             
             @Step {
                 Overlay the `OverviewMap` using ``OverviewMap/forSceneView(with:map:)``.
-                @Code(name: "OverviewMapForSceneView.swift", file: OverviewMapForSceneStep3)
+                @Code(name: "OverviewMapForSceneView.swift", file: OverviewMapForSceneStep3.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/PopupViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/PopupViewTutorial.tutorial
@@ -13,34 +13,34 @@
         @Steps {
             @Step {
                 Initialize data containing popups.
-                @Code(name: "PopupExampleView.swift", file: PopupViewStep1)
+                @Code(name: "PopupExampleView.swift", file: PopupViewStep1.swift)
             }
             
             @Step {
                 Track important information like the last selected screen point and the current
                 `Popup`.
-                @Code(name: "PopupExampleView.swift", file: PopupViewStep2)
+                @Code(name: "PopupExampleView.swift", file: PopupViewStep2.swift)
             }
             
             @Step {
                 Add the `MapView` with the `Popup` data.
-                @Code(name: "PopupExampleView.swift", file: PopupViewStep3)
+                @Code(name: "PopupExampleView.swift", file: PopupViewStep3.swift)
             }
             
             @Step {
                 Track any tap gestures on the `MapView`.
-                @Code(name: "PopupExampleView.swift", file: PopupViewStep4)
+                @Code(name: "PopupExampleView.swift", file: PopupViewStep4.swift)
             }
             
             @Step {
                 Perform an identify operation whenever the map is tapped and grab the `Popup` data
                 if present.
-                @Code(name: "PopupExampleView.swift", file: PopupViewStep5)
+                @Code(name: "PopupExampleView.swift", file: PopupViewStep5.swift)
             }
             
             @Step {
                 Show the `PopupView` in a `FloatingPanel`.
-                @Code(name: "PopupExampleView.swift", file: PopupViewStep6)
+                @Code(name: "PopupExampleView.swift", file: PopupViewStep6.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/ScalebarTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/ScalebarTutorial.tutorial
@@ -15,23 +15,23 @@
             @Step {
                 To begin, set up the parent view.
                 Initialize a map property and pass it to a `MapView` in the view's body.
-                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep1)
+                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep1.swift)
             }
             
             @Step {
                 The Scalebar needs three pieces of information to determine scale: a spatial reference, the number of units per point, and the viewpoint. Set these values and track their changes with their respective modifiers.
-                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep2)
+                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep2.swift)
             }
             
             @Step {
                 Choose an alignment for the Scalebar, such as `bottomLeading`, and determine
                 the maximum amount of screen width the Scalebar should consume.
-                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep3)
+                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep3.swift)
             }
             
             @Step {
                 Overlay the `Scalebar` on the `MapView`, passing in all of the previously created properties.
-                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep4)
+                @Code(name: "ScalebarExampleView.swift", file: ScalebarStep4.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/SearchViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/SearchViewTutorial.tutorial
@@ -16,43 +16,43 @@
                 
                 Also create a map viewpoint used by the `SearchView` to pan/zoom the map to the 
                 extent of the search results.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep1)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep1.swift)
             }
             
             @Step {
                 Provide a search source which also allows search behavior customization.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep2)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep2.swift)
             }
             
             @Step {
                 Add a `GraphicsOverlay` to display search results on the map.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep3)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep3.swift)
             }
             
             @Step {
                 Add a property to detect when the viewpoint is changing. This will help to implement
                 repeat search behavior.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep4)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep4.swift)
             }
             
             @Step {
                 Add properties to track the extent and center of the visible region.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep5)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep5.swift)
             }
             
             @Step {
                 Add a `MapView` and overlay the `SearchView`.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep6)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep6.swift)
             }
             
             @Step {
                 Add additional modifiers, further interconnecting the `SearchView` and `MapView`.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep7)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep7.swift)
             }
             
             @Step {
                 Use `MapView` modifiers to track stateful information important to the `SearchView`.
-                @Code(name: "SearchExampleView.swift", file: SearchViewStep8)
+                @Code(name: "SearchExampleView.swift", file: SearchViewStep8.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/TableTopSceneViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/TableTopSceneViewTutorial.tutorial
@@ -18,19 +18,19 @@
                 physical surface. The translation factor determines how many meters the scene view
                 translates as the device moves in the AR experience. The clipping distance is the 
                 distance in meters that the ArcGIS Scene data will be clipped to.
-                @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep1)
+                @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep1.swift)
             }
             
             @Step {
                 Add a `SceneView` to the `TableTopSceneView` closure. The closure builds and overlays 
                 the scene view on top of the augmented reality video feed. Specify the `scene` state 
                 variable.
-                @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep2)
+                @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep2.swift)
             }
             
             @Step {
                 Set the `scene.baseSurface.opacity` to zero to make the basemap transparent.
-                @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep3)
+                @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep3.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/UtilityNetworkTraceTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/UtilityNetworkTraceTutorial.tutorial
@@ -15,28 +15,28 @@
                 required. A `Point` and `CGPoint` will help allow the component to create trace
                 starting points at tap locations. A `GraphicsOverlay` will allow the component to
                 visually display trace results.
-                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep1)
+                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep1.swift)
             }
             
             @Step {
                 Add a `MapView`, optionally setting credentials if needed within a task.
-                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep2)
+                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep2.swift)
             }
             
             @Step {
                 Track viewpoint changes.
-                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep3)
+                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep3.swift)
             }
             
             @Step {
                 Track any tap gestures on the map view. When the user is adding starting points,
                 the trace tool needs to know the tap locations to detect the desired network element.
-                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep4)
+                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep4.swift)
             }
             
             @Step {
                 Overlay the `UtilityNetworkTrace` on the `MapView` with a `FloatingPanel`.
-                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep5)
+                @Code(name: "UtilityNetworkTraceExampleView.swift", file: UtilityNetworkTraceStep5.swift)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/WorldScaleSceneViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/WorldScaleSceneViewTutorial.tutorial
@@ -17,19 +17,19 @@
                 The tracking mode determines the type of tracking configuration that will be used by the AR view. 
                 The `worldTracking` mode uses the `ARWorldTrackingConfiguration` and the `geoTracking` mode uses the `ARGeoTrackingConfiguration`. The `preferGeoTracking` mode uses the `ARGeoTrackingConfiguration` if 
                 geo tracking is available, otherwise, `ARWorldTrackingConfiguration` is used.
-                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep1)
+                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep1.swift)
             }
             
             @Step {
                 Add a `SceneView` to the `WorldScaleSceneView` closure. The closure builds and overlays 
                 the scene view on top of the augmented reality video feed. Specify the `scene` state 
                 variable.
-                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep2)
+                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep2.swift)
             }
             
             @Step {
                 Set the `scene.baseSurface.opacity` to zero to make the basemap transparent.
-                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep3)
+                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep3.swift)
             }
             
             @Step {
@@ -39,23 +39,23 @@
                 in order to display a ring around the initial location. The current location is also
                 necessary because the `WorldScaleSceneView` utilizes a location datasource that
                 will not start until authorized.
-                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep4)
+                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep4.swift)
             }
             
             @Step {
                 Start the location datasource and get the initial location.
-                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep5)
+                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep5.swift)
             }
             
             @Step {
                 To display a ring around the initial location, create a graphic using the 
                 initial location and add it to the graphics overlay.
-                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep6)
+                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep6.swift)
             }
             
             @Step {
                 Stop the location datasource after the initial location is retrieved.
-                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep7)
+                @Code(name: "TableTopExampleView.swift", file: WorldScaleSceneViewStep7.swift)
             }
         }
     }


### PR DESCRIPTION
A while back, @pgruenler noticed that our tutorials didn't have highlighted code steps anymore.

I've tracked this down to us missing the `.swift` file extension as the cause. I think the requirement must've been added silently because I recall highlighting previously working okay.