### PR TITLE
Small tweaks for new, final, FF Attachments API.

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -102,12 +102,9 @@ struct AttachmentImportMenu: View {
                 .progressViewStyle(.circular)
         }
         Menu {
-            if element.input is AnyAttachmentsFormInput {
-                // Show photo/video and library picker if
-                // we're allowing all input types.
-                takePhotoOrVideoButton()
-                chooseFromLibraryButton()
-            }
+            // Show photo/video and library picker.
+            takePhotoOrVideoButton()
+            chooseFromLibraryButton()
             // Always show file picker, no matter the input type.
             chooseFromFilesButton()
         } label: {

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
@@ -30,9 +30,6 @@ public enum FeatureAttachmentKind {
 }
 
 public protocol FeatureAttachment: Loadable {
-    /// The underlying `Attachment`.
-    var attachment: Attachment? { get }
-    
     /// The MIME content type of the attachment.
     var contentType: String { get }
     


### PR DESCRIPTION
Build fixes for consuming the final FF Attachments API.

- `AnyAttachmentsFormInput` is now internal.
- The `FormAttachment.attachment` property is now non-nullable, which differs from `PopupAttachment.attachment`. However, the `FeatureForm` protocol's `attachment` property wasn't being used, so it was removed, which eliminated the discrepancy between `FormAttachment` and `PopupAttachment`.