### PR TITLE
Don't show elements with BarcodeScanner input types

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -136,7 +136,7 @@ extension FeatureFormView {
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func makeFieldElement(_ element: FieldFormElement) -> some View {
         if !(element.input is UnsupportedFormInput ||
-             element.input is BarcodeScannerFormInput){
+             element.input is BarcodeScannerFormInput) {
             InputWrapper(element: element)
             Divider()
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -135,7 +135,8 @@ extension FeatureFormView {
     /// Makes UI for a field form element including a divider beneath it.
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func makeFieldElement(_ element: FieldFormElement) -> some View {
-        if !(element.input is UnsupportedFormInput) {
+        if !(element.input is UnsupportedFormInput ||
+             element.input is BarcodeScannerFormInput){
             InputWrapper(element: element)
             Divider()
         }


### PR DESCRIPTION
We're not going to display barcodes in the current release.