### PR TITLE
fetchAttachments build fix

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -191,7 +191,7 @@ struct AttachmentsFeatureElementView: View {
     func onDelete(attachmentModel: AttachmentModel) -> Void {
         if let element = featureElement as? AttachmentsFormElement,
            let attachment = attachmentModel.attachment as? FormAttachment {
-            element.deleteAttachment(attachment)
+            element.delete(attachment)
             guard case .initialized(var models) = attachmentModelsState else { return }
             models.removeAll { $0 == attachmentModel }
             attachmentModelsState = .initialized(models)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -142,7 +142,11 @@ struct AttachmentImportMenu: View {
             if let presetFileName = newAttachmentImportData.fileName {
                 fileName = presetFileName
             } else {
-                let attachmentNumber = element.attachments.count + 1
+                // `element.attachments` is now marked `async throws`, so this
+                // needs to be modified. We can address it as part of
+                // Apollo #682. Temporarily, just use a random Int.
+//                let attachmentNumber = element.attachments.count + 1
+                let attachmentNumber = Int.random(in: 0...99)
                 if let fileExtension = newAttachmentImportData.fileExtension {
                     fileName = "Attachment \(attachmentNumber).\(fileExtension)"
                 } else {

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
@@ -27,8 +27,7 @@ extension AttachmentsFormElement : AttachmentsFeatureElement {
     /// This property will be empty if the element has not yet been evaluated.
     public var featureAttachments: [FeatureAttachment] {
         get async throws {
-            try await fetchAttachments()
-            return attachments.map { $0 as FeatureAttachment }
+            try await attachments.map { $0 as FeatureAttachment }
         }
     }
     


### PR DESCRIPTION
Fixes the build for the `AttachmentsFormElement.fetchAttachments` change (to internal, in favor of an `async throws` `attachments` property).