### PR TITLE
`FeatureFormView` - Clear photo picker selection after dismissal

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentPhotoPicker.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentPhotoPicker.swift
@@ -39,6 +39,7 @@ struct AttachmentPhotoPicker: ViewModifier {
             )
             .task(id: item) {
                 guard let item else { return }
+                self.item = nil
                 importState = .importing
                 do {
                     guard let data = try await item.loadTransferable(type: Data.self) else {


### PR DESCRIPTION
Currently, the selection is not cleared, meaning that if the photo picker is reopened, the previously imported item is still indicated as selected.