### PR TITLE
Mark `UtilityNetworkTraceViewModelTests.testCase_2_x` with expected failures

### DIFF
--- a/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
@@ -78,6 +78,8 @@ final class UtilityNetworkTraceViewModelTests: XCTestCase {
     /// Test initializing a `UtilityNetworkTraceViewModel` with starting points.
     @MainActor
     func testCase_2_1() async throws {
+        XCTExpectFailure("https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/780")
+        
         let map = try await makeMapWithPortalItem()
         
         let layer = try XCTUnwrap(map.operationalLayers[0].subLayerContents[4] as? FeatureLayer)
@@ -122,6 +124,8 @@ final class UtilityNetworkTraceViewModelTests: XCTestCase {
     /// configuration.
     @MainActor
     func testCase_2_2() async throws {
+        XCTExpectFailure("https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/780")
+        
         let map = try await makeMapWithPortalItem()
         
         let layer = try XCTUnwrap(map.operationalLayers[0].subLayerContents[7] as? FeatureLayer)
@@ -175,6 +179,8 @@ final class UtilityNetworkTraceViewModelTests: XCTestCase {
     /// Test modifying the fractional starting point along an edge based utility element.
     @MainActor
     func testCase_2_3() async throws {
+        XCTExpectFailure("https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/780")
+        
         let map = try await makeMapWithPortalItem()
         
         let layer = try XCTUnwrap(map.operationalLayers[0].subLayerContents[4] as? FeatureLayer)


### PR DESCRIPTION
#780 