### PR TITLE
Remove captured photo editing

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
@@ -31,7 +31,6 @@ struct AttachmentCameraController: UIViewControllerRepresentable {
     }
     
     func makeUIViewController(context: Context) -> some UIViewController {
-        controller.allowsEditing = true
         controller.mediaTypes = UIImagePickerController.availableMediaTypes(for: .camera) ?? []
         controller.sourceType = .camera
         controller.delegate = context.coordinator


### PR DESCRIPTION
This removes the ability to edit captured photos/videos during adding an attachment.

Apollo #696