### PR TITLE
Cleanup `AttachmentPreview`, adding `Carousel`

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -17,9 +17,6 @@ import SwiftUI
 
 /// A view displaying a list of attachments in a "carousel", with a thumbnail and title.
 struct AttachmentPreview: View {
-    /// The size of each attachment preview cell as computed by the Carousel.
-    @State private var computedCellSize: CGSize?
-    
     /// The name for the existing attachment being edited.
     @State private var currentAttachmentName = ""
     
@@ -77,7 +74,7 @@ struct AttachmentPreview: View {
             Group {
                 EmptyView()
                     .id(carouselFront)
-                carouselContent
+                makeCarouselContent(for: computedCellSize)
             }
             .onAppear {
                 scrollToFrontAction = {
@@ -86,17 +83,14 @@ struct AttachmentPreview: View {
                     }
                 }
             }
-            .onChange(of: computedCellSize) { newComputedCellSize in
-                self.computedCellSize = newComputedCellSize
-            }
         }
         .cellBaseWidth(proposedCellSize.width)
     }
     
     @MainActor
-    var carouselContent: some View {
+    func makeCarouselContent(for size: CGSize) -> some View {
         ForEach(attachmentModels) { attachmentModel in
-            AttachmentCell(attachmentModel: attachmentModel, cellSize: computedCellSize ?? proposedCellSize)
+            AttachmentCell(attachmentModel: attachmentModel, cellSize: size)
                 .contextMenu {
                     if !editControlsDisabled {
                         Button {

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -52,8 +52,8 @@ struct AttachmentPreview: View {
     
     init(
         attachmentModels: [AttachmentModel],
-        proposedCellSize: CGSize,
         editControlsDisabled: Bool = true,
+        proposedCellSize: CGSize,
         onRename: ((AttachmentModel, String) -> Void)? = nil,
         onDelete: ((AttachmentModel) -> Void)? = nil,
         scrollToNewAttachmentAction: Binding<(() -> Void)?>

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -17,6 +17,9 @@ import SwiftUI
 
 /// A view displaying a list of attachments in a "carousel", with a thumbnail and title.
 struct AttachmentPreview: View {
+    /// An action which scrolls the Carousel to the front.
+    @Binding var scrollToNewAttachmentAction: (() -> Void)?
+    
     /// The name for the existing attachment being edited.
     @State private var currentAttachmentName = ""
     
@@ -32,30 +35,27 @@ struct AttachmentPreview: View {
     /// A Boolean value indicating the user has requested that the attachment be renamed.
     @State private var renameDialogueIsShowing = false
     
-    /// An action which scrolls the Carousel to the front.
-    @Binding var scrollToNewAttachmentAction: (() -> Void)?
-    
     /// The models for the attachments displayed in the list.
-    let attachmentModels: [AttachmentModel]
+    private let attachmentModels: [AttachmentModel]
     
     /// A Boolean value which determines if the attachment editing controls should be disabled.
-    let editControlsDisabled: Bool
+    private  let editControlsDisabled: Bool
     
     /// The action to perform when the attachment is deleted.
-    let onDelete: ((AttachmentModel) -> Void)?
+    private let onDelete: ((AttachmentModel) -> Void)?
     
     /// The action to perform when the attachment is renamed.
-    let onRename: ((AttachmentModel, String) -> Void)?
+    private let onRename: ((AttachmentModel, String) -> Void)?
     
     /// The proposed size of each attachment preview cell.
-    let proposedCellSize: CGSize
+    private let proposedCellSize: CGSize
     
     init(
         attachmentModels: [AttachmentModel],
-        proposedCellSize: CGSize,
         editControlsDisabled: Bool = true,
         onRename: ((AttachmentModel, String) -> Void)? = nil,
         onDelete: ((AttachmentModel) -> Void)? = nil,
+        proposedCellSize: CGSize,
         scrollToNewAttachmentAction: Binding<(() -> Void)?>
     ) {
         self.attachmentModels = attachmentModels

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -39,7 +39,7 @@ struct AttachmentPreview: View {
     private let attachmentModels: [AttachmentModel]
     
     /// A Boolean value which determines if the attachment editing controls should be disabled.
-    private  let editControlsDisabled: Bool
+    private let editControlsDisabled: Bool
     
     /// The action to perform when the attachment is deleted.
     private let onDelete: ((AttachmentModel) -> Void)?

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -62,7 +62,7 @@ struct AttachmentPreview: View {
     }
     
     var body: some View {
-        Carousel { cellSize in
+        Carousel { cellSize, _ in
             carouselContent
         }
         .cellBaseWidth(cellSize.width)

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -33,13 +33,10 @@ struct AttachmentPreview: View {
     @State private var renameDialogueIsShowing = false
     
     /// An action which scrolls the Carousel to the front.
-    @Binding var scrollToFrontAction: (() -> Void)?
+    @Binding var scrollToNewAttachmentAction: (() -> Void)?
     
     /// The models for the attachments displayed in the list.
     let attachmentModels: [AttachmentModel]
-    
-    /// The identifier for the leading item in the Carousel.
-    let carouselFront = UUID()
     
     /// A Boolean value which determines if the attachment editing controls should be disabled.
     let editControlsDisabled: Bool
@@ -59,29 +56,23 @@ struct AttachmentPreview: View {
         editControlsDisabled: Bool = true,
         onRename: ((AttachmentModel, String) -> Void)? = nil,
         onDelete: ((AttachmentModel) -> Void)? = nil,
-        scrollToFrontAction: Binding<(() -> Void)?>
+        scrollToNewAttachmentAction: Binding<(() -> Void)?>
     ) {
         self.attachmentModels = attachmentModels
         self.proposedCellSize = proposedCellSize
         self.editControlsDisabled = editControlsDisabled
         self.onRename = onRename
         self.onDelete = onDelete
-        _scrollToFrontAction = scrollToFrontAction
+        _scrollToNewAttachmentAction = scrollToNewAttachmentAction
     }
     
     var body: some View {
-        Carousel { computedCellSize, scrollViewProxy in
+        Carousel { computedCellSize, scrollToLeftAction in
             Group {
-                EmptyView()
-                    .id(carouselFront)
                 makeCarouselContent(for: computedCellSize)
             }
             .onAppear {
-                scrollToFrontAction = {
-                    withAnimation {
-                        scrollViewProxy.scrollTo(carouselFront, anchor: .leading)
-                    }
-                }
+                scrollToNewAttachmentAction = scrollToLeftAction
             }
         }
         .cellBaseWidth(proposedCellSize.width)

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -52,8 +52,8 @@ struct AttachmentPreview: View {
     
     init(
         attachmentModels: [AttachmentModel],
-        editControlsDisabled: Bool = true,
         proposedCellSize: CGSize,
+        editControlsDisabled: Bool = true,
         onRename: ((AttachmentModel, String) -> Void)? = nil,
         onDelete: ((AttachmentModel) -> Void)? = nil,
         scrollToNewAttachmentAction: Binding<(() -> Void)?>

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -32,6 +32,9 @@ struct AttachmentPreview: View {
     /// A Boolean value indicating the user has requested that the attachment be renamed.
     @State private var renameDialogueIsShowing = false
     
+    /// The proxy to the scroll view within the Carousel.
+    @Binding var scrollViewProxy: ScrollViewProxy?
+    
     /// The models for the attachments displayed in the list.
     let attachmentModels: [AttachmentModel]
     
@@ -52,18 +55,25 @@ struct AttachmentPreview: View {
         cellSize: CGSize,
         editControlsDisabled: Bool = true,
         onRename: ((AttachmentModel, String) -> Void)? = nil,
-        onDelete: ((AttachmentModel) -> Void)? = nil
+        onDelete: ((AttachmentModel) -> Void)? = nil,
+        scrollViewProxy: Binding<ScrollViewProxy?>
     ) {
         self.attachmentModels = attachmentModels
         self.cellSize = cellSize
         self.editControlsDisabled = editControlsDisabled
         self.onRename = onRename
         self.onDelete = onDelete
+        _scrollViewProxy = scrollViewProxy
     }
     
     var body: some View {
-        Carousel { cellSize, _ in
+        Carousel { cellSize, scrollViewProxy in
+            EmptyView()
+                .id("First Element")
             carouselContent
+                .onAppear {
+                    self.scrollViewProxy = scrollViewProxy
+                }
         }
         .cellBaseWidth(cellSize.width)
     }

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -32,11 +32,14 @@ struct AttachmentPreview: View {
     /// A Boolean value indicating the user has requested that the attachment be renamed.
     @State private var renameDialogueIsShowing = false
     
-    /// The proxy to the scroll view within the Carousel.
-    @Binding var scrollViewProxy: ScrollViewProxy?
+    /// An action which scrolls the Carousel to the front.
+    @Binding var scrollToFrontAction: (() -> Void)?
     
     /// The models for the attachments displayed in the list.
     let attachmentModels: [AttachmentModel]
+    
+    /// The identifier for the leading item in the Carousel.
+    let carouselFront = UUID()
     
     /// The size of each cell.
     let cellSize: CGSize
@@ -56,23 +59,27 @@ struct AttachmentPreview: View {
         editControlsDisabled: Bool = true,
         onRename: ((AttachmentModel, String) -> Void)? = nil,
         onDelete: ((AttachmentModel) -> Void)? = nil,
-        scrollViewProxy: Binding<ScrollViewProxy?>
+        scrollToFrontAction: Binding<(() -> Void)?>
     ) {
         self.attachmentModels = attachmentModels
         self.cellSize = cellSize
         self.editControlsDisabled = editControlsDisabled
         self.onRename = onRename
         self.onDelete = onDelete
-        _scrollViewProxy = scrollViewProxy
+        _scrollToFrontAction = scrollToFrontAction
     }
     
     var body: some View {
         Carousel { cellSize, scrollViewProxy in
             EmptyView()
-                .id("First Element")
+                .id(carouselFront)
             carouselContent
                 .onAppear {
-                    self.scrollViewProxy = scrollViewProxy
+                    scrollToFrontAction = {
+                        withAnimation {
+                            scrollViewProxy.scrollTo(carouselFront, anchor: .leading)
+                        }
+                    }
                 }
         }
         .cellBaseWidth(cellSize.width)

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -34,8 +34,10 @@ struct AttachmentsFeatureElementView: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
     
-    /// The proxy to the scroll view within an AttachmentPreview.
-    @State private var scrollViewProxy: ScrollViewProxy?
+    /// Scrolls an ``AttachmentPreview`` to the front.
+    ///
+    /// Call this action when a new attachment is added to make it visible to the user.
+    @State private var scrollToFrontAction: (() -> Void)?
     
     /// A Boolean value denoting if the view should be shown as regular width.
     var isRegularWidth: Bool {
@@ -126,7 +128,7 @@ struct AttachmentsFeatureElementView: View {
                 editControlsDisabled: !isEditable,
                 onRename: onRename,
                 onDelete: onDelete,
-                scrollViewProxy: $scrollViewProxy
+                scrollToFrontAction: $scrollToFrontAction
             )
         case .auto:
             Group {
@@ -137,7 +139,7 @@ struct AttachmentsFeatureElementView: View {
                         editControlsDisabled: !isEditable,
                         onRename: onRename,
                         onDelete: onDelete,
-                        scrollViewProxy: $scrollViewProxy
+                        scrollToFrontAction: $scrollToFrontAction
                     )
                 } else {
                     AttachmentList(attachmentModels: attachmentModels)
@@ -176,7 +178,7 @@ struct AttachmentsFeatureElementView: View {
         models.insert(newModel, at: 0)
         attachmentModelsState = .initialized(models)
         formViewModel.evaluateExpressions()
-        withAnimation { scrollViewProxy?.scrollTo("First Element", anchor: .leading) }
+        scrollToFrontAction?()
     }
     
     /// Renames the attachment associated with the given model.

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -124,7 +124,7 @@ struct AttachmentsFeatureElementView: View {
         case .preview:
             AttachmentPreview(
                 attachmentModels: attachmentModels,
-                cellSize: thumbnailSize,
+                proposedCellSize: thumbnailSize,
                 editControlsDisabled: !isEditable,
                 onRename: onRename,
                 onDelete: onDelete,
@@ -135,7 +135,7 @@ struct AttachmentsFeatureElementView: View {
                 if isRegularWidth {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
-                        cellSize: thumbnailSize,
+                        proposedCellSize: thumbnailSize,
                         editControlsDisabled: !isEditable,
                         onRename: onRename,
                         onDelete: onDelete,

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -37,7 +37,7 @@ struct AttachmentsFeatureElementView: View {
     /// Scrolls an ``AttachmentPreview`` to the front.
     ///
     /// Call this action when a new attachment is added to make it visible to the user.
-    @State private var scrollToFrontAction: (() -> Void)?
+    @State private var scrollToNewAttachmentAction: (() -> Void)?
     
     /// A Boolean value denoting if the view should be shown as regular width.
     var isRegularWidth: Bool {
@@ -128,7 +128,7 @@ struct AttachmentsFeatureElementView: View {
                 editControlsDisabled: !isEditable,
                 onRename: onRename,
                 onDelete: onDelete,
-                scrollToFrontAction: $scrollToFrontAction
+                scrollToNewAttachmentAction: $scrollToNewAttachmentAction
             )
         case .auto:
             Group {
@@ -139,7 +139,7 @@ struct AttachmentsFeatureElementView: View {
                         editControlsDisabled: !isEditable,
                         onRename: onRename,
                         onDelete: onDelete,
-                        scrollToFrontAction: $scrollToFrontAction
+                        scrollToNewAttachmentAction: $scrollToNewAttachmentAction
                     )
                 } else {
                     AttachmentList(attachmentModels: attachmentModels)
@@ -178,7 +178,7 @@ struct AttachmentsFeatureElementView: View {
         models.insert(newModel, at: 0)
         attachmentModelsState = .initialized(models)
         formViewModel.evaluateExpressions()
-        scrollToFrontAction?()
+        scrollToNewAttachmentAction?()
     }
     
     /// Renames the attachment associated with the given model.

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -124,8 +124,8 @@ struct AttachmentsFeatureElementView: View {
         case .preview:
             AttachmentPreview(
                 attachmentModels: attachmentModels,
-                editControlsDisabled: !isEditable,
                 proposedCellSize: thumbnailSize,
+                editControlsDisabled: !isEditable,
                 onRename: onRename,
                 onDelete: onDelete,
                 scrollToNewAttachmentAction: $scrollToNewAttachmentAction
@@ -135,8 +135,8 @@ struct AttachmentsFeatureElementView: View {
                 if isRegularWidth {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
-                        editControlsDisabled: !isEditable,
                         proposedCellSize: thumbnailSize,
+                        editControlsDisabled: !isEditable,
                         onRename: onRename,
                         onDelete: onDelete,
                         scrollToNewAttachmentAction: $scrollToNewAttachmentAction

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -34,6 +34,9 @@ struct AttachmentsFeatureElementView: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
     
+    /// The proxy to the scroll view within an AttachmentPreview.
+    @State private var scrollViewProxy: ScrollViewProxy?
+    
     /// A Boolean value denoting if the view should be shown as regular width.
     var isRegularWidth: Bool {
         !isPortraitOrientation
@@ -122,7 +125,8 @@ struct AttachmentsFeatureElementView: View {
                 cellSize: thumbnailSize,
                 editControlsDisabled: !isEditable,
                 onRename: onRename,
-                onDelete: onDelete
+                onDelete: onDelete,
+                scrollViewProxy: $scrollViewProxy
             )
         case .auto:
             Group {
@@ -132,7 +136,8 @@ struct AttachmentsFeatureElementView: View {
                         cellSize: thumbnailSize,
                         editControlsDisabled: !isEditable,
                         onRename: onRename,
-                        onDelete: onDelete
+                        onDelete: onDelete,
+                        scrollViewProxy: $scrollViewProxy
                     )
                 } else {
                     AttachmentList(attachmentModels: attachmentModels)
@@ -171,6 +176,7 @@ struct AttachmentsFeatureElementView: View {
         models.insert(newModel, at: 0)
         attachmentModelsState = .initialized(models)
         formViewModel.evaluateExpressions()
+        withAnimation { scrollViewProxy?.scrollTo("First Element", anchor: .leading) }
     }
     
     /// Renames the attachment associated with the given model.

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -119,6 +119,7 @@ struct AttachmentsFeatureElementView: View {
         case .preview:
             AttachmentPreview(
                 attachmentModels: attachmentModels,
+                cellSize: thumbnailSize,
                 editControlsDisabled: !isEditable,
                 onRename: onRename,
                 onDelete: onDelete
@@ -128,6 +129,7 @@ struct AttachmentsFeatureElementView: View {
                 if isRegularWidth {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
+                        cellSize: thumbnailSize,
                         editControlsDisabled: !isEditable,
                         onRename: onRename,
                         onDelete: onDelete

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -124,10 +124,10 @@ struct AttachmentsFeatureElementView: View {
         case .preview:
             AttachmentPreview(
                 attachmentModels: attachmentModels,
-                proposedCellSize: thumbnailSize,
                 editControlsDisabled: !isEditable,
                 onRename: onRename,
                 onDelete: onDelete,
+                proposedCellSize: thumbnailSize,
                 scrollToNewAttachmentAction: $scrollToNewAttachmentAction
             )
         case .auto:
@@ -135,10 +135,10 @@ struct AttachmentsFeatureElementView: View {
                 if isRegularWidth {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
-                        proposedCellSize: thumbnailSize,
                         editControlsDisabled: !isEditable,
                         onRename: onRename,
                         onDelete: onDelete,
+                        proposedCellSize: thumbnailSize,
                         scrollToNewAttachmentAction: $scrollToNewAttachmentAction
                     )
                 } else {

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -124,8 +124,8 @@ struct AttachmentsFeatureElementView: View {
         case .preview:
             AttachmentPreview(
                 attachmentModels: attachmentModels,
-                proposedCellSize: thumbnailSize,
                 editControlsDisabled: !isEditable,
+                proposedCellSize: thumbnailSize,
                 onRename: onRename,
                 onDelete: onDelete,
                 scrollToNewAttachmentAction: $scrollToNewAttachmentAction
@@ -135,8 +135,8 @@ struct AttachmentsFeatureElementView: View {
                 if isRegularWidth {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
-                        proposedCellSize: thumbnailSize,
                         editControlsDisabled: !isEditable,
+                        proposedCellSize: thumbnailSize,
                         onRename: onRename,
                         onDelete: onDelete,
                         scrollToNewAttachmentAction: $scrollToNewAttachmentAction

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
@@ -14,10 +14,12 @@
 
 import ArcGIS
 
-extension AttachmentsFormElement : AttachmentsFeatureElement {
+extension AttachmentsFormElement: AttachmentsFeatureElement {
     /// Indicates how to display the attachments.
+    ///
+    /// - Note: Currently, ``AttachmentsFormElement`` only supports
+    /// ``AttachmentsFeatureElementDisplayType/preview``.
     public var attachmentsDisplayType: AttachmentsFeatureElementDisplayType {
-        // Currently, Attachment Form Elements only support `Preview`.
         AttachmentsFeatureElementDisplayType.preview
     }
     

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsPopupElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsPopupElement.swift
@@ -14,7 +14,7 @@
 
 import ArcGIS
 
-extension AttachmentsPopupElement : AttachmentsFeatureElement {
+extension AttachmentsPopupElement: AttachmentsFeatureElement {
     /// Indicates how to display the attachments.
     public var attachmentsDisplayType: AttachmentsFeatureElementDisplayType {
         AttachmentsFeatureElementDisplayType(kind: displayType)

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -67,7 +67,8 @@ struct Carousel<Content: View>: View {
         .frame(height: cellSize.height)
     }
     
-//    iOS18Implementation remains commented as it contains symbols not available in Xcode 15.4.
+//    The iOS 18 implementation is commented as it contains symbols not
+//    available in Xcode 15.4.
 //    @available(iOS 18.0, *)
 //    var iOS18Implementation: some View {
 //        ScrollViewReader { scrollViewProxy in

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -70,8 +70,10 @@ struct Carousel<Content: View>: View {
 //    iOS18Implementation remains commented as it contains symbols not available in Xcode 15.4.
 //    @available(iOS 18.0, *)
 //    var iOS18Implementation: some View {
-//        ScrollView(.horizontal) {
-//            commonScrollViewContent
+//        ScrollViewReader { scrollViewProxy in
+//            ScrollView(.horizontal) {
+//                makeCommonScrollViewContent(scrollViewProxy)
+//            }
 //        }
 //        .onScrollGeometryChange(for: CGFloat.self) { geometry in
 //            geometry.containerSize.width

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -21,8 +21,8 @@ struct Carousel<Content: View>: View {
     /// The size of each cell.
     @State private var cellSize = CGSize.zero
     
-    /// The identifier for the leading item in the Carousel.
-    let carouselLeftAnchor = UUID()
+    /// The identifier for the Carousel content.
+    let contentIdentifier = UUID()
     
     /// The content shown in the Carousel.
     let content: (_: CGSize, _: (() -> Void)?) -> Content
@@ -88,13 +88,12 @@ struct Carousel<Content: View>: View {
     
     func makeCommonScrollViewContent(_ scrollViewProxy: ScrollViewProxy) -> some View {
         HStack(spacing: cellSpacing) {
-            EmptyView()
-                .id(carouselLeftAnchor)
             content(cellSize) {
                 withAnimation {
-                    scrollViewProxy.scrollTo(carouselLeftAnchor, anchor: .leading)
+                    scrollViewProxy.scrollTo(contentIdentifier, anchor: .leading)
                 }
             }
+            .id(contentIdentifier)
             .frame(width: cellSize.width, height: cellSize.height)
             .clipped()
         }
@@ -181,7 +180,6 @@ extension Carousel {
                 withAnimation {
                     scrollToLeftAction?()
                 }
-                
             }
         }
     }

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -1,0 +1,132 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+/// A view that arranges its subviews in a horizontal scrolling container.
+///
+/// The view can be configured to size subviews such that one is partially visible at all times.
+struct Carousel<Content: View>: View {
+    /// The size of each cell.
+    @State private var cellSize = CGSize.zero
+    
+    /// The content shown in the Carousel.
+    let content: () -> Content
+    
+    /// This number is used to compute the final width that allows for a partially visible cell.
+    var cellBaseWidth = 120.0
+    
+    /// The horizontal spacing between each cell.
+    var cellSpacing = 8.0
+    
+    /// The fractional width of the partially visible cell.
+    var cellVisiblePortion = 0.25
+    
+    /// A horizontally scrolling container to display a set of content.
+    /// - Parameter content: A view builder that creates the content of this Carousel.
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView(.horizontal) {
+                HStack(spacing: cellSpacing) {
+                    content()
+                        .frame(width: cellSize.width, height: cellSize.height)
+                }
+            }
+            .onAppear {
+                updateCellSizeForContainer(geometry.size.width)
+            }
+            .onChange(of: geometry.size.width) { width in
+                updateCellSizeForContainer(width)
+            }
+        }
+        .frame(height: cellSize.height)
+    }
+}
+
+extension Carousel {
+    /// Updates `cellSize` based on the provided container width, `cellBaseWidth`,
+    /// `cellSpacing`, and `visiblePortion` such that the `cellVisiblePortion` width of
+    /// one cell is shown to indicate scrollability.
+    /// - Parameter width: The width of the container the `AttachmentPreview` is in.
+    func updateCellSizeForContainer(_ width: CGFloat) {
+        let fullyVisible = modf(width / cellBaseWidth)
+        let totalPadding = fullyVisible.0 * cellSpacing
+        let newWidth = (width - totalPadding) / (fullyVisible.0 + cellVisiblePortion)
+        cellSize = CGSize(width: newWidth, height: newWidth)
+    }
+    
+    func cellBaseWidth(_ width: CGFloat) -> Self {
+        var copy = self
+        copy.cellBaseWidth = width
+        return copy
+    }
+    
+    func cellSpacing(_ spacing: CGFloat) -> Self {
+        var copy = self
+        copy.cellSpacing = spacing
+        return copy
+    }
+    
+    func cellVisiblePortion(_ visiblePortion: CGFloat) -> Self {
+        var copy = self
+        copy.cellVisiblePortion = visiblePortion
+        return copy
+    }
+}
+
+#Preview("Custom base width") {
+    Carousel {
+        PreviewContent()
+    }
+    .cellBaseWidth(75)
+}
+
+#Preview("Custom spacing") {
+    Carousel {
+        PreviewContent()
+    }
+    .cellSpacing(2)
+}
+
+#Preview("Custom visible portion") {
+    Carousel {
+        PreviewContent()
+    }
+    .cellVisiblePortion(0.5)
+}
+
+#Preview("In a list") {
+    List {
+        Text("Hello")
+        Carousel {
+            PreviewContent()
+        }
+        Text("World!")
+    }
+}
+
+private struct PreviewContent: View {
+    var colors: [Color] = [.red, .orange, .yellow, .green, .blue, .indigo, .purple]
+    
+    var body: some View {
+        ForEach(colors, id: \.self) { color in
+            Rectangle()
+                .fill(color)
+        }
+    }
+}

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -42,7 +42,7 @@ struct Carousel<Content: View>: View {
         self.content = content
     }
     
-    /// - Note: The iOS 18 version currently uses the `legacyImplementation` as
+    /// - Note: The iOS 18 version currently uses `legacyImplementation` as
     /// `iOS18Implementation` contains symbols not available in Xcode 15.4.
     var body: some View {
         if #available(iOS 18.0, *) {

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -86,6 +86,7 @@ struct Carousel<Content: View>: View {
         HStack(spacing: cellSpacing) {
             content(cellSize, scrollViewProxy)
                 .frame(width: cellSize.width, height: cellSize.height)
+                .clipped()
         }
     }
 }
@@ -121,21 +122,21 @@ extension Carousel {
     }
 }
 
-#Preview("Custom base width") {
+#Preview("Custom smaller base width") {
     Carousel { _, _ in
         PreviewContent()
     }
     .cellBaseWidth(75)
 }
 
-#Preview("Custom spacing") {
+#Preview("Custom smaller spacing") {
     Carousel { _, _ in
         PreviewContent()
     }
     .cellSpacing(2)
 }
 
-#Preview("Custom visible portion") {
+#Preview("Custom larger visible portion (50%)") {
     Carousel { _, _ in
         PreviewContent()
     }

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -39,9 +39,10 @@ struct Carousel<Content: View>: View {
         self.content = content
     }
     
+    /// - Note: The iOS 18 version currently uses the `legacyImplementation` as
+    /// `iOS18Implementation` contains symbols not available in Xcode 15.4.
     var body: some View {
         if #available(iOS 18.0, *) {
-//            iOS18Implementation
             legacyImplementation
         } else {
             legacyImplementation
@@ -66,6 +67,7 @@ struct Carousel<Content: View>: View {
         .frame(height: cellSize.height)
     }
     
+//    iOS18Implementation remains commented as it contains symbols not available in Xcode 15.4.
 //    @available(iOS 18.0, *)
 //    var iOS18Implementation: some View {
 //        ScrollView(.horizontal) {

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -132,28 +132,28 @@ extension Carousel {
     }
 }
 
-#Preview("Custom smaller base width") {
+#Preview("cellBaseWidth(_:)") {
     Carousel { _, _ in
         PreviewContent()
     }
     .cellBaseWidth(75)
 }
 
-#Preview("Custom smaller spacing") {
+#Preview("cellSpacing(_:)") {
     Carousel { _, _ in
         PreviewContent()
     }
     .cellSpacing(2)
 }
 
-#Preview("Custom larger visible portion (50%)") {
+#Preview("cellVisiblePortion(_:)") {
     Carousel { _, _ in
         PreviewContent()
     }
     .cellVisiblePortion(0.5)
 }
 
-#Preview("In a list") {
+#Preview("In a List") {
     List {
         Text("Hello")
         Carousel { _, _ in
@@ -163,7 +163,7 @@ extension Carousel {
     }
 }
 
-#Preview("Scroll to left") {
+#Preview("Scroll to left action") {
     struct ScrollDemo: View {
         @State var scrollToLeftAction: (() -> Void)?
         


### PR DESCRIPTION
Apollo 655

Followup to #782 

| Popups on `v.next` prior to #782 | Popups on this branch |
|---|---|
| <img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/e685b120-15e2-4948-9aa2-258b28984185"> | <img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/b03305a9-aafb-471f-97a5-9f7911933697"> |