### PR TITLE
Fix attachment file extension for camera captures

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
@@ -63,7 +63,7 @@ final class CameraControllerCoordinator: NSObject, UIImagePickerControllerDelega
             }
         } else if let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL {
             if let videoData = try? Data(contentsOf: videoURL) {
-                parent.importState = .finalizing(AttachmentImportData(data: videoData, contentType: "video/quicktime", fileName: videoURL.lastPathComponent))
+                parent.importState = .finalizing(AttachmentImportData(data: videoData, contentType: "video/quicktime", fileExtension: videoURL.pathExtension))
             }
         }
         parent.endCapture()

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
@@ -59,7 +59,7 @@ final class CameraControllerCoordinator: NSObject, UIImagePickerControllerDelega
         parent.importState = .importing
         if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
             if let pngData = image.pngData() {
-                parent.importState = .finalizing(AttachmentImportData(data: pngData, contentType: "image/png"))
+                parent.importState = .finalizing(AttachmentImportData(data: pngData, contentType: "image/png", fileExtension: "png"))
             }
         } else if let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL {
             if let videoData = try? Data(contentsOf: videoURL) {


### PR DESCRIPTION
Apollo #767

This adds a "png" extension to attachments grabbed from the Camera; it also uses ONLY the extension for Video captures, instead of the real long, GUID-like, complete filename.