### PR TITLE
`FeatureFormView` - Re-prompt for camera access

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -68,19 +68,19 @@ struct AttachmentImportMenu: View {
     }
     
     private func takePhotoOrVideoButton() -> Button<some View> {
-       Button {
-           if AVCaptureDevice.authorizationStatus(for: .video) == .authorized {
-               cameraIsShowing = true
-           } else {
-               Task {
-                   let granted = await AVCaptureDevice.requestAccess(for: .video)
-                   if granted {
-                      cameraIsShowing = true
-                   } else {
-                       cameraAccessAlertIsPresented = true
-                   }
-               }
-           }
+        Button {
+            if AVCaptureDevice.authorizationStatus(for: .video) == .authorized {
+                cameraIsShowing = true
+            } else {
+                Task {
+                    let granted = await AVCaptureDevice.requestAccess(for: .video)
+                    if granted {
+                        cameraIsShowing = true
+                    } else {
+                        cameraAccessAlertIsPresented = true
+                    }
+                }
+            }
         } label: {
             Label {
                 Text(cameraButtonLabel)
@@ -92,7 +92,7 @@ struct AttachmentImportMenu: View {
     }
     
     private func chooseFromLibraryButton() -> Button<some View> {
-       Button {
+        Button {
             photoPickerIsPresented = true
         } label: {
             Label {
@@ -105,7 +105,7 @@ struct AttachmentImportMenu: View {
     }
     
     private func chooseFromFilesButton() -> Button<some View> {
-       Button {
+        Button {
             fileImporterIsShowing = true
         } label: {
             Label {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
+import AVFoundation
 import OSLog
 import SwiftUI
 import UniformTypeIdentifiers
@@ -30,6 +31,9 @@ struct AttachmentImportMenu: View {
         self.element = element
         self.onAdd = onAdd
     }
+    
+    /// A Boolean value indicating whether the camera access alert is presented.
+    @State private var cameraAccessAlertIsPresented = false
     
     /// A Boolean value indicating whether the attachment camera controller is presented.
     @State private var cameraIsShowing = false
@@ -65,7 +69,18 @@ struct AttachmentImportMenu: View {
     
     private func takePhotoOrVideoButton() -> Button<some View> {
        Button {
-            cameraIsShowing = true
+           if AVCaptureDevice.authorizationStatus(for: .video) == .authorized {
+               cameraIsShowing = true
+           } else {
+               Task {
+                   let granted = await AVCaptureDevice.requestAccess(for: .video)
+                   if granted {
+                      cameraIsShowing = true
+                   } else {
+                       cameraAccessAlertIsPresented = true
+                   }
+               }
+           }
         } label: {
             Label {
                 Text(cameraButtonLabel)
@@ -119,6 +134,14 @@ struct AttachmentImportMenu: View {
                 .padding(5)
         }
         .disabled(importState.importInProgress)
+        .alert(cameraAccessAlertTitle, isPresented: $cameraAccessAlertIsPresented) {
+            Button(String.settings) {
+                Task { await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!) }
+            }
+            Button(String.cancel, role: .cancel) { }
+        } message: {
+            Text(cameraAccessAlertMessage)
+        }
         .alert(importFailureAlertTitle, isPresented: errorIsPresented) { } message: {
             Text(importFailureAlertMessage)
         }
@@ -210,6 +233,24 @@ extension URL {
 }
 
 private extension AttachmentImportMenu {
+    /// A message for an alert requesting camera access.
+    var cameraAccessAlertMessage: String {
+        .init(
+            localized: "Please enable camera access in settings.",
+            bundle: .toolkitModule,
+            comment: "A message for an alert requesting camera access."
+        )
+    }
+    
+    /// A title for an alert that camera access is disabled.
+    var cameraAccessAlertTitle: String {
+        .init(
+            localized: "Camera access is disabled",
+            bundle: .toolkitModule,
+            comment: "A title for an alert that camera access is disabled."
+        )
+    }
+    
     /// A label for a button to capture a new photo or video.
     var cameraButtonLabel: String {
         .init(

--- a/Sources/ArcGISToolkit/Extensions/Swift/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/String.swift
@@ -42,6 +42,15 @@ extension String {
         )
     }
     
+    /// A label for a button to take the user to a contextually inferred settings page.
+    static var settings: String {
+        .init(
+            localized: "Settings",
+            bundle: .toolkitModule,
+            comment: "A label for a button to take the user to a contextually inferred settings page."
+        )
+    }
+    
     /// A localized string for the word "Value".
     static var value: Self {
         .init(

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -42,6 +42,9 @@ content on a remote host. The variable is the host that prompted the challenge. 
 for the AR experience. */
 "Calibration" = "Calibration";
 
+/* A title for an alert that camera access is disabled. */
+"Camera access is disabled" = "Camera access is disabled";
+
 /* A label for a button to cancel an operation. */
 "Cancel" = "Cancel";
 
@@ -264,6 +267,9 @@ AR experience. */
 /* A label indicating that a password is required to proceed with an operation. */
 "Password Required" = "Password Required";
 
+/* A message for an alert requesting camera access. */
+"Please enable camera access in settings." = "Please enable camera access in settings.";
+
 /* A label requesting the password associated with the chosen certificate. */
 "Please enter a password for the chosen certificate." = "Please enter a password for the chosen certificate.";
 
@@ -305,6 +311,9 @@ current visible extent of the map or scene. */
 /* A label directing the user to select a facility. A facility contains one
 or more levels in a floor-aware map or scene. */
 "Select a facility" = "Select a facility";
+
+/* A label for a button to take the user to a contextually inferred settings page. */
+"Settings" = "Settings";
 
 /* A label in reference to all of the sites in a floor-aware map or scene. */
 "Sites" = "Sites";


### PR DESCRIPTION
Apollo 695

Re-prompt for camera access when it's been disabled in system settings.