### PR TITLE
`AttachmentsFeatureElementView` - Swap out deprecated alert API

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentList.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentList.swift
@@ -100,8 +100,6 @@ struct AttachmentLoadButton: View  {
             .frame(width: 24, height: 24)
             .padding(.leading)
         }
-        .alert(isPresented: $downloadAlertIsPresented) {
-            Alert(title: Text.emptyAttachmentDownloadErrorMessage)
-        }
+        .alert(String.emptyAttachmentDownloadErrorMessage, isPresented: $downloadAlertIsPresented) { }
     }
 }

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -216,9 +216,7 @@ struct AttachmentPreview: View {
                 }
             }
             .quickLookPreview($url)
-            .alert(isPresented: $downloadAlertIsPresented) {
-                Alert(title: Text.emptyAttachmentDownloadErrorMessage)
-            }
+            .alert(String.emptyAttachmentDownloadErrorMessage, isPresented: $downloadAlertIsPresented) { }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/Swift/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/String.swift
@@ -24,6 +24,15 @@ extension String {
         )
     }
     
+    /// An error message explaining attachments with empty files (0 bytes) cannot be downloaded.
+    static var emptyAttachmentDownloadErrorMessage: Self {
+        .init(
+            localized: "Empty attachments cannot be downloaded.",
+            bundle: .toolkitModule,
+            comment: "An error message explaining attachments with empty files (0 bytes) cannot be downloaded."
+        )
+    }
+    
     /// A localized string for the word "Field".
     static var field: Self {
         .init(

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
@@ -24,15 +24,6 @@ extension Text {
         )
     }
     
-    /// An error message explaining attachments with empty files (0 bytes) cannot be downloaded.
-    static var emptyAttachmentDownloadErrorMessage: Self {
-        .init(
-            "Empty attachments cannot be downloaded.",
-            bundle: .toolkitModule,
-            comment: "An error message explaining attachments with empty files (0 bytes) cannot be downloaded."
-        )
-    }
-    
     /// Localized text for the word "Required".
     static var required: Self {
         Text(


### PR DESCRIPTION
[Followup](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/791#discussion_r1669413256) to #791