### PR TITLE
`AttachmentsFeatureElementView` - Validate microphone access

### DIFF
--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -213,6 +213,9 @@ AR experience. */
 /* A label in reference to media elements contained within a popup. */
 "Media" = "Media";
 
+/* A warning message indicating microphone access has been disabled for the current application in the system settings. */
+"Microphone access has been disabled in Settings." = "Microphone access has been disabled in Settings.";
+
 /* Text indicating a field's minimum number of allowed characters is not met. */
 "Minimum character length not met" = "Minimum character length not met";
 
@@ -290,6 +293,9 @@ chosen utility network trace configuration. */
 /* An error message shown when a popup cannot be displayed. The
 variable provides additional data. */
 "Popup evaluation failed: %@" = "Popup evaluation failed: %@";
+
+/* A button allowing users to proceed to record a video while acknowledging audio will not be captured. */
+"Record video only" = "Record video only";
 
 /* A label for a button to rename an attachment. */
 "Rename" = "Rename";

--- a/Test Runner/Test Runner.xcodeproj/project.pbxproj
+++ b/Test Runner/Test Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		8A1138132BC7407D007E0BFB /* BookmarksTestCase6View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1138122BC7407D007E0BFB /* BookmarksTestCase6View.swift */; };
 		8A1562F52B86896300000DD6 /* UI Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F42B86896300000DD6 /* UI Tests.xctestplan */; };
 		8A1562F72B86896C00000DD6 /* Unit Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F62B86896C00000DD6 /* Unit Tests.xctestplan */; };
+		8A9845752C3F43EB001CCE22 /* AttachmentCameraControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9845742C3F43EB001CCE22 /* AttachmentCameraControllerTests.swift */; };
+		8A9845772C3F444B001CCE22 /* AttachmentCameraControllerTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9845762C3F4447001CCE22 /* AttachmentCameraControllerTestView.swift */; };
 		8A9F898F2B5B4F0A0027215E /* FeatureFormTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */; };
 		8AEE70482BEEC0B400C9949C /* RepresentedUITextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE70472BEEC0B400C9949C /* RepresentedUITextViewTests.swift */; };
 		8AEE704A2BEEC18000C9949C /* RepresentedUITextViewTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */; };
@@ -66,6 +68,8 @@
 		8A1138122BC7407D007E0BFB /* BookmarksTestCase6View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksTestCase6View.swift; sourceTree = "<group>"; };
 		8A1562F42B86896300000DD6 /* UI Tests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "UI Tests.xctestplan"; sourceTree = "<group>"; };
 		8A1562F62B86896C00000DD6 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
+		8A9845742C3F43EB001CCE22 /* AttachmentCameraControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentCameraControllerTests.swift; sourceTree = "<group>"; };
+		8A9845762C3F4447001CCE22 /* AttachmentCameraControllerTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentCameraControllerTestView.swift; sourceTree = "<group>"; };
 		8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureFormTestView.swift; sourceTree = "<group>"; };
 		8AEE70472BEEC0B400C9949C /* RepresentedUITextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepresentedUITextViewTests.swift; sourceTree = "<group>"; };
 		8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepresentedUITextViewTestView.swift; sourceTree = "<group>"; };
@@ -143,6 +147,7 @@
 			isa = PBXGroup;
 			children = (
 				75B2366A2A5CB8CE00AEFACE /* BasemapGalleryTests.swift */,
+				8A9845742C3F43EB001CCE22 /* AttachmentCameraControllerTests.swift */,
 				7552A76B2A573DFB0023DA5A /* BookmarksTests.swift */,
 				75B2366E2A5CCADC00AEFACE /* FloorFilterTests.swift */,
 				75022F952A7AC9A0000ED7B7 /* FormViewTests.swift */,
@@ -171,6 +176,7 @@
 				8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */,
 				8AEE70492BEEC18000C9949C /* RepresentedUITextViewTestView.swift */,
 				75B236682A5CB49B00AEFACE /* BasemapGalleryTestView.swift */,
+				8A9845762C3F4447001CCE22 /* AttachmentCameraControllerTestView.swift */,
 				7584B7532B1A798B00772AB7 /* BookmarksTestViews */,
 				75B2366C2A5CC78C00AEFACE /* FloorFilterTestView.swift */,
 			);
@@ -293,6 +299,7 @@
 			files = (
 				7552A7562A573CBB0023DA5A /* Tests.swift in Sources */,
 				7552A7542A573CBB0023DA5A /* TestRunnerApp.swift in Sources */,
+				8A9845772C3F444B001CCE22 /* AttachmentCameraControllerTestView.swift in Sources */,
 				7584B7552B1A79DD00772AB7 /* BookmarksTestViews.swift in Sources */,
 				75B2366D2A5CC78C00AEFACE /* FloorFilterTestView.swift in Sources */,
 				75384C112B2D1BD800D97E6C /* BookmarksTestCase5View.swift in Sources */,
@@ -313,6 +320,7 @@
 			files = (
 				75022F962A7AC9A0000ED7B7 /* FormViewTests.swift in Sources */,
 				75B2366F2A5CCADC00AEFACE /* FloorFilterTests.swift in Sources */,
+				8A9845752C3F43EB001CCE22 /* AttachmentCameraControllerTests.swift in Sources */,
 				75B2366B2A5CB8CE00AEFACE /* BasemapGalleryTests.swift in Sources */,
 				8AEE70482BEEC0B400C9949C /* RepresentedUITextViewTests.swift in Sources */,
 				7552A76C2A573DFB0023DA5A /* BookmarksTests.swift in Sources */,
@@ -460,6 +468,8 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "For component testing.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "For component testing.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -493,6 +503,8 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "For component testing.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "For component testing.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Test Runner/Test Runner/TestViews/AttachmentCameraControllerTestView.swift
+++ b/Test Runner/Test Runner/TestViews/AttachmentCameraControllerTestView.swift
@@ -1,0 +1,42 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+@testable import ArcGISToolkit
+
+import SwiftUI
+
+struct AttachmentCameraControllerTestView: View {
+    @State private var captureMode: UIImagePickerController.CameraCaptureMode?
+    
+    var body: some View {
+        Text(captureMode?.description ?? "None")
+            .accessibilityIdentifier("Camera Capture Mode")
+        AttachmentCameraController(importState: .constant(.none))
+            .onCameraCaptureModeChanged { captureMode in
+                self.captureMode = captureMode
+            }
+    }
+    
+}
+
+extension UIImagePickerController.CameraCaptureMode: @retroactive CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .photo: "Photo"
+        case .video: "Video"
+        @unknown default: "N/A"
+        }
+    }
+}

--- a/Test Runner/Test Runner/Tests.swift
+++ b/Test Runner/Test Runner/Tests.swift
@@ -18,6 +18,7 @@ struct Tests: View {
     var body: some View {
         NavigationStack {
             List {
+                NavigationLink("AttachmentCameraController Tests", destination: AttachmentCameraControllerTestView())
                 NavigationLink("Basemap Gallery Tests", destination: BasemapGalleryTestView())
                 NavigationLink("Bookmarks Tests", destination: BookmarksTestViews())
                 NavigationLink("Feature Form Tests", destination: FeatureFormTestView())

--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -1,0 +1,62 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+final class AttachmentCameraControllerTests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = true
+    }
+    
+    /// Test `AttachmentCameraController.onCameraCaptureModeChanged(perform:)`
+    func testOnCameraCaptureModeChanged() throws {
+#if targetEnvironment(simulator)
+        XCTSkip("This test intended for iOS devices only.")
+#elseif targetEnvironment(macCatalyst)
+        XCTSkip("This test intended for iOS devices only.")
+#endif
+        let app = XCUIApplication()
+        let cameraModeController = app.otherElements["CameraMode"]
+        let cameraModeLabel = app.staticTexts["Camera Capture Mode"]
+        app.launch()
+        
+        addUIInterruptionMonitor(withDescription: "Camera access alert") { (alert) -> Bool in
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        addUIInterruptionMonitor(withDescription: "Microphone access alert") { (alert) -> Bool in
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        
+        let attachmentCameraControllerTestsButton = app.buttons["AttachmentCameraController Tests"]
+        
+        XCTAssertTrue(
+            attachmentCameraControllerTestsButton.exists,
+            "The AttachmentCameraController Tests button wasn't found."
+        )
+        attachmentCameraControllerTestsButton.tap()
+        
+        XCTAssertTrue(
+            cameraModeController.waitForExistence(timeout: 5)
+        )
+        cameraModeController.swipeDown()
+        
+        XCTAssertEqual(cameraModeLabel.label, "Video")
+        
+        cameraModeController.swipeUp()
+        
+        XCTAssertEqual(cameraModeLabel.label, "Photo")
+    }
+}


### PR DESCRIPTION
Apollo 695

If microphone access is denied, videos will be recorded without audio, likely without the user knowing/remembering. This allows us to check the microphone access status when the user switches to video and show an alert if access is denied. 

iOS will only automatically prompt for microphone access the first time after the app is installed.

![IMG_5DBE13DA049E-1](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/c2cadc0e-c31d-4e0a-9ca6-8ef504acdb8a)
