### PR TITLE
Reverse attachment order

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -97,7 +97,8 @@ struct AttachmentsFeatureElementView: View {
             attachmentModelsState = .initializing
             let attachments = (try? await featureElement.featureAttachments) ?? []
             
-            var attachmentModels = attachments
+            let attachmentModels = attachments
+                .reversed()
                 .map {
                     AttachmentModel(
                         attachment: $0,
@@ -105,14 +106,6 @@ struct AttachmentsFeatureElementView: View {
                         thumbnailSize: thumbnailSize
                     )
                 }
-            
-            if !isShowingAttachmentsFormElement {
-                // Reverse attachment models array if we're not displaying
-                // via an AttachmentsFormElement.
-                // This allows attachments in a non-editing context to
-                // display in the same order as the online Map Viewer.
-                attachmentModels = attachmentModels.reversed()
-            }
             attachmentModelsState = .initialized(attachmentModels)
         }
     }

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
@@ -68,7 +68,7 @@ public protocol FeatureAttachment: Loadable {
 
 extension FeatureAttachmentKind {
     /// Creates a feature attachment kind from a popup attachment kind.
-    /// - Parameter kind: The popup attachment kind.
+    /// - Parameter kind: The feature attachment kind.
     init(kind: PopupAttachment.Kind) {
         self = switch kind {
         case .image: .image
@@ -79,8 +79,8 @@ extension FeatureAttachmentKind {
         }
     }
     
-    /// Creates a feature attachment kind from a popup attachment kind.
-    /// - Parameter kind: The popup attachment kind.
+    /// Creates a feature attachment kind from a form attachment kind.
+    /// - Parameter kind: The feature attachment kind.
     init(kind: FormAttachment.Kind) {
         self = switch kind {
         case .other: .other

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
@@ -68,7 +68,7 @@ public protocol FeatureAttachment: Loadable {
 
 extension FeatureAttachmentKind {
     /// Creates a feature attachment kind from a popup attachment kind.
-    /// - Parameter kind: The feature attachment kind.
+    /// - Parameter kind: The popup attachment kind.
     init(kind: PopupAttachment.Kind) {
         self = switch kind {
         case .image: .image
@@ -80,7 +80,7 @@ extension FeatureAttachmentKind {
     }
     
     /// Creates a feature attachment kind from a form attachment kind.
-    /// - Parameter kind: The feature attachment kind.
+    /// - Parameter kind: The form attachment kind.
     init(kind: FormAttachment.Kind) {
         self = switch kind {
         case .other: .other


### PR DESCRIPTION
With the latest change in Core, we now need to reverse the attachment order to display in the correct order. This means that both Popup and FeatureForm attachment arrays get reversed.

Also, a minor doc change.