### PR TITLE
`AttachmentModel` - Auto load local attachments

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentModel.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentModel.swift
@@ -67,12 +67,16 @@ import SwiftUI
         self.name = attachment.name
         self.thumbnailSize = thumbnailSize
         
-        systemImageName = switch attachment.featureAttachmentKind {
-        case .image: "photo"
-        case .video: "film"
-        case .audio: "waveform"
-        case .document: "doc"
-        case .other: "questionmark"
+        if attachment.isLocal {
+            load()
+        } else {
+            systemImageName = switch attachment.featureAttachmentKind {
+            case .image: "photo"
+            case .video: "film"
+            case .audio: "waveform"
+            case .document: "doc"
+            case .other: "questionmark"
+            }
         }
     }
     


### PR DESCRIPTION
`isLocal` doc: A value indicating whether “loading” (fetching the data) can be accomplished without using the network.


<p align="center">
Thumbnails are shown automatically when a form is re-opened and an attachment was previously loaded.
<img src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/7339163e-415f-49fd-8f43-83b9ae4b9526">
</p>
