### PR TITLE
`AttachmentImportMenu` - Adjust padding for Mac Catalyst

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -112,6 +112,7 @@ struct AttachmentImportMenu: View {
         if importState.importInProgress {
             ProgressView()
                 .progressViewStyle(.circular)
+                .catalystPadding(5)
         }
         Menu {
             // Show photo/video and library picker.


### PR DESCRIPTION
| Before | After |
|---|---|
| <img width="124" alt="Screenshot 2024-07-11 at 11 56 12 AM" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/dad19d63-0d7e-4d78-a8a7-8c6a0c4a4f5f"> | <img width="133" alt="Screenshot 2024-07-11 at 11 57 27 AM" src="https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/assets/16397058/6670ac50-9567-4294-abc7-77d7e331f072"> |


