### PR TITLE
Stabilize `AttachmentCameraControllerTests.testOnCameraCaptureModeChanged()`

### DIFF
--- a/Test Runner/Test Runner/TestViews/AttachmentCameraControllerTestView.swift
+++ b/Test Runner/Test Runner/TestViews/AttachmentCameraControllerTestView.swift
@@ -20,6 +20,8 @@ import SwiftUI
 struct AttachmentCameraControllerTestView: View {
     @State private var captureMode: UIImagePickerController.CameraCaptureMode?
     
+    @State private var orientation = UIDeviceOrientation.unknown
+    
     var body: some View {
         Color.clear
             .fullScreenCover(isPresented: .constant(true)) {
@@ -28,10 +30,31 @@ struct AttachmentCameraControllerTestView: View {
                         self.captureMode = captureMode
                     }
                     .overlay {
-                        Text(captureMode?.name ?? "None")
-                            .accessibilityIdentifier("Camera Capture Mode")
+                        VStack {
+                            Text(captureMode?.name ?? "None")
+                                .accessibilityIdentifier("Camera Capture Mode")
+                            Text(orientation.name)
+                                .accessibilityIdentifier("Device Orientation")
+                                .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+                                    orientation = UIDevice.current.orientation
+                                }
+                                .task {
+                                    orientation = UIDevice.current.orientation
+                                }
+                        }
                     }
             }
+    }
+}
+
+extension UIDeviceOrientation {
+    var name: String {
+        switch self {
+        case .portrait: "Portrait"
+        case .landscapeLeft: "Landscape Left"
+        case .landscapeRight: "Landscape Right"
+        default: "Other"
+        }
     }
 }
 

--- a/Test Runner/Test Runner/TestViews/AttachmentCameraControllerTestView.swift
+++ b/Test Runner/Test Runner/TestViews/AttachmentCameraControllerTestView.swift
@@ -21,14 +21,18 @@ struct AttachmentCameraControllerTestView: View {
     @State private var captureMode: UIImagePickerController.CameraCaptureMode?
     
     var body: some View {
-        Text(captureMode?.name ?? "None")
-            .accessibilityIdentifier("Camera Capture Mode")
-        AttachmentCameraController(importState: .constant(.none))
-            .onCameraCaptureModeChanged { captureMode in
-                self.captureMode = captureMode
+        Color.clear
+            .fullScreenCover(isPresented: .constant(true)) {
+                AttachmentCameraController(importState: .constant(.none))
+                    .onCameraCaptureModeChanged { captureMode in
+                        self.captureMode = captureMode
+                    }
+                    .overlay {
+                        Text(captureMode?.name ?? "None")
+                            .accessibilityIdentifier("Camera Capture Mode")
+                    }
             }
     }
-    
 }
 
 extension UIImagePickerController.CameraCaptureMode {

--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -34,6 +34,14 @@ final class AttachmentCameraControllerTests: XCTestCase {
         
         app.launch()
         
+        let attachmentCameraControllerTestsButton = app.buttons["AttachmentCameraController Tests"]
+        
+        XCTAssertTrue(
+            attachmentCameraControllerTestsButton.exists,
+            "The AttachmentCameraController Tests button wasn't found."
+        )
+        attachmentCameraControllerTestsButton.tap()
+        
         addUIInterruptionMonitor(withDescription: "Camera access alert") { (alert) -> Bool in
             alert.buttons["Allow"].tap()
             return true
@@ -42,14 +50,6 @@ final class AttachmentCameraControllerTests: XCTestCase {
             alert.buttons["Allow"].tap()
             return true
         }
-        
-        let attachmentCameraControllerTestsButton = app.buttons["AttachmentCameraController Tests"]
-        
-        XCTAssertTrue(
-            attachmentCameraControllerTestsButton.exists,
-            "The AttachmentCameraController Tests button wasn't found."
-        )
-        attachmentCameraControllerTestsButton.tap()
         
         XCTAssertTrue(
             cameraModeController.waitForExistence(timeout: 5)

--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -29,8 +29,8 @@ final class AttachmentCameraControllerTests: XCTestCase {
         let app = XCUIApplication()
         let cameraModeController = app.otherElements["CameraMode"]
         let cameraModeLabel = app.staticTexts["Camera Capture Mode"]
-        let deviceOrientation = XCUIDevice.shared.orientation
-        let deviceType = UIDevice.current.userInterfaceIdiom
+        let device = UIDevice.current.userInterfaceIdiom
+        let orientation = app.staticTexts["Device Orientation"]
         
         app.launch()
         
@@ -55,21 +55,21 @@ final class AttachmentCameraControllerTests: XCTestCase {
             cameraModeController.waitForExistence(timeout: 5)
         )
         
-        if deviceType == .pad {
+        if device == .pad || (device == .phone && orientation.label == "Landscape Right") {
             cameraModeController.swipeDown()
-        } else if deviceOrientation.isLandscape && deviceType == .phone {
+        } else if orientation.label == "Landscape Left" {
             cameraModeController.swipeUp()
-        } else {
+        } else /* iPhone - portrait */ {
             cameraModeController.swipeRight()
         }
         
         XCTAssertEqual(cameraModeLabel.label, "Video")
         
-        if deviceType == .pad {
+        if device == .pad || (device == .phone && orientation.label == "Landscape Right") {
             cameraModeController.swipeUp()
-        } else if deviceOrientation.isLandscape && deviceType == .phone {
+        } else if orientation.label == "Landscape Left" {
             cameraModeController.swipeDown()
-        } else {
+        } else /* iPhone - portrait */ {
             cameraModeController.swipeLeft()
         }
         

--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -30,6 +30,8 @@ final class AttachmentCameraControllerTests: XCTestCase {
         let cameraModeController = app.otherElements["CameraMode"]
         let cameraModeLabel = app.staticTexts["Camera Capture Mode"]
         let deviceOrientation = XCUIDevice.shared.orientation
+        let deviceType = UIDevice.current.userInterfaceIdiom
+        
         app.launch()
         
         addUIInterruptionMonitor(withDescription: "Camera access alert") { (alert) -> Bool in
@@ -53,18 +55,18 @@ final class AttachmentCameraControllerTests: XCTestCase {
             cameraModeController.waitForExistence(timeout: 5)
         )
         
-        if deviceOrientation.isPortrait {
-            cameraModeController.swipeRight()
+        if deviceOrientation.isLandscape || deviceType == .pad {
+            cameraModeController.swipeUp()
         } else {
-            cameraModeController.swipeDown()
+            cameraModeController.swipeRight()
         }
         
         XCTAssertEqual(cameraModeLabel.label, "Video")
         
-        if deviceOrientation.isPortrait {
-            cameraModeController.swipeLeft()
+        if deviceOrientation.isLandscape || deviceType == .pad {
+            cameraModeController.swipeDown()
         } else {
-            cameraModeController.swipeUp()
+            cameraModeController.swipeLeft()
         }
         
         XCTAssertEqual(cameraModeLabel.label, "Photo")

--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -29,6 +29,7 @@ final class AttachmentCameraControllerTests: XCTestCase {
         let app = XCUIApplication()
         let cameraModeController = app.otherElements["CameraMode"]
         let cameraModeLabel = app.staticTexts["Camera Capture Mode"]
+        let deviceOrientation = XCUIDevice.shared.orientation
         app.launch()
         
         addUIInterruptionMonitor(withDescription: "Camera access alert") { (alert) -> Bool in
@@ -51,11 +52,20 @@ final class AttachmentCameraControllerTests: XCTestCase {
         XCTAssertTrue(
             cameraModeController.waitForExistence(timeout: 5)
         )
-        cameraModeController.swipeDown()
+        
+        if deviceOrientation.isPortrait {
+            cameraModeController.swipeRight()
+        } else {
+            cameraModeController.swipeDown()
+        }
         
         XCTAssertEqual(cameraModeLabel.label, "Video")
         
-        cameraModeController.swipeUp()
+        if deviceOrientation.isPortrait {
+            cameraModeController.swipeLeft()
+        } else {
+            cameraModeController.swipeUp()
+        }
         
         XCTAssertEqual(cameraModeLabel.label, "Photo")
     }

--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -55,7 +55,9 @@ final class AttachmentCameraControllerTests: XCTestCase {
             cameraModeController.waitForExistence(timeout: 5)
         )
         
-        if deviceOrientation.isLandscape || deviceType == .pad {
+        if deviceType == .pad {
+            cameraModeController.swipeDown()
+        } else if deviceOrientation.isLandscape && deviceType == .phone {
             cameraModeController.swipeUp()
         } else {
             cameraModeController.swipeRight()
@@ -63,7 +65,9 @@ final class AttachmentCameraControllerTests: XCTestCase {
         
         XCTAssertEqual(cameraModeLabel.label, "Video")
         
-        if deviceOrientation.isLandscape || deviceType == .pad {
+        if deviceType == .pad {
+            cameraModeController.swipeUp()
+        } else if deviceOrientation.isLandscape && deviceType == .phone {
             cameraModeController.swipeDown()
         } else {
             cameraModeController.swipeLeft()


### PR DESCRIPTION
- Attempts to address the two failures since this test was merged
- Fixes camera view rendering on iPhone in landscape mode