### PR TITLE
Make public types sendable

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -17,6 +17,8 @@ import SwiftUI
 import ArcGIS
 
 /// A scene view that provides an augmented reality fly over experience.
+@MainActor
+@preconcurrency
 public struct FlyoverSceneView: View {
     /// The AR session.
     @StateObject private var session = ObservableARSession()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -18,6 +18,7 @@ import ArcGIS
 
 /// A scene view that provides an augmented reality table top experience.
 @MainActor
+@preconcurrency
 public struct TableTopSceneView: View {
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSwiftUIViewProxy()

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
@@ -56,7 +56,7 @@ import ArcGIS
 @preconcurrency
 public struct BasemapGallery: View {
     /// The view style of the gallery.
-    public enum Style {
+    public enum Style: Sendable {
         /// The `BasemapGallery` will display as a grid when there is an appropriate
         /// width available for the gallery to do so. Otherwise, the gallery will display as a list.
         /// When displayed as a grid, `maxGridItemWidth` sets the maximum width of a grid item.

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -30,6 +30,8 @@ import SwiftUI
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [CompassExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/CompassExampleView.swift)
 /// in the project. To learn more about using the `Compass` see the <doc:CompassTutorial>.
+@MainActor
+@preconcurrency
 public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 public extension FeatureFormView {
     /// The validation error visibility configuration of a form.
-    enum ValidationErrorVisibility {
+    enum ValidationErrorVisibility: Sendable {
         /// Errors may be visible or hidden for a given form field depending on its focus state.
         case automatic
         /// Errors will always be visible for a given form field.

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelDetent.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelDetent.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// A value that represents a height where a sheet naturally rests.
-public enum FloatingPanelDetent: Equatable {
+public enum FloatingPanelDetent: Equatable, Sendable {
     /// A height based upon a fraction of the maximum height.
     case fraction(_ fraction: CGFloat)
     /// The maximum height.

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterAutomaticSelectionMode.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterAutomaticSelectionMode.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Defines automatic selection behavior.
-public enum FloorFilterAutomaticSelectionMode {
+public enum FloorFilterAutomaticSelectionMode: Sendable {
     /// Always update selection based on the current viewpoint; clear the selection when the user
     /// navigates away.
     case always

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterSelection.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterSelection.swift
@@ -15,7 +15,7 @@
 import ArcGIS
 
 ///  A selected site, facility, or level.
-public enum FloorFilterSelection: Hashable {
+public enum FloorFilterSelection: Hashable, Sendable {
     /// A selected site.
     case site(FloorSite)
     /// A selected facility.

--- a/Sources/ArcGISToolkit/Components/JobManager/JobManager.swift
+++ b/Sources/ArcGISToolkit/Components/JobManager/JobManager.swift
@@ -287,7 +287,7 @@ public class JobManager: ObservableObject {
 }
 
 /// An enum that defines a schedule for background status checks.
-public enum BackgroundStatusCheckSchedule {
+public enum BackgroundStatusCheckSchedule: Sendable {
     /// No background status checks will be requested.
     case disabled
     /// Requests that the system schedule a background check at a regular interval.
@@ -300,11 +300,11 @@ extension Logger {
     ///
     /// To enable logging add an environment variable named "LOGGING_FOR_JOB_MANAGER" under Scheme
     /// -> Arguments -> Environment Variables
-    static let jobManager: Logger = {
+    static var jobManager: Logger {
         if ProcessInfo.processInfo.environment.keys.contains("LOGGING_FOR_JOB_MANAGER") {
             return Logger(subsystem: "com.esri.ArcGISToolkit", category: "JobManager")
         } else {
             return Logger(OSLog.disabled)
         }
-    }()
+    }
 }

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
@@ -15,7 +15,7 @@
 import SwiftUI
 
 /// Customizes scalebar appearance and behavior.
-public struct ScalebarSettings {
+public struct ScalebarSettings: Sendable {
     /// Determines if the scalebar should automatically hide/show itself.
     var autoHide: Bool
     

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
-
 /// Visual scalebar styles.
-public enum ScalebarStyle {
+public enum ScalebarStyle: Sendable {
     /// Displays a single unit with segmented bars of alternating fill color.
     case alternatingBar
     

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
@@ -15,7 +15,7 @@
 import ArcGIS
 import Foundation
 
-public enum ScalebarUnits {
+public enum ScalebarUnits: Sendable {
     /// Imperial units (feet, miles, etc)
     case imperial
     

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -17,7 +17,7 @@ import Combine
 import SwiftUI
 
 /// Defines how many results to return; one, many, or automatic based on circumstance.
-public enum SearchResultMode {
+public enum SearchResultMode: Sendable {
     /// Search should always result in at most one result.
     case single
     /// Search should always try to return multiple results.

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceStartingPoint.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceStartingPoint.swift
@@ -16,7 +16,7 @@ import ArcGIS
 import UIKit
 
 /// A starting point of a utility network trace.
-public struct UtilityNetworkTraceStartingPoint {
+public struct UtilityNetworkTraceStartingPoint: Sendable {
     /// The geo element to be used as a starting point.
     var geoElement: GeoElement
     

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFeatureElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFeatureElement.swift
@@ -16,7 +16,7 @@ import ArcGIS
 import Foundation
 
 /// Indicates how to display the attachments.
-public enum AttachmentsFeatureElementDisplayType {
+public enum AttachmentsFeatureElementDisplayType: Sendable {
     /// Show attachments as links.
     case list
     /// Attachments expand to the width of the view.

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
@@ -16,7 +16,7 @@ import ArcGIS
 import UIKit
 
 /// The type of an attachment in a FeatureAttachment.
-public enum FeatureAttachmentKind {
+public enum FeatureAttachmentKind: Sendable {
     /// An attachment of another type.
     case other
     /// An image.

--- a/Sources/ArcGISToolkit/Extensions/OS/Logger.swift
+++ b/Sources/ArcGISToolkit/Extensions/OS/Logger.swift
@@ -18,7 +18,7 @@ internal import os
 
 extension Logger {
     /// A logger for the common `AttachmentsFeatureElementView` view.
-    static let attachmentsFeatureElementView: Logger = {
+    static var attachmentsFeatureElementView: Logger {
         Logger(subsystem: Bundle.toolkitIdentifier, category: "AttachmentsFeatureElementView")
-    }()
+    }
 }

--- a/Sources/ArcGISToolkit/Utility/SearchField.swift
+++ b/Sources/ArcGISToolkit/Utility/SearchField.swift
@@ -16,6 +16,8 @@ import SwiftUI
 
 /// A custom view implementing a SearchField. It contains a search button, text field, delete text button,
 /// and a button to allow users to hide/show the search results list.
+@MainActor
+@preconcurrency
 public struct SearchField: View {
     /// Creates a `SearchField`.
     /// - Parameters:

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -20,6 +20,7 @@ import XCTest
 final class CompassTests: XCTestCase {
     /// Verifies that the compass accurately indicates it shouldn't be hidden when `autoHideDisabled`
     /// is applied.
+    @MainActor
     func testHiddenWithAutoHideOff() {
         let compass1Heading = Double.zero
         let compass1 = Compass(rotation: compass1Heading, mapViewProxy: nil, action: nil)
@@ -38,6 +39,7 @@ final class CompassTests: XCTestCase {
     }
     
     /// Verifies that the compass accurately indicates when it should be hidden.
+    @MainActor
     func testHiddenWithAutoHideOn() {
         let compass1Heading: Double = .zero
         let compass1 = Compass(rotation: compass1Heading, mapViewProxy: nil, action: nil)


### PR DESCRIPTION
This does not include SwiftUI views, which are typically not sendable.