### PR TITLE
`AttachmentPreview` - Apply size based functionality restrictions

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -52,7 +52,7 @@ struct AttachmentImportMenu: View {
     @State private var photoPickerIsPresented = false
     
     /// The maximum attachment size limit.
-    let attachmentSizeLimit = Measurement(
+    let attachmentUploadSizeLimit = Measurement(
         value: 50,
         unit: UnitInformationStorage.megabytes
     )
@@ -146,7 +146,7 @@ struct AttachmentImportMenu: View {
                 value: Double(newAttachmentImportData.data.count),
                 unit: UnitInformationStorage.bytes
             )
-            guard attachmentSize <= attachmentSizeLimit else {
+            guard attachmentSize <= attachmentUploadSizeLimit else {
                 importState = .errored(.sizeLimitExceeded)
                 return
             }
@@ -340,7 +340,7 @@ private extension AttachmentImportMenu {
     /// An error message indicating the selected attachment exceeds the megabyte limit.
     var sizeLimitExceededImportFailureAlertMessage: String {
         .init(
-            localized: "The selected attachment exceeds the \(attachmentSizeLimit.formatted()) limit.",
+            localized: "The selected attachment exceeds the \(attachmentUploadSizeLimit.formatted()) limit.",
             bundle: .toolkitModule,
             comment: "An error message indicating the selected attachment exceeds the megabyte limit."
         )

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -23,6 +23,9 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A label in reference to attachments. */
 "Attachments" = "Attachments";
 
+/* An error message explaining attachments larger than the provided maximum cannot be downloaded. */
+"Attachments larger than %@ cannot be downloaded." = "Attachments larger than %@ cannot be downloaded.";
+
 /* A label in reference to the attributes of a geo element. */
 "Attributes" = "Attributes";
 


### PR DESCRIPTION
Apollo 768 & 786

- Disables the context menu for attachments with size 0 bytes.
- Disables the rename action for attachments over 50 MB.
- Disables downloads of attachments over 50 MB.