### PR TITLE
 `AttachmentsFeatureElementView` - Fix Catalyst audio/video capture

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ExamplesApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = ExamplesApp/Info.plist;
@@ -448,6 +449,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ExamplesApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = ExamplesApp/Info.plist;

--- a/Examples/ExamplesApp/Examples.entitlements
+++ b/Examples/ExamplesApp/Examples.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
@@ -77,15 +77,16 @@ final class CameraControllerCoordinator: NSObject, UIImagePickerControllerDelega
     }
 }
 
+#if !targetEnvironment(macCatalyst) && !targetEnvironment(simulator)
 extension AttachmentCameraController {
     /// Specifies an action to perform when the camera capture mode has changed from photo to video or vice versa.
     /// - Parameter action: The new camera capture mode.
-    @available(macCatalyst, unavailable)
     func onCameraCaptureModeChanged(perform action: @escaping (_: UIImagePickerController.CameraCaptureMode) -> Void) -> Self {
         self.controller.action = action
         return self
     }
 }
+#endif
 
 /// A wrapper around ``UIImagePickerController``.
 ///

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
@@ -80,6 +80,7 @@ final class CameraControllerCoordinator: NSObject, UIImagePickerControllerDelega
 extension AttachmentCameraController {
     /// Specifies an action to perform when the camera capture mode has changed from photo to video or vice versa.
     /// - Parameter action: The new camera capture mode.
+    @available(macCatalyst, unavailable)
     func onCameraCaptureModeChanged(perform action: @escaping (_: UIImagePickerController.CameraCaptureMode) -> Void) -> Self {
         self.controller.action = action
         return self

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -128,7 +128,9 @@ struct AttachmentImportMenu: View {
         }
         .disabled(importState.importInProgress)
         .alert(cameraAccessAlertTitle, isPresented: $cameraAccessAlertIsPresented) {
+#if !targetEnvironment(macCatalyst)
             appSettingsButton
+#endif
             Button(String.cancel, role: .cancel) { }
         } message: {
             Text(cameraAccessAlertMessage)
@@ -205,7 +207,9 @@ struct AttachmentImportMenu: View {
                 }
             }
             .alert(microphoneAccessWarningMessage, isPresented: $microphoneAccessAlertIsVisible) {
+#if !targetEnvironment(macCatalyst)
                 appSettingsButton
+#endif
                 Button(role: .cancel) { } label: {
                     Text(recordVideoOnlyButtonLabel)
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -201,7 +201,7 @@ struct AttachmentImportMenu: View {
             AttachmentCameraController(
                 importState: $importState
             )
-#if !targetEnvironment(macCatalyst)
+#if !targetEnvironment(macCatalyst) && !targetEnvironment(simulator)
             .onCameraCaptureModeChanged { captureMode in
                 if captureMode == .video && AVCaptureDevice.authorizationStatus(for: .audio) == .denied {
                     microphoneAccessAlertIsVisible = true

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -201,15 +201,15 @@ struct AttachmentImportMenu: View {
             AttachmentCameraController(
                 importState: $importState
             )
+#if !targetEnvironment(macCatalyst)
             .onCameraCaptureModeChanged { captureMode in
                 if captureMode == .video && AVCaptureDevice.authorizationStatus(for: .audio) == .denied {
                     microphoneAccessAlertIsVisible = true
                 }
             }
-            .alert(microphoneAccessWarningMessage, isPresented: $microphoneAccessAlertIsVisible) {
-#if !targetEnvironment(macCatalyst)
-                appSettingsButton
 #endif
+            .alert(microphoneAccessWarningMessage, isPresented: $microphoneAccessAlertIsVisible) {
+                appSettingsButton
                 Button(role: .cancel) { } label: {
                     Text(recordVideoOnlyButtonLabel)
                 }


### PR DESCRIPTION
Ref Apollo 778

- Adds audio/camera entitlements for Catalyst for the Examples app.
  - Xcode enables hardened runtime for `macos` when these entitlements are added
- Marks `AttachmentCameraController.onCameraCaptureModeChanged` unavailable for Catalyst as I could not find a suitable NSNotification to detect the audio/video change.
- Disables the app settings buttons for Catalyst as I couldn't find a suitable alternative to `UIApplication.openSettingsURLString`. Instead, the user must open settings manually:

<p align="center">
  <img width="40%" src="https://github.com/user-attachments/assets/8de94014-e31c-47d1-9597-4a313b6abfae">
</p>

