### PR TITLE
`FloorFilter` - Fix unintended `SiteAndFacilitySelector` re-open

### DIFF
--- a/Examples/Examples/FloorFilterExampleView.swift
+++ b/Examples/Examples/FloorFilterExampleView.swift
@@ -76,8 +76,8 @@ struct FloorFilterExampleView: View {
                         maxWidth: 400,
                         maxHeight: 400
                     )
-                    .padding([.horizontal], 10)
-                    .padding([.vertical], 10 + attributionBarHeight)
+                    .padding([.bottom, .leading])
+                    .padding(.bottom, attributionBarHeight)
                 } else if mapLoadError {
                     Label(
                         "Map load error!",

--- a/Examples/Examples/FloorFilterExampleView.swift
+++ b/Examples/Examples/FloorFilterExampleView.swift
@@ -76,8 +76,8 @@ struct FloorFilterExampleView: View {
                         maxWidth: 400,
                         maxHeight: 400
                     )
-                    .padding([.bottom, .leading])
-                    .padding(.bottom, attributionBarHeight)
+                    .padding([.horizontal], 10)
+                    .padding([.vertical], 10 + attributionBarHeight)
                 } else if mapLoadError {
                     Label(
                         "Map load error!",

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -101,7 +101,7 @@ public struct FloorFilter: View {
     @StateObject private var viewModel: FloorFilterViewModel
     
     /// A Boolean value that indicates whether the site and facility selector is presented.
-    @State private var isSitesAndFacilitiesHidden = true
+    @State private var sitesAndFacilitiesArePresented = false
     
     /// The selected site, floor, or level.
     private var selection: Binding<FloorFilterSelection?>?
@@ -119,7 +119,7 @@ public struct FloorFilter: View {
     /// Button to open and close the site and facility selector.
     private var sitesAndFacilitiesButton: some View {
         Button {
-            isSitesAndFacilitiesHidden.toggle()
+            sitesAndFacilitiesArePresented.toggle()
         } label: {
             Image(systemName: "building.2")
                 .padding(.toolkitDefault)
@@ -133,7 +133,7 @@ public struct FloorFilter: View {
         }
     }
     
-    /// A view that displays the level selector and the sites and facilites button.
+    /// A view that displays the level selector and the sites and facilities button.
     private var levelSelectorContainer: some View {
         VStack {
             if isTopAligned {
@@ -185,18 +185,18 @@ public struct FloorFilter: View {
     @ViewBuilder private var siteAndFacilitySelector: some View {
         if horizontalSizeClass == .compact {
             Color.clear
-                .sheet(isPresented: .constant(!$isSitesAndFacilitiesHidden.wrappedValue)) {
-                    SiteAndFacilitySelector(isHidden: $isSitesAndFacilitiesHidden)
+                .sheet(isPresented: $sitesAndFacilitiesArePresented) {
+                    SiteAndFacilitySelector(isPresented: $sitesAndFacilitiesArePresented)
                 }
         } else {
             ZStack {
                 Color.clear
                     .esriBorder()
-                SiteAndFacilitySelector(isHidden: $isSitesAndFacilitiesHidden)
+                SiteAndFacilitySelector(isPresented: $sitesAndFacilitiesArePresented)
                     .padding([.top, .leading, .trailing], 2.5)
                     .padding(.bottom)
             }
-            .opacity(isSitesAndFacilitiesHidden ? .zero : 1)
+            .opacity(sitesAndFacilitiesArePresented ? 1 : .zero)
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -101,7 +101,7 @@ public struct FloorFilter: View {
     @StateObject private var viewModel: FloorFilterViewModel
     
     /// A Boolean value that indicates whether the site and facility selector is presented.
-    @State private var sitesAndFacilitiesArePresented = false
+    @State private var siteAndFacilitySelectorIsPresented = false
     
     /// The selected site, floor, or level.
     private var selection: Binding<FloorFilterSelection?>?
@@ -119,7 +119,7 @@ public struct FloorFilter: View {
     /// Button to open and close the site and facility selector.
     private var sitesAndFacilitiesButton: some View {
         Button {
-            sitesAndFacilitiesArePresented.toggle()
+            siteAndFacilitySelectorIsPresented.toggle()
         } label: {
             Image(systemName: "building.2")
                 .padding(.toolkitDefault)
@@ -185,18 +185,18 @@ public struct FloorFilter: View {
     @ViewBuilder private var siteAndFacilitySelector: some View {
         if horizontalSizeClass == .compact {
             Color.clear
-                .sheet(isPresented: $sitesAndFacilitiesArePresented) {
-                    SiteAndFacilitySelector(isPresented: $sitesAndFacilitiesArePresented)
+                .sheet(isPresented: $siteAndFacilitySelectorIsPresented) {
+                    SiteAndFacilitySelector(isPresented: $siteAndFacilitySelectorIsPresented)
                 }
         } else {
             ZStack {
                 Color.clear
                     .esriBorder()
-                SiteAndFacilitySelector(isPresented: $sitesAndFacilitiesArePresented)
+                SiteAndFacilitySelector(isPresented: $siteAndFacilitySelectorIsPresented)
                     .padding([.top, .leading, .trailing], 2.5)
                     .padding(.bottom)
             }
-            .opacity(sitesAndFacilitiesArePresented ? 1 : .zero)
+            .opacity(siteAndFacilitySelectorIsPresented ? 1 : .zero)
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -18,17 +18,11 @@ import SwiftUI
 /// A view which allows selection of sites and facilities represented in a `FloorManager`.
 @MainActor
 struct SiteAndFacilitySelector: View {
-    /// Creates a `SiteAndFacilitySelector`.
-    /// - Parameter isHidden: A binding used to dismiss the site selector.
-    init(isHidden: Binding<Bool>) {
-        self.isHidden = isHidden
-    }
-    
     /// The view model used by the `SiteAndFacilitySelector`.
     @EnvironmentObject var viewModel: FloorFilterViewModel
     
     /// Allows the user to toggle the visibility of the site and facility selector.
-    private var isHidden: Binding<Bool>
+    @Binding var isPresented: Bool
     
     var body: some View {
         NavigationStack {
@@ -36,13 +30,13 @@ struct SiteAndFacilitySelector: View {
                 // If there's more than one site
                 if viewModel.sites.count > 1 {
                     // Show the list of sites for site selection
-                    SitesList(isHidden: isHidden)
+                    SitesList(isPresented: $isPresented)
                 } else {
                     // Otherwise there're no sites or only one site, show the list of facilities
                     FacilitiesList(
                         usesAllSitesStyling: false,
                         facilities: viewModel.facilities,
-                        isHidden: isHidden
+                        isPresented: $isPresented
                     )
                     .navigationBarBackButtonHidden(true)
                 }
@@ -50,7 +44,7 @@ struct SiteAndFacilitySelector: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    CloseButton { isHidden.wrappedValue.toggle() }
+                    CloseButton { isPresented = false }
                 }
             }
         }
@@ -75,7 +69,7 @@ struct SiteAndFacilitySelector: View {
         @State private var userBackedOutOfSelectedSite = false
         
         /// Allows the user to toggle the visibility of the site and facility selector.
-        var isHidden: Binding<Bool>
+        @Binding var isPresented: Bool
         
         /// A subset of `sites` with names containing `searchPhrase` or all `sites` if
         /// `searchPhrase` is empty.
@@ -133,11 +127,11 @@ struct SiteAndFacilitySelector: View {
                 FacilitiesList(
                     usesAllSitesStyling: true,
                     facilities: viewModel.sites.flatMap(\.facilities),
-                    isHidden: isHidden
+                    isPresented: $isPresented
                 )
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        CloseButton { isHidden.wrappedValue.toggle() }
+                        CloseButton { isPresented = false }
                     }
                 }
             } label: {
@@ -213,7 +207,7 @@ struct SiteAndFacilitySelector: View {
         let facilities: [FloorFacility]
         
         /// Allows the user to toggle the visibility of the site and facility selector.
-        var isHidden: Binding<Bool>
+        @Binding var isPresented: Bool
         
         /// A subset of `facilities` with names containing `searchPhrase` or all
         /// `facilities` if `searchPhrase` is empty.
@@ -298,7 +292,7 @@ struct SiteAndFacilitySelector: View {
                     .onTapGesture {
                         viewModel.setFacility(facility, zoomTo: true)
                         if horizontalSizeClass == .compact {
-                            isHidden.wrappedValue.toggle()
+                            isPresented = false
                         }
                     }
                 }
@@ -340,7 +334,7 @@ extension SiteAndFacilitySelector.SitesList {
         SiteAndFacilitySelector.FacilitiesList(
             usesAllSitesStyling: false,
             facilities: site.facilities,
-            isHidden: isHidden
+            isPresented: $isPresented
         )
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -354,7 +348,7 @@ extension SiteAndFacilitySelector.SitesList {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                CloseButton { isHidden.wrappedValue.toggle() }
+                CloseButton { isPresented = false }
             }
         }
     }


### PR DESCRIPTION
Closes #783

> [!IMPORTANT]  
> Test under `UserInterfaceSizeClass.compact` (e.g. iPhone or iPad in Split View)

How to test:
1. Open the Site and Facility Selector. 
2. **Interactively** dismiss the Site and Facility Selector (e.g. swipe down from the header or empty body area).
3. Pan the map. The Site and Facility Selector does not unexpectedly reappear.

Findings:
The `.constant(!$isSitesAndFacilitiesHidden.wrappedValue)` prevented `isSitesAndFacilitiesHidden` from being set `true` when the sheet was interactively dismissed, causing it to reappear when the view was re-evaluated.