### PR TITLE
Update `AttachmentCameraControllerTests`

### DIFF
--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -35,7 +35,7 @@ final class AttachmentCameraControllerTests: XCTestCase {
         let device = UIDevice.current.userInterfaceIdiom
         let orientation = app.staticTexts["Device Orientation"]
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        let allowButton = springboard.buttons["Allow"]
+        let allowButton = springboard.buttons["OK"]
         
         app.launch()
         


### PR DESCRIPTION
Followup to #821 

On my iPad running 17.6 the button label is "Allow", on the daily iPad running 17.0.2 the label is "OK".