### PR TITLE
Use attribution bar height in remaining examples

### DIFF
--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -25,6 +25,9 @@ struct PopupExampleView: View {
         return Map(item: portalItem)
     }
     
+    /// The height of the map view's attribution bar.
+    @State private var attributionBarHeight: CGFloat = 0
+    
     /// The `Map` displayed in the `MapView`.
     @State private var map = makeMap()
     
@@ -45,6 +48,9 @@ struct PopupExampleView: View {
     var body: some View {
         MapViewReader { proxy in
             MapView(map: map)
+                .onAttributionBarHeightChanged {
+                    attributionBarHeight = $0
+                }
                 .onSingleTapGesture { screenPoint, _ in
                     identifyScreenPoint = screenPoint
                 }
@@ -58,6 +64,7 @@ struct PopupExampleView: View {
                     popup = identifyResult?.popups.first
                 }
                 .floatingPanel(
+                    attributionBarHeight: attributionBarHeight,
                     selectedDetent: $floatingPanelDetent,
                     horizontalAlignment: .leading,
                     isPresented: $showPopup

--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -25,6 +25,9 @@ struct UtilityNetworkTraceExampleView: View {
     /// The current detent of the floating panel presenting the trace tool.
     @State private var activeDetent: FloatingPanelDetent = .half
     
+    /// The height of the map view's attribution bar.
+    @State private var attributionBarHeight: CGFloat = 0
+    
     /// The map with the utility networks.
     @State private var map = makeMap()
     
@@ -48,6 +51,9 @@ struct UtilityNetworkTraceExampleView: View {
                     viewpoint: viewpoint,
                     graphicsOverlays: [resultGraphicsOverlay]
                 )
+                .onAttributionBarHeightChanged {
+                    attributionBarHeight = $0
+                }
                 .onSingleTapGesture { screenPoint, mapPoint in
                     self.screenPoint = screenPoint
                     self.mapPoint = mapPoint
@@ -60,6 +66,7 @@ struct UtilityNetworkTraceExampleView: View {
                     ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(publicSample!)
                 }
                 .floatingPanel(
+                        attributionBarHeight: attributionBarHeight,
                         backgroundColor: Color(uiColor: .systemGroupedBackground),
                         selectedDetent: $activeDetent,
                         horizontalAlignment: .trailing,


### PR DESCRIPTION
Closes #30 

Adds attribution bar height into remaining examples not already using it.