### PR TITLE
Rename `CertificateError.couldNotAccessCertificateFile` to `failedToAccessCertificateFile`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -22,8 +22,8 @@ import UniformTypeIdentifiers
 @MainActor final class CertificatePickerViewModel: ObservableObject {
     /// The types of certificate error.
     enum CertificateError: Error {
-        /// Could not access the certificate file.
-        case couldNotAccessCertificateFile
+        /// Failed to access the certificate file.
+        case failedToAccessCertificateFile
         /// The certificate import error.
         case importError(CertificateImportError)
         // The other error.
@@ -95,7 +95,7 @@ import UniformTypeIdentifiers
                     let credential = try NetworkCredential.certificate(at: certificateURL, password: password)
                     await self.challenge.resume(with: .continueWithCredential(credential))
                 } else {
-                    await self.showCertificateError(.couldNotAccessCertificateFile)
+                    await self.showCertificateError(.failedToAccessCertificateFile)
                 }
             } catch(let certificateImportError as CertificateImportError) {
                 await self.showCertificateError(.importError(certificateImportError))
@@ -144,9 +144,9 @@ extension ArcGIS.CertificateImportError: Foundation.LocalizedError {
 extension CertificatePickerViewModel.CertificateError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case .couldNotAccessCertificateFile:
+        case .failedToAccessCertificateFile:
             return String(
-                localized: "Could not access the certificate file.",
+                localized: "Failed to access the certificate file.",
                 bundle: .toolkitModule,
                 comment: "A label indicating a certificate file was inaccessible."
             )

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -84,9 +84,6 @@ east, etc.). */
 /* A label for a button used to continue the authentication operation. */
 "Continue" = "Continue";
 
-/* A label indicating a certificate file was inaccessible. */
-"Could not access the certificate file." = "Could not access the certificate file.";
-
 /* A warning that the host service (challenge.host) is providing a potentially unsafe certificate. */
 "Dangerous: The certificate provided by '%@' is not signed by a trusted authority." = "Dangerous: The certificate provided by '%@' is not signed by a trusted authority.";
 
@@ -164,6 +161,9 @@ The variable provides additional data. */
 
 /* Text indicating a field's value exceeds the maximum allowed value. */
 "Exceeds maximum value" = "Exceeds maximum value";
+
+/* A label indicating a certificate file was inaccessible. */
+"Failed to access the certificate file." = "Failed to access the certificate file.";
 
 /* A message indicating that the chosen utility network element wasn't able
 to be used as a trace starting point. */

--- a/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
@@ -76,8 +76,8 @@ final class CertificatePickerViewModelTests: XCTestCase {
     }
     
     func testCertificateErrorLocalizedDescription() {
-        let couldNotAccessCertificateFileError = CertificatePickerViewModel.CertificateError.couldNotAccessCertificateFile
-        XCTAssertEqual(couldNotAccessCertificateFileError.localizedDescription, "Could not access the certificate file.")
+        let failedToAccessCertificateFile = CertificatePickerViewModel.CertificateError.failedToAccessCertificateFile
+        XCTAssertEqual(failedToAccessCertificateFile.localizedDescription, "Failed to access the certificate file.")
         
         let importErrorInvalidData = CertificatePickerViewModel.CertificateError.importError(.invalidData)
         XCTAssertEqual(importErrorInvalidData.localizedDescription, "The certificate file was invalid.")


### PR DESCRIPTION
Closes #636 