### PR TITLE
Fix SwiftUI preview strings generating entries in Localizable.strings

### DIFF
--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -154,11 +154,11 @@ extension Carousel {
 
 #Preview("In a List") {
     List {
-        Text("Hello")
+        Text(verbatim: "Hello")
         Carousel { _, _ in
             PreviewContent()
         }
-        Text("World!")
+        Text(verbatim: "World!")
     }
 }
 

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -176,10 +176,12 @@ extension Carousel {
                     self.scrollToLeftAction = scrollToLeftAction
                 }
             }
-            Button("Scroll to 1") {
+            Button {
                 withAnimation {
                     scrollToLeftAction?()
                 }
+            } label: {
+                Text(verbatim: "Scroll to left")
             }
         }
     }

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -47,7 +47,7 @@ extension View {
 
 struct CredentialInputSheetView_Previews: PreviewProvider {
     static var previews: some View {
-        Text(verbatim: "test")
+        Color.clear
             .credentialInput(
                 isPresented: .constant(true),
                 fields: .usernamePassword,

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -47,27 +47,23 @@ extension View {
 
 struct CredentialInputSheetView_Previews: PreviewProvider {
     static var previews: some View {
-        Text(
-            "test",
-            bundle: .toolkitModule,
-            comment: "A label for development purposes only. This is not user visible."
-        )
-        .credentialInput(
-            isPresented: .constant(true),
-            fields: .usernamePassword,
-            message: "You must sign in to access 'arcgis.com'",
-            title: "Authentication Required",
-            cancelAction: .init(
-                title: "Cancel",
-                handler: { _, _ in
-                }
-            ),
-            continueAction: .init(
-                title: "Continue",
-                handler: { username, password in
-                }
+        Text(verbatim: "test")
+            .credentialInput(
+                isPresented: .constant(true),
+                fields: .usernamePassword,
+                message: "You must sign in to access 'arcgis.com'",
+                title: "Authentication Required",
+                cancelAction: .init(
+                    title: "Cancel",
+                    handler: { _, _ in
+                    }
+                ),
+                continueAction: .init(
+                    title: "Continue",
+                    handler: { username, password in
+                    }
+                )
             )
-        )
     }
 }
 


### PR DESCRIPTION
Strings in SwiftUI previews generate entries in Localizable.strings for translation unless we use `Text(verbatim:)`.

I don't believe we need to translate preview strings, as they're essentially developer tooling and not for end-users. If we do, I can close this PR.