### PR TITLE
`FeatureFormExampleView` - `Model.textForState` -> `Model.State.label`

### DIFF
--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -103,7 +103,7 @@ struct FeatureFormExampleView: View {
                         HStack(spacing: 5) {
                             ProgressView()
                                 .progressViewStyle(.circular)
-                            model.textForState
+                            Text(model.state.label)
                         }
                         .padding()
                         .background(.thinMaterial)
@@ -184,6 +184,26 @@ class Model: ObservableObject {
         case idle
         /// The form is being checked for validation errors.
         case validating(FeatureForm)
+        
+        /// User-friendly text that describes this state.
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     /// The current feature form workflow state.
@@ -250,22 +270,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    /// User facing text indicating the current form workflow state.
-    ///
-    /// This is most useful during post form processing to indicate ongoing background work.
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
@@ -34,6 +34,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -92,19 +111,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -55,6 +55,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -113,19 +132,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -71,6 +71,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -129,19 +148,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -85,6 +85,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -143,19 +162,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -91,6 +91,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -149,19 +168,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -115,6 +115,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -173,19 +192,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -124,6 +124,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -182,19 +201,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -132,6 +132,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -190,19 +209,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -84,7 +84,7 @@ struct FeatureFormExampleView: View {
                             HStack(spacing: 5) {
                                 ProgressView()
                                     .progressViewStyle(.circular)
-                                model.textForState
+                                Text(model.state.label)
                             }
                             .padding()
                             .background(.thinMaterial)
@@ -147,6 +147,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -205,19 +224,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep5.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep5.swift
@@ -34,6 +34,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -92,19 +111,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep6.swift
@@ -34,6 +34,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -92,19 +111,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep7.swift
@@ -34,6 +34,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -92,19 +111,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep8.swift
@@ -34,6 +34,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -92,19 +111,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
@@ -34,6 +34,25 @@ class Model: ObservableObject {
         case generalError(FeatureForm, Text)
         case idle
         case validating(FeatureForm)
+        
+        var label: String {
+            switch self {
+            case .applyingEdits:
+                "Applying Edits"
+            case .cancellationPending:
+                "Cancellation Pending"
+            case .editing:
+                "Editing"
+            case .finishingEdits:
+                "Finishing Edits"
+            case .generalError:
+                "Error"
+            case .idle:
+                ""
+            case .validating:
+                "Validating"
+            }
+        }
     }
     
     @Published var state: State = .idle {
@@ -92,19 +111,6 @@ class Model: ObservableObject {
             guard case .idle = self.state else { return true }
             return false
         } set: { _ in
-        }
-    }
-    
-    var textForState: Text {
-        switch state {
-        case .validating:
-            Text("Validating")
-        case .finishingEdits:
-            Text("Finishing edits")
-        case .applyingEdits:
-            Text("Applying edits")
-        default:
-            Text("")
         }
     }
     


### PR DESCRIPTION
As suggested by @rolson

> Consider making this logic an extension on the State type that has something like var label: String
> Then usage is just something like
Text(state.label)