### PR TITLE
`FeatureFormView` & `PopupView` -  Add ability to hide default headers

### DIFF
--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -70,7 +70,6 @@ struct PopupExampleView: View {
                     isPresented: $showPopup
                 ) { [popup] in
                     PopupView(popup: popup!, isPresented: $showPopup)
-                        .showCloseButton(true)
                         .padding()
                 }
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+FormHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+FormHeader.swift
@@ -14,6 +14,7 @@
 
 import SwiftUI
 
+@available(visionOS, unavailable)
 public extension FeatureFormView {
     /// Specifies the visibility of the form header.
     /// - Parameter visibility: The preferred visibility of the form header.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+FormHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+FormHeader.swift
@@ -15,21 +15,12 @@
 import SwiftUI
 
 public extension FeatureFormView {
-    /// The visibility of the form title.
-    /// - Since: 200.6
-    enum TitleVisibility: Sendable {
-        /// The form title is hidden.
-        case hidden
-        /// The form title is visible.
-        case visible
-    }
-    
-    /// Specifies the visibility of the form title.
-    /// - Parameter visibility: The preferred visibility of the form title.
-    /// - Since: 200.6
-    func formTitle(_ visibility: TitleVisibility) -> FeatureFormView {
+    /// Specifies the visibility of the form header.
+    /// - Parameter visibility: The preferred visibility of the form header.
+    /// - Since: 200.7
+    func formHeader(_ visibility: Visibility) -> Self {
         var copy = self
-        copy.titleVisibility = visibility
+        copy.headerVisibility = visibility
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+TitleVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+TitleVisibility.swift
@@ -1,0 +1,34 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+public extension FeatureFormView {
+    /// The visibility of the form title.
+    enum TitleVisibility: Sendable {
+        /// The form title is hidden.
+        case hidden
+        /// The form title is visible.
+        case visible
+    }
+    
+    /// Specifies the visibility of the form title.
+    /// - Parameter visibility: The preferred visibility of the form title.
+    /// - Since: 200.6
+    func formTitle(_ visibility: TitleVisibility) -> FeatureFormView {
+        var copy = self
+        copy.titleVisibility = visibility
+        return copy
+    }
+}

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+TitleVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+TitleVisibility.swift
@@ -16,6 +16,7 @@ import SwiftUI
 
 public extension FeatureFormView {
     /// The visibility of the form title.
+    /// - Since: 200.6
     enum TitleVisibility: Sendable {
         /// The form title is hidden.
         case hidden

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
@@ -26,7 +26,7 @@ public extension FeatureFormView {
     
     /// Specifies the visibility of validation errors in the form.
     /// - Parameter visibility: The preferred visibility of validation errors in the form.
-    func validationErrors(_ visibility: ValidationErrorVisibility) -> FeatureFormView {
+    func validationErrors(_ visibility: ValidationErrorVisibility) -> Self {
         var copy = self
         copy.validationErrorVisibility = visibility
         return copy

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
@@ -26,8 +26,10 @@ public extension FeatureFormView {
     
     /// Specifies the visibility of validation errors in the form.
     /// - Parameter visibility: The preferred visibility of validation errors in the form.
-    func validationErrors(_ visibility: ValidationErrorVisibility) -> some View {
-        environment(\.validationErrorVisibility, visibility)
+    func validationErrors(_ visibility: ValidationErrorVisibility) -> FeatureFormView {
+        var copy = self
+        copy.validationErrorVisibility = visibility
+        return copy
     }
 }
 
@@ -42,6 +44,6 @@ extension EnvironmentValues {
 
 /// The validation error visibility configuration of a form.
 @available(visionOS, unavailable)
-private struct FormViewValidationErrorVisibility: EnvironmentKey {
+struct FormViewValidationErrorVisibility: EnvironmentKey {
     static let defaultValue: FeatureFormView.ValidationErrorVisibility = .automatic
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -76,7 +76,7 @@ public struct FeatureFormView: View {
     /// The title of the feature form view.
     @State private var title = ""
     
-    /// The title visibility configuration of the form.
+    /// The visibility of the form title.
     var titleVisibility: TitleVisibility = .visible
     
     /// The validation error visibility configuration of the form.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -76,6 +76,12 @@ public struct FeatureFormView: View {
     /// The title of the feature form view.
     @State private var title = ""
     
+    /// The title visibility configuration of the form.
+    var titleVisibility: TitleVisibility = .visible
+    
+    /// The validation error visibility configuration of the form.
+    var validationErrorVisibility: ValidationErrorVisibility = FormViewValidationErrorVisibility.defaultValue
+    
     /// Initializes a form view.
     /// - Parameters:
     ///   - featureForm: The feature form defining the editing experience.
@@ -95,7 +101,7 @@ public struct FeatureFormView: View {
         ScrollViewReader { scrollViewProxy in
             ScrollView {
                 VStack(alignment: .leading) {
-                    if !title.isEmpty {
+                    if !title.isEmpty && titleVisibility == .visible {
                         FormHeader(title: title)
                         Divider()
                     }
@@ -123,6 +129,7 @@ public struct FeatureFormView: View {
 #if os(iOS)
         .scrollDismissesKeyboard(.immediately)
 #endif
+        .environment(\.validationErrorVisibility, validationErrorVisibility)
         .environmentObject(model)
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -76,8 +76,8 @@ public struct FeatureFormView: View {
     /// The title of the feature form view.
     @State private var title = ""
     
-    /// The visibility of the form title.
-    var titleVisibility: TitleVisibility = .visible
+    /// The visibility of the form header.
+    var headerVisibility: Visibility = .automatic
     
     /// The validation error visibility configuration of the form.
     var validationErrorVisibility: ValidationErrorVisibility = FormViewValidationErrorVisibility.defaultValue
@@ -101,7 +101,7 @@ public struct FeatureFormView: View {
         ScrollViewReader { scrollViewProxy in
             ScrollView {
                 VStack(alignment: .leading) {
-                    if !title.isEmpty && titleVisibility == .visible {
+                    if !title.isEmpty && headerVisibility != .hidden {
                         FormHeader(title: title)
                         Divider()
                     }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView+PopupHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView+PopupHeader.swift
@@ -1,0 +1,26 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+public extension PopupView {
+    /// Specifies the visibility of the popup header.
+    /// - Parameter visibility: The preferred visibility of the popup header.
+    /// - Since: 200.7
+    func popupHeader(_ visibility: Visibility) -> Self {
+        var copy = self
+        copy.headerVisibility = visibility
+        return copy
+    }
+}

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView+ShowCloseButton.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView+ShowCloseButton.swift
@@ -21,10 +21,12 @@ public extension PopupView /* Deprecated */ {
     /// Defaults to `false`.
     /// - Parameter newShowCloseButton: The new value.
     /// - Returns: A new `PopupView`.
-    @available(*, deprecated, message: "Use 'popupHeader(_:)' instead.")
+    /// - Attention: Deprecated at 200.7. To not show the close button use `PopupView(popup:)`.
+    @available(*, deprecated)
     func showCloseButton(_ newShowCloseButton: Bool) -> Self {
         var copy = self
         copy.showCloseButton = newShowCloseButton
+        copy.showCloseButtonDeprecatedModifierIsApplied = true
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView+ShowCloseButton.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView+ShowCloseButton.swift
@@ -1,0 +1,30 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+public extension PopupView /* Deprecated */ {
+    /// Specifies whether a "close" button should be shown to the right of the popup title. If the "close"
+    /// button is shown, you should pass in the `isPresented` argument to the `PopupView`
+    /// initializer, so that the the "close" button can close the view.
+    /// Defaults to `false`.
+    /// - Parameter newShowCloseButton: The new value.
+    /// - Returns: A new `PopupView`.
+    @available(*, deprecated, message: "Use 'popupHeader(_:)' instead.")
+    func showCloseButton(_ newShowCloseButton: Bool) -> Self {
+        var copy = self
+        copy.showCloseButton = newShowCloseButton
+        return copy
+    }
+}

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -69,6 +69,13 @@ public struct PopupView: View {
     /// so that the the "close" button can close the view.
     var showCloseButton = false
     
+    /// A Boolean value indicating whether the deprecated `PopupView.showCloseButton(_:)`
+    /// modifier is applied.
+    ///
+    /// Once the modifier is removed this property can be removed and the presence or lack of a value for
+    /// `isPresented` should be the sole criteria to show or hide the close button.
+    var showCloseButtonDeprecatedModifierIsApplied = false
+    
     /// The visibility of the popup header.
     var headerVisibility: Visibility = .automatic
     
@@ -88,7 +95,8 @@ public struct PopupView: View {
                             .fontWeight(.bold)
                     }
                     Spacer()
-                    if isPresented != nil {
+                    if (showCloseButtonDeprecatedModifierIsApplied && showCloseButton)
+                        || (!showCloseButtonDeprecatedModifierIsApplied && isPresented != nil) {
                         Button(String.close, systemImage: "xmark") {
                             isPresented?.wrappedValue = false
                         }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -67,7 +67,7 @@ public struct PopupView: View {
     /// A Boolean value specifying whether a "close" button should be shown or not. If the "close"
     /// button is shown, you should pass in the `isPresented` argument to the initializer,
     /// so that the the "close" button can close the view.
-    private var showCloseButton = false
+    var showCloseButton = false
     
     /// The visibility of the popup title.
     private var titleVisibility: TitleVisibility = .visible

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -215,6 +215,15 @@ extension PopupView {
         case visible
     }
     
+    /// Specifies the visibility of the popup title.
+    /// - Parameter visibility: The visibility of the popup title.
+    /// - Since: 200.6
+    public func popupTitle(_ visibility: TitleVisibility) -> Self {
+        var copy = self
+        copy.titleVisibility = visibility
+        return copy
+    }
+    
     /// Specifies whether a "close" button should be shown to the right of the popup title. If the "close"
     /// button is shown, you should pass in the `isPresented` argument to the `PopupView`
     /// initializer, so that the the "close" button can close the view.
@@ -224,15 +233,6 @@ extension PopupView {
     public func showCloseButton(_ newShowCloseButton: Bool) -> Self {
         var copy = self
         copy.showCloseButton = newShowCloseButton
-        return copy
-    }
-    
-    /// Specifies the visibility of the popup title.
-    /// - Parameter visibility: The visibility of the popup title.
-    /// - Since: 200.6
-    public func popupTitle(_ visibility: TitleVisibility) -> Self {
-        var copy = self
-        copy.titleVisibility = visibility
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -69,6 +69,9 @@ public struct PopupView: View {
     /// so that the the "close" button can close the view.
     private var showCloseButton = false
     
+    /// The visibility of the popup title.
+    private var titleVisibility: TitleVisibility = .visible
+    
     /// The result of evaluating the popup expressions.
     @State private var evaluation: Evaluation?
     
@@ -78,7 +81,7 @@ public struct PopupView: View {
     public var body: some View {
         VStack(alignment: .leading) {
             HStack {
-                if !popup.title.isEmpty {
+                if !popup.title.isEmpty && titleVisibility == .visible {
                     Text(popup.title)
                         .font(.title)
                         .fontWeight(.bold)
@@ -203,6 +206,15 @@ extension PopupView {
 }
 
 extension PopupView {
+    /// The visibility of the popup title.
+    /// - Since: 200.6
+    public enum TitleVisibility: Sendable {
+        /// The popup title is hidden.
+        case hidden
+        /// The popup title is visible.
+        case visible
+    }
+    
     /// Specifies whether a "close" button should be shown to the right of the popup title. If the "close"
     /// button is shown, you should pass in the `isPresented` argument to the `PopupView`
     /// initializer, so that the the "close" button can close the view.
@@ -212,6 +224,15 @@ extension PopupView {
     public func showCloseButton(_ newShowCloseButton: Bool) -> Self {
         var copy = self
         copy.showCloseButton = newShowCloseButton
+        return copy
+    }
+    
+    /// Specifies the visibility of the popup title.
+    /// - Parameter visibility: The visibility of the popup title.
+    /// - Since: 200.6
+    public func popupTitle(_ visibility: TitleVisibility) -> Self {
+        var copy = self
+        copy.titleVisibility = visibility
         return copy
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -206,35 +206,3 @@ extension PopupView {
         }
     }
 }
-
-extension PopupView {
-    /// The visibility of the popup title.
-    /// - Since: 200.6
-    public enum TitleVisibility: Sendable {
-        /// The popup title is hidden.
-        case hidden
-        /// The popup title is visible.
-        case visible
-    }
-    
-    /// Specifies the visibility of the popup title.
-    /// - Parameter visibility: The visibility of the popup title.
-    /// - Since: 200.6
-    public func popupTitle(_ visibility: TitleVisibility) -> Self {
-        var copy = self
-        copy.titleVisibility = visibility
-        return copy
-    }
-    
-    /// Specifies whether a "close" button should be shown to the right of the popup title. If the "close"
-    /// button is shown, you should pass in the `isPresented` argument to the `PopupView`
-    /// initializer, so that the the "close" button can close the view.
-    /// Defaults to `false`.
-    /// - Parameter newShowCloseButton: The new value.
-    /// - Returns: A new `PopupView`.
-    public func showCloseButton(_ newShowCloseButton: Bool) -> Self {
-        var copy = self
-        copy.showCloseButton = newShowCloseButton
-        return copy
-    }
-}

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -80,27 +80,29 @@ public struct PopupView: View {
     
     public var body: some View {
         VStack(alignment: .leading) {
-            HStack {
-                if !popup.title.isEmpty && titleVisibility == .visible {
-                    Text(popup.title)
-                        .font(.title)
-                        .fontWeight(.bold)
-                }
-                Spacer()
-                if showCloseButton {
-                    Button(String.close, systemImage: "xmark") {
-                        isPresented?.wrappedValue = false
+            if headerVisibility != .hidden {
+                HStack {
+                    if !popup.title.isEmpty {
+                        Text(popup.title)
+                            .font(.title)
+                            .fontWeight(.bold)
                     }
-                    .labelStyle(.iconOnly)
+                    Spacer()
+                    if showCloseButton && isPresented != nil {
+                        Button(String.close, systemImage: "xmark") {
+                            isPresented?.wrappedValue = false
+                        }
+                        .labelStyle(.iconOnly)
 #if !os(visionOS)
-                    .foregroundColor(.secondary)
-                    .padding([.top, .bottom, .trailing], 4)
-                    .symbolVariant(.circle)
-                    .buttonStyle(.plain)
+                        .foregroundColor(.secondary)
+                        .padding([.top, .bottom, .trailing], 4)
+                        .symbolVariant(.circle)
+                        .buttonStyle(.plain)
 #endif
+                    }
                 }
+                Divider()
             }
-            Divider()
             Group {
                 if let evaluation {
                     if let error = evaluation.error {

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -69,8 +69,8 @@ public struct PopupView: View {
     /// so that the the "close" button can close the view.
     var showCloseButton = false
     
-    /// The visibility of the popup title.
-    private var titleVisibility: TitleVisibility = .visible
+    /// The visibility of the popup header.
+    var headerVisibility: Visibility = .automatic
     
     /// The result of evaluating the popup expressions.
     @State private var evaluation: Evaluation?

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -88,7 +88,7 @@ public struct PopupView: View {
                             .fontWeight(.bold)
                     }
                     Spacer()
-                    if showCloseButton && isPresented != nil {
+                    if isPresented != nil {
                         Button(String.close, systemImage: "xmark") {
                             isPresented?.wrappedValue = false
                         }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
@@ -44,7 +44,6 @@ struct PopupExampleView: View {
                     isPresented: $showPopup
                 ) { [popup] in
                     PopupView(popup: popup!, isPresented: $showPopup)
-                        .showCloseButton(true)
                         .padding()
                 }
         }


### PR DESCRIPTION
Closes #835 

- Adds:
  - `PopupView.popupHeader(_:)`
    - Controls the visibility of the title and close button (visible by default).
  - `FeatureFormView.formHeader(_:)`
    - Controls the visibility of the title (visible by default).
- Deprecates:
  - `PopupView.showCloseButton(_:)`

