### PR TITLE
Offline: Open a preplanned map area

### DIFF
--- a/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
+++ b/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
@@ -19,13 +19,16 @@ import SwiftUI
 @MainActor
 struct OfflineMapAreasExampleView: View {
     /// The map of the Naperville water network.
-    @State private var map = Map(item: PortalItem.naperville())
+    @State private var onlineMap = Map(item: PortalItem.naperville())
+    
+    /// The selected map.
+    @State private var map: Map?
     
     /// A Boolean value indicating whether the offline map ares view should be presented.
     @State private var isShowingOfflineMapAreasView = false
     
     var body: some View {
-        MapView(map: map)
+        MapView(map: map ?? onlineMap)
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button("Offline Maps") {
@@ -34,7 +37,10 @@ struct OfflineMapAreasExampleView: View {
                 }
             }
             .sheet(isPresented: $isShowingOfflineMapAreasView) {
-                OfflineMapAreasView(map: map)
+                OfflineMapAreasView(map: onlineMap)
+                    .onMapSelectionChanged { newMap in
+                        map = newMap
+                    }
             }
     }
 }

--- a/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
+++ b/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
@@ -38,8 +38,8 @@ struct OfflineMapAreasExampleView: View {
             }
             .sheet(isPresented: $isShowingOfflineMapAreasView) {
                 OfflineMapAreasView(
-                    onlineMap: onlineMap,
-                    selectedMap: $selectedMap
+                    online: onlineMap,
+                    selection: $selectedMap
                 )
             }
     }

--- a/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
+++ b/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
@@ -22,13 +22,13 @@ struct OfflineMapAreasExampleView: View {
     @State private var onlineMap = Map(item: PortalItem.naperville())
     
     /// The selected map.
-    @State private var map: Map?
+    @State private var selectedMap: Map?
     
     /// A Boolean value indicating whether the offline map ares view should be presented.
     @State private var isShowingOfflineMapAreasView = false
     
     var body: some View {
-        MapView(map: map ?? onlineMap)
+        MapView(map: selectedMap ?? onlineMap)
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button("Offline Maps") {
@@ -39,7 +39,7 @@ struct OfflineMapAreasExampleView: View {
             .sheet(isPresented: $isShowingOfflineMapAreasView) {
                 OfflineMapAreasView(map: onlineMap)
                     .onMapSelectionChanged { newMap in
-                        map = newMap
+                        selectedMap = newMap
                     }
             }
     }

--- a/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
+++ b/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
@@ -37,10 +37,7 @@ struct OfflineMapAreasExampleView: View {
                 }
             }
             .sheet(isPresented: $isShowingOfflineMapAreasView) {
-                OfflineMapAreasView(
-                    online: onlineMap,
-                    selection: $selectedMap
-                )
+                OfflineMapAreasView(online: onlineMap, selection: $selectedMap)
             }
     }
 }

--- a/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
+++ b/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
@@ -37,10 +37,10 @@ struct OfflineMapAreasExampleView: View {
                 }
             }
             .sheet(isPresented: $isShowingOfflineMapAreasView) {
-                OfflineMapAreasView(map: onlineMap)
-                    .onMapSelectionChanged { newMap in
-                        selectedMap = newMap
-                    }
+                OfflineMapAreasView(
+                    onlineMap: onlineMap,
+                    selectedMap: $selectedMap
+                )
             }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -29,18 +29,18 @@ public struct OfflineMapAreasView: View {
     @State private var isReloadingPreplannedMapAreas = false
     
     /// The currently selected map.
-    private var selectedMap: Binding<Map?>
+    @Binding private var selectedMap: Map?
     
-    /// Creates an `OfflineMapAreasView` with a given web map.
+    /// Creates a view with a given web map.
     /// - Parameters:
-    ///   - onlineMap: The web map.
-    ///   - selectedMap: A binding to the currently selected map.
+    ///   - online: The web map to be taken offline.
+    ///   - selection: A binding to the currently selected map.
     public init(
-        onlineMap: Map,
-        selectedMap: Binding<Map?>
+        online: Map,
+        selection: Binding<Map?>
     ) {
-        _mapViewModel = StateObject(wrappedValue: MapViewModel(map: onlineMap))
-        self.selectedMap = selectedMap
+        _mapViewModel = StateObject(wrappedValue: MapViewModel(map: online))
+        _selectedMap = selection
     }
     
     public var body: some View {
@@ -91,9 +91,8 @@ public struct OfflineMapAreasView: View {
                 List(models) { preplannedMapModel in
                     PreplannedListItemView(
                         model: preplannedMapModel
-                    )
-                    .onMapSelectionChanged { newMap in
-                        selectedMap.wrappedValue = newMap
+                    ) { newMap in
+                        selectedMap = newMap
                         dismiss()
                     }
                 }
@@ -133,13 +132,13 @@ public struct OfflineMapAreasView: View {
         
         var body: some View {
             OfflineMapAreasView(
-                onlineMap: Map(
+                online: Map(
                     item: PortalItem(
                         portal: .arcGISOnline(connection: .anonymous),
                         id: PortalItem.ID("acc027394bc84c2fb04d1ed317aac674")!
                     )
                 ),
-                selectedMap: $map
+                selection: $map
             )
         }
     }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -28,13 +28,19 @@ public struct OfflineMapAreasView: View {
     /// A Boolean value indicating whether the preplanned map areas are being reloaded.
     @State private var isReloadingPreplannedMapAreas = false
     
-    /// The closure to perform when the map selection changes.
-    private var onMapSelectionChanged: ((Map) -> Void)?
+    /// The currently selected map.
+    private var selectedMap: Binding<Map?>
     
     /// Creates an `OfflineMapAreasView` with a given web map.
-    /// - Parameter map: The web map.
-    public init(map: Map) {
-        _mapViewModel = StateObject(wrappedValue: MapViewModel(map: map))
+    /// - Parameters:
+    ///   - onlineMap: The web map.
+    ///   - selectedMap: A binding to the currently selected map.
+    public init(
+        onlineMap: Map,
+        selectedMap: Binding<Map?>
+    ) {
+        _mapViewModel = StateObject(wrappedValue: MapViewModel(map: onlineMap))
+        self.selectedMap = selectedMap
     }
     
     public var body: some View {
@@ -87,7 +93,7 @@ public struct OfflineMapAreasView: View {
                         model: preplannedMapModel
                     )
                     .onMapSelectionChanged { newMap in
-                        onMapSelectionChanged?(newMap)
+                        selectedMap.wrappedValue = newMap
                         dismiss()
                     }
                 }
@@ -118,24 +124,24 @@ public struct OfflineMapAreasView: View {
         }
         .frame(maxWidth: .infinity)
     }
-    
-    /// Sets the closure to call when the map selection changes.
-    public func onMapSelectionChanged(
-        perform action: @escaping (_ newMap: Map) -> Void
-    ) -> Self {
-        var copy = self
-        copy.onMapSelectionChanged = action
-        return copy
-    }
 }
 
 #Preview {
-    OfflineMapAreasView(
-        map: Map(
-            item: PortalItem(
-                portal: .arcGISOnline(connection: .anonymous),
-                id: PortalItem.ID("acc027394bc84c2fb04d1ed317aac674")!
+    @MainActor
+    struct OfflineMapAreasViewPreview: View {
+        @State private var map: Map?
+        
+        var body: some View {
+            OfflineMapAreasView(
+                onlineMap: Map(
+                    item: PortalItem(
+                        portal: .arcGISOnline(connection: .anonymous),
+                        id: PortalItem.ID("acc027394bc84c2fb04d1ed317aac674")!
+                    )
+                ),
+                selectedMap: $map
             )
-        )
-    )
+        }
+    }
+    return OfflineMapAreasViewPreview()
 }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -35,10 +35,7 @@ public struct OfflineMapAreasView: View {
     /// - Parameters:
     ///   - online: The web map to be taken offline.
     ///   - selection: A binding to the currently selected map.
-    public init(
-        online: Map,
-        selection: Binding<Map?>
-    ) {
+    public init(online: Map, selection: Binding<Map?>) {
         _mapViewModel = StateObject(wrappedValue: MapViewModel(map: online))
         _selectedMap = selection
     }
@@ -89,9 +86,7 @@ public struct OfflineMapAreasView: View {
         case .success(let models):
             if !models.isEmpty {
                 List(models) { preplannedMapModel in
-                    PreplannedListItemView(
-                        model: preplannedMapModel
-                    ) { newMap in
+                    PreplannedListItemView(model: preplannedMapModel) { newMap in
                         selectedMap = newMap
                         dismiss()
                     }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -29,7 +29,7 @@ public struct OfflineMapAreasView: View {
     @State private var isReloadingPreplannedMapAreas = false
     
     /// The closure to perform when the map selection changes.
-    public var onMapSelectionChanged: ((Map) -> Void)?
+    private var onMapSelectionChanged: ((Map) -> Void)?
     
     /// Creates an `OfflineMapAreasView` with a given web map.
     /// - Parameter map: The web map.

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -28,6 +28,9 @@ public struct OfflineMapAreasView: View {
     /// A Boolean value indicating whether the preplanned map areas are being reloaded.
     @State private var isReloadingPreplannedMapAreas = false
     
+    /// The closure to perform when the map selection changes.
+    public var onMapSelectionChanged: ((Map) -> Void)?
+    
     /// Creates an `OfflineMapAreasView` with a given web map.
     /// - Parameter map: The web map.
     public init(map: Map) {
@@ -83,6 +86,10 @@ public struct OfflineMapAreasView: View {
                     PreplannedListItemView(
                         model: preplannedMapModel
                     )
+                    .onMapSelectionChanged { newMap in
+                        onMapSelectionChanged?(newMap)
+                        dismiss()
+                    }
                 }
             } else {
                 emptyPreplannedMapAreasView
@@ -110,6 +117,15 @@ public struct OfflineMapAreasView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
+    }
+    
+    /// Sets the closure to call when the map selection changes.
+    public func onMapSelectionChanged(
+        perform action: @escaping (_ newMap: Map) -> Void
+    ) -> Self {
+        var copy = self
+        copy.onMapSelectionChanged = action
+        return copy
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -22,7 +22,7 @@ struct PreplannedListItemView: View {
     @ObservedObject var model: PreplannedMapModel
     
     /// The closure to perform when the map selection changes.
-    let onMapSelectionChanged: ((Map) -> Void)
+    let onMapSelectionChanged: (Map) -> Void
     
     var body: some View {
         HStack(alignment: .center, spacing: 10) {

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -17,7 +17,7 @@ import ArcGIS
 
 @MainActor
 @preconcurrency
-public struct PreplannedListItemView: View {
+struct PreplannedListItemView: View {
     /// The view model for the preplanned map.
     @ObservedObject var model: PreplannedMapModel
     

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -22,7 +22,7 @@ struct PreplannedListItemView: View {
     @ObservedObject var model: PreplannedMapModel
     
     /// The closure to perform when the map selection changes.
-    var onMapSelectionChanged: ((Map) -> Void)?
+    let onMapSelectionChanged: ((Map) -> Void)
     
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
@@ -61,7 +61,7 @@ struct PreplannedListItemView: View {
             Button {
                 Task {
                     if let map = await model.loadMobileMapPackage() {
-                        onMapSelectionChanged?(map)
+                        onMapSelectionChanged(map)
                     }
                 }
             } label: {
@@ -156,6 +156,6 @@ struct PreplannedListItemView: View {
             portalItemID: .init("preview")!,
             preplannedMapAreaID: .init("preview")!
         )
-    )
+    ) { _ in }
     .padding()
 }

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -66,13 +66,11 @@ struct PreplannedListItemView: View {
                 }
             } label: {
                 Text("Open")
-                    .font(.system(.headline, weight: .bold))
-                    .foregroundStyle(Color.accentColor)
-                    .frame(width: 76, height: 32)
-                    .background(Color(.tertiarySystemFill))
-                    .clipShape(.rect(cornerRadius: 16))
+                    .font(.footnote)
+                    .fontWeight(.bold)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.capsule)
         case .downloading:
             if let job = model.job {
                 ProgressView(job.progress)

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -24,7 +24,7 @@ struct PreplannedListItemView: View {
     /// The closure to perform when the map selection changes.
     var onMapSelectionChanged: ((Map) -> Void)?
     
-    public var body: some View {
+    var body: some View {
         HStack(alignment: .center, spacing: 10) {
             thumbnailView
             VStack(alignment: .leading, spacing: 4) {
@@ -133,15 +133,6 @@ struct PreplannedListItemView: View {
         }
         .font(.caption2)
         .foregroundStyle(.tertiary)
-    }
-    
-    /// Sets the closure to call when the map selection changes.
-    public func onMapSelectionChanged(
-        perform action: @escaping (_ newMap: Map) -> Void
-    ) -> Self {
-        var copy = self
-        copy.onMapSelectionChanged = action
-        return copy
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -59,8 +59,7 @@ public struct PreplannedListItemView: View {
         case .downloaded:
             Button {
                 Task {
-                    try await model.mobileMapPackage?.load()
-                    if let map = model.mobileMapPackage?.maps.first {
+                    if let map = await model.loadMobileMapPackage() {
                         onMapSelectionChanged?(map)
                     }
                 }
@@ -111,7 +110,7 @@ public struct PreplannedListItemView: View {
             switch model.status {
             case .notLoaded, .loading:
                 Text("Loading")
-            case .loadFailure:
+            case .loadFailure, .mmpkLoadFailure:
                 Image(systemName: "exclamationmark.circle")
                 Text("Loading failed")
             case .packaging:

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -22,7 +22,7 @@ public struct PreplannedListItemView: View {
     @ObservedObject var model: PreplannedMapModel
     
     /// The closure to perform when the map selection changes.
-    public var onMapSelectionChanged: ((Map) -> Void)?
+    var onMapSelectionChanged: ((Map) -> Void)?
     
     public var body: some View {
         HStack(alignment: .center, spacing: 10) {
@@ -67,10 +67,10 @@ public struct PreplannedListItemView: View {
             } label: {
                 Text("Open")
                     .font(.system(.headline, weight: .bold))
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(Color.accentColor)
                     .frame(width: 76, height: 32)
-                    .background(Color(UIColor.tertiarySystemFill))
-                    .cornerRadius(16)
+                    .background(Color(.tertiarySystemFill))
+                    .clipShape(.rect(cornerRadius: 16))
             }
             .buttonStyle(.plain)
         case .downloading:
@@ -89,7 +89,7 @@ public struct PreplannedListItemView: View {
             }
             .buttonStyle(.plain)
             .disabled(!model.status.allowsDownload)
-            .foregroundColor(.accentColor)
+            .foregroundStyle(Color.accentColor)
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -125,12 +125,14 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     /// Loads the mobile map package and updates the status.
     /// - Returns: The mobile map package map.
     func loadMobileMapPackage() async -> Map? {
+        guard let mobileMapPackage else { return nil }
+        
         do {
-            try await mobileMapPackage?.load()
+            try await mobileMapPackage.load()
         } catch {
             status = .mmpkLoadFailure(error)
         }
-        return mobileMapPackage?.maps.first
+        return mobileMapPackage.maps.first
     }
     
     /// Downloads the preplanned map area.

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -137,6 +137,17 @@ class PreplannedMapModel: ObservableObject, Identifiable {
         return MobileMapPackage.init(fileURL: fileURL)
     }
     
+    /// Loads the mobile map package and updates the status.
+    /// - Returns: The mobile map package map.
+    func loadMobileMapPackage() async -> Map? {
+        do {
+            try await mobileMapPackage?.load()
+        } catch {
+            status = .mmpkLoadFailure(error)
+        }
+        return mobileMapPackage?.maps.first
+    }
+    
     /// Downloads the preplanned map area.
     /// - Precondition: `canDownload`
     func downloadPreplannedMapArea() async {
@@ -201,12 +212,14 @@ extension PreplannedMapModel {
         case downloaded
         /// Preplanned map area failed to download.
         case downloadFailure(Error)
+        /// Downloaded mobile map package failed to load.
+        case mmpkLoadFailure(Error)
         
         /// A Boolean value indicating whether the model is in a state
         /// where it needs to be loaded or reloaded.
         var needsToBeLoaded: Bool {
             switch self {
-            case .loading, .packaging, .packaged, .downloading, .downloaded:
+            case .loading, .packaging, .packaged, .downloading, .downloaded, .mmpkLoadFailure:
                 false
             default:
                 true
@@ -217,7 +230,7 @@ extension PreplannedMapModel {
         var allowsDownload: Bool {
             switch self {
             case .notLoaded, .loading, .loadFailure, .packaging, .packageFailure,
-                    .downloading, .downloaded:
+                    .downloading, .downloaded, .mmpkLoadFailure:
                 false
             case .packaged, .downloadFailure:
                 true

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -226,6 +226,26 @@ extension PreplannedMapModel {
     }
 }
 
+extension PreplannedMapModel.Status: Equatable {
+    static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
+        return switch (lhs, rhs) {
+        case (.notLoaded, .notLoaded),
+            (.loading, .loading),
+            (.loadFailure, .loadFailure),
+            (.packaged, .packaged),
+            (.packaging, .packaging),
+            (.packageFailure, .packageFailure),
+            (.downloading, .downloading),
+            (.downloaded, .downloaded),
+            (.downloadFailure, .downloadFailure),
+            (.mmpkLoadFailure, .mmpkLoadFailure):
+            true
+        default:
+            false
+        }
+    }
+}
+
 private extension PreplannedMapModel.Status {
     init(packagingStatus: PreplannedMapArea.PackagingStatus) {
         self = switch packagingStatus {

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -226,26 +226,6 @@ extension PreplannedMapModel {
     }
 }
 
-extension PreplannedMapModel.Status: Equatable {
-    static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
-        return switch (lhs, rhs) {
-        case (.notLoaded, .notLoaded),
-            (.loading, .loading),
-            (.loadFailure, .loadFailure),
-            (.packaged, .packaged),
-            (.packaging, .packaging),
-            (.packageFailure, .packageFailure),
-            (.downloading, .downloading),
-            (.downloaded, .downloaded),
-            (.downloadFailure, .downloadFailure),
-            (.mmpkLoadFailure, .mmpkLoadFailure):
-            true
-        default:
-            false
-        }
-    }
-}
-
 private extension PreplannedMapModel.Status {
     init(packagingStatus: PreplannedMapArea.PackagingStatus) {
         self = switch packagingStatus {

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelStatusTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelStatusTests.swift
@@ -23,6 +23,7 @@ class PreplannedMapModelStatusTests: XCTestCase {
         XCTAssertFalse(PreplannedMapModel.Status.packaged.needsToBeLoaded)
         XCTAssertFalse(PreplannedMapModel.Status.downloading.needsToBeLoaded)
         XCTAssertFalse(PreplannedMapModel.Status.downloaded.needsToBeLoaded)
+        XCTAssertFalse(PreplannedMapModel.Status.mmpkLoadFailure(NSError()).needsToBeLoaded)
         XCTAssertTrue(PreplannedMapModel.Status.notLoaded.needsToBeLoaded)
         XCTAssertTrue(PreplannedMapModel.Status.downloadFailure(NSError()).needsToBeLoaded)
         XCTAssertTrue(PreplannedMapModel.Status.loadFailure(NSError()).needsToBeLoaded)
@@ -39,5 +40,6 @@ class PreplannedMapModelStatusTests: XCTestCase {
         XCTAssertFalse(PreplannedMapModel.Status.downloading.allowsDownload)
         XCTAssertFalse(PreplannedMapModel.Status.downloaded.allowsDownload)
         XCTAssertTrue(PreplannedMapModel.Status.downloadFailure(NSError()).allowsDownload)
+        XCTAssertFalse(PreplannedMapModel.Status.mmpkLoadFailure(NSError()).allowsDownload)
     }
 }

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelStatusTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelStatusTests.swift
@@ -17,29 +17,31 @@ import ArcGIS
 @testable import ArcGISToolkit
 
 class PreplannedMapModelStatusTests: XCTestCase {
+    private typealias Status = PreplannedMapModel.Status
+    
     func testNeedsToBeLoaded() {
-        XCTAssertFalse(PreplannedMapModel.Status.loading.needsToBeLoaded)
-        XCTAssertFalse(PreplannedMapModel.Status.packaging.needsToBeLoaded)
-        XCTAssertFalse(PreplannedMapModel.Status.packaged.needsToBeLoaded)
-        XCTAssertFalse(PreplannedMapModel.Status.downloading.needsToBeLoaded)
-        XCTAssertFalse(PreplannedMapModel.Status.downloaded.needsToBeLoaded)
-        XCTAssertFalse(PreplannedMapModel.Status.mmpkLoadFailure(NSError()).needsToBeLoaded)
-        XCTAssertTrue(PreplannedMapModel.Status.notLoaded.needsToBeLoaded)
-        XCTAssertTrue(PreplannedMapModel.Status.downloadFailure(NSError()).needsToBeLoaded)
-        XCTAssertTrue(PreplannedMapModel.Status.loadFailure(NSError()).needsToBeLoaded)
-        XCTAssertTrue(PreplannedMapModel.Status.packageFailure.needsToBeLoaded)
+        XCTAssertFalse(Status.loading.needsToBeLoaded)
+        XCTAssertFalse(Status.packaging.needsToBeLoaded)
+        XCTAssertFalse(Status.packaged.needsToBeLoaded)
+        XCTAssertFalse(Status.downloading.needsToBeLoaded)
+        XCTAssertFalse(Status.downloaded.needsToBeLoaded)
+        XCTAssertFalse(Status.mmpkLoadFailure(CancellationError()).needsToBeLoaded)
+        XCTAssertTrue(Status.notLoaded.needsToBeLoaded)
+        XCTAssertTrue(Status.downloadFailure(CancellationError()).needsToBeLoaded)
+        XCTAssertTrue(Status.loadFailure(CancellationError()).needsToBeLoaded)
+        XCTAssertTrue(Status.packageFailure.needsToBeLoaded)
     }
     
     func testAllowsDownload() {
-        XCTAssertFalse(PreplannedMapModel.Status.notLoaded.allowsDownload)
-        XCTAssertFalse(PreplannedMapModel.Status.loading.allowsDownload)
-        XCTAssertFalse(PreplannedMapModel.Status.loadFailure(NSError()).allowsDownload)
-        XCTAssertFalse(PreplannedMapModel.Status.packaging.allowsDownload)
-        XCTAssertTrue(PreplannedMapModel.Status.packaged.allowsDownload)
-        XCTAssertFalse(PreplannedMapModel.Status.packageFailure.allowsDownload)
-        XCTAssertFalse(PreplannedMapModel.Status.downloading.allowsDownload)
-        XCTAssertFalse(PreplannedMapModel.Status.downloaded.allowsDownload)
-        XCTAssertTrue(PreplannedMapModel.Status.downloadFailure(NSError()).allowsDownload)
-        XCTAssertFalse(PreplannedMapModel.Status.mmpkLoadFailure(NSError()).allowsDownload)
+        XCTAssertFalse(Status.notLoaded.allowsDownload)
+        XCTAssertFalse(Status.loading.allowsDownload)
+        XCTAssertFalse(Status.loadFailure(CancellationError()).allowsDownload)
+        XCTAssertFalse(Status.packaging.allowsDownload)
+        XCTAssertTrue(Status.packaged.allowsDownload)
+        XCTAssertFalse(Status.packageFailure.allowsDownload)
+        XCTAssertFalse(Status.downloading.allowsDownload)
+        XCTAssertFalse(Status.downloaded.allowsDownload)
+        XCTAssertTrue(Status.downloadFailure(CancellationError()).allowsDownload)
+        XCTAssertFalse(Status.mmpkLoadFailure(CancellationError()).allowsDownload)
     }
 }

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -310,7 +310,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         await model.load()
         
-        // Start downloading
+        // Start downloading.
         await model.downloadPreplannedMapArea()
         
         // Wait for job to finish.

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -244,7 +244,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         await model.load()
         
-        // Start downloading
+        // Start downloading.
         await model.downloadPreplannedMapArea()
         
         // Wait for job to finish.

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -47,7 +47,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel.makeTest(mapArea: mockArea)
-        model.status.assertExpectedValue(.notLoaded)
+        XCTAssertEqual(model.status, .notLoaded)
     }
     
     @MainActor
@@ -62,7 +62,7 @@ class PreplannedMapModelTests: XCTestCase {
         // When the preplanned map area finishes loading, if its
         // packaging status is `nil`, we consider it as completed.
         await model.load()
-        model.status.assertExpectedValue(.packaged)
+        XCTAssertEqual(model.status, .packaged)
     }
     
     @MainActor
@@ -78,7 +78,7 @@ class PreplannedMapModelTests: XCTestCase {
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel.makeTest(mapArea: mockArea)
         await model.load()
-        model.status.assertExpectedValue(.loadFailure(MappingError.notLoaded(details: "")))
+        XCTAssertEqual(model.status, .loadFailure(MappingError.notLoaded(details: "")))
     }
     
     @MainActor
@@ -98,7 +98,7 @@ class PreplannedMapModelTests: XCTestCase {
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel.makeTest(mapArea: mockArea)
         await model.load()
-        model.status.assertExpectedValue(.packaging)
+        XCTAssertEqual(model.status, .packaging)
     }
     
     @MainActor
@@ -118,7 +118,7 @@ class PreplannedMapModelTests: XCTestCase {
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel.makeTest(mapArea: mockArea)
         await model.load()
-        model.status.assertExpectedValue(.packaged)
+        XCTAssertEqual(model.status, .packaged)
     }
     
     @MainActor
@@ -139,7 +139,7 @@ class PreplannedMapModelTests: XCTestCase {
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel.makeTest(mapArea: mockArea)
         await model.load()
-        model.status.assertExpectedValue(.packageFailure)
+        XCTAssertEqual(model.status, .packageFailure)
     }
     
     @MainActor
@@ -157,7 +157,7 @@ class PreplannedMapModelTests: XCTestCase {
         let mockArea = MockPreplannedMapArea()
         let model = PreplannedMapModel.makeTest(mapArea: mockArea)
         await model.load()
-        model.status.assertExpectedValue(.packageFailure)
+        XCTAssertEqual(model.status, .packageFailure)
     }
     
     /// This tests that the initial status is "downloading" if there is a matching job
@@ -197,7 +197,7 @@ class PreplannedMapModelTests: XCTestCase {
             showsUserNotificationOnCompletion: false
         )
         
-        model.status.assertExpectedValue(.downloading)
+        XCTAssertEqual(model.status, .downloading)
         
         // Cancel the job to be a good citizen.
         await job.cancel()
@@ -270,7 +270,9 @@ class PreplannedMapModelTests: XCTestCase {
         ]
         
         for (status, expected) in zip(statuses, expected) {
-            status.assertExpectedValue(expected)
+            if status != expected {
+                XCTFail("Status '\(status)' does not match expected status of '\(expected)'")
+            }
         }
         
         // Now test that creating a new matching model will have the status set to
@@ -282,7 +284,7 @@ class PreplannedMapModelTests: XCTestCase {
             preplannedMapAreaID: areaID
         )
         
-        model2.status.assertExpectedValue(.downloaded)
+        XCTAssertEqual(model2.status, .downloaded)
     }
     
     @MainActor
@@ -354,35 +356,10 @@ class PreplannedMapModelTests: XCTestCase {
         ]
         
         for (status, expected) in zip(statuses, expected) {
-            status.assertExpectedValue(expected)
+            if status != expected {
+                XCTFail("Status '\(status)' does not match expected status of '\(expected)'")
+            }
         }
-    }
-}
-
-private extension PreplannedMapModel.Status {
-    /// Checks if another value is equivalent to this value ignoring
-    /// any associated values.
-    private func isMatch(for other: Self) -> Bool {
-        return switch (self, other) {
-        case (.notLoaded, .notLoaded),
-            (.loading, .loading),
-            (.loadFailure, .loadFailure),
-            (.packaged, .packaged),
-            (.packaging, .packaging),
-            (.packageFailure, .packageFailure),
-            (.downloading, .downloading),
-            (.downloaded, .downloaded),
-            (.downloadFailure, .downloadFailure),
-            (.mmpkLoadFailure, .mmpkLoadFailure):
-            true
-        default:
-            false
-        }
-    }
-    
-    func assertExpectedValue(_ expected: Self, file: StaticString = #filePath, line: UInt = #line) {
-        guard !isMatch(for: expected) else { return }
-        XCTFail("Status '\(self)' does not match expected status of '\(expected)'", file: file, line: line)
     }
 }
 

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -253,27 +253,11 @@ class PreplannedMapModelTests: XCTestCase {
         // Give the final status some time to be updated.
         try? await Task.sleep(nanoseconds: 1_000_000)
         
-        // Verify statuses
-        let expectedStatusCount = 6
-        guard statuses.count == expectedStatusCount else {
-            XCTFail("Expected a statuses count of \(expectedStatusCount), count is \(statuses.count).")
-            return
-        }
-        
-        let expected: [PreplannedMapModel.Status] = [
-            .notLoaded,
-            .loading,
-            .packaged,
-            .downloading,
-            .downloading,
-            .downloaded
-        ]
-        
-        for (status, expected) in zip(statuses, expected) {
-            if status != expected {
-                XCTFail("Status '\(status)' does not match expected status of '\(expected)'")
-            }
-        }
+        // Verify statuses.
+        XCTAssertEqual(
+            statuses,
+            [.notLoaded, .loading, .packaged, .downloading, .downloading, .downloaded]
+        )
         
         // Now test that creating a new matching model will have the status set to
         // downloaded as there is a mmpk downloaded at the appropriate location.
@@ -339,26 +323,30 @@ class PreplannedMapModelTests: XCTestCase {
         // Give the final status some time to be updated.
         try? await Task.sleep(nanoseconds: 1_000_000)
         
-        // Verify statuses
-        let expectedStatusCount = 6
-        guard statuses.count == expectedStatusCount else {
-            XCTFail("Expected a statuses count of \(expectedStatusCount), count is \(statuses.count).")
-            return
-        }
-        
-        let expected: [PreplannedMapModel.Status] = [
-            .notLoaded,
-            .loading,
-            .packaged,
-            .downloading,
-            .downloading,
-            .downloaded
-        ]
-        
-        for (status, expected) in zip(statuses, expected) {
-            if status != expected {
-                XCTFail("Status '\(status)' does not match expected status of '\(expected)'")
-            }
+        // Verify statuses.
+        XCTAssertEqual(
+            statuses,
+            [.notLoaded, .loading, .packaged, .downloading, .downloading, .downloaded]
+        )
+    }
+}
+
+extension PreplannedMapModel.Status: Equatable {
+    public static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
+        return switch (lhs, rhs) {
+        case (.notLoaded, .notLoaded),
+            (.loading, .loading),
+            (.loadFailure, .loadFailure),
+            (.packaged, .packaged),
+            (.packaging, .packaging),
+            (.packageFailure, .packageFailure),
+            (.downloading, .downloading),
+            (.downloaded, .downloaded),
+            (.downloadFailure, .downloadFailure),
+            (.mmpkLoadFailure, .mmpkLoadFailure):
+            true
+        default:
+            false
         }
     }
 }


### PR DESCRIPTION
Closes `swift/5358`

Adds support to open a downloaded preplanned map area with the "open" button which dismisses the view and returns a `Map` via the `onMapSelectionChanged` view modifier. If the preplanned map area's mobile map package fails to load when opened then the view's status is set to `mmpkLoadFailure`.