### PR TITLE
`Carousel` - Add bottom padding to offset scrollbar

### DIFF
--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -57,6 +57,7 @@ struct Carousel<Content: View>: View {
             ScrollViewReader { scrollViewProxy in
                 ScrollView(.horizontal) {
                     makeCommonScrollViewContent(scrollViewProxy)
+                        .padding(.bottom, 10)
                 }
             }
             .onAppear {
@@ -77,6 +78,7 @@ struct Carousel<Content: View>: View {
 //        ScrollViewReader { scrollViewProxy in
 //            ScrollView(.horizontal) {
 //                makeCommonScrollViewContent(scrollViewProxy)
+//                    .padding(.bottom, 10)
 //            }
 //        }
 //        .onScrollGeometryChange(for: CGFloat.self) { geometry in


### PR DESCRIPTION
Offsets the scrollbar from covering cell bottoms as requested by @rolson

Before

<img width="584" alt="Screenshot 2024-08-22 at 1 21 43 PM" src="https://github.com/user-attachments/assets/4d61cff4-d9b9-451e-8743-0fa350173522">

After
<img width="470" alt="Screenshot 2024-08-22 at 1 21 52 PM" src="https://github.com/user-attachments/assets/08a9be9e-1a8b-4b6a-8ab7-6cae58e4351d">
