### PR TITLE
Remove `swift-markdown` as Test Runner dependency

### DIFF
--- a/Test Runner/Test Runner.xcodeproj/project.pbxproj
+++ b/Test Runner/Test Runner.xcodeproj/project.pbxproj
@@ -27,7 +27,6 @@
 		8A1138132BC7407D007E0BFB /* BookmarksTestCase6View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1138122BC7407D007E0BFB /* BookmarksTestCase6View.swift */; };
 		8A1562F52B86896300000DD6 /* UI Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F42B86896300000DD6 /* UI Tests.xctestplan */; };
 		8A1562F72B86896C00000DD6 /* Unit Tests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8A1562F62B86896C00000DD6 /* Unit Tests.xctestplan */; };
-		8A836B0F2C7D448D004EC961 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 8A836B0E2C7D448D004EC961 /* Markdown */; };
 		8A9845752C3F43EB001CCE22 /* AttachmentCameraControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9845742C3F43EB001CCE22 /* AttachmentCameraControllerTests.swift */; };
 		8A9845772C3F444B001CCE22 /* AttachmentCameraControllerTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9845762C3F4447001CCE22 /* AttachmentCameraControllerTestView.swift */; };
 		8A9F898F2B5B4F0A0027215E /* FeatureFormTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F898E2B5B4F0A0027215E /* FeatureFormTestView.swift */; };
@@ -89,7 +88,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A836B0F2C7D448D004EC961 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -240,7 +238,6 @@
 			);
 			name = UITests;
 			packageProductDependencies = (
-				8A836B0E2C7D448D004EC961 /* Markdown */,
 			);
 			productName = UITests;
 			productReference = 7552A7692A573DFB0023DA5A /* UITests.xctest */;
@@ -275,7 +272,6 @@
 			);
 			mainGroup = 7552A7472A573CBB0023DA5A;
 			packageReferences = (
-				8A836B062C7D4303004EC961 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			productRefGroup = 7552A7512A573CBB0023DA5A /* Products */;
 			projectDirPath = "";
@@ -614,26 +610,10 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		8A836B062C7D4303004EC961 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/swiftlang/swift-markdown.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
 		7552A7752A573E900023DA5A /* ArcGISToolkit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ArcGISToolkit;
-		};
-		8A836B0E2C7D448D004EC961 /* Markdown */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 8A836B062C7D4303004EC961 /* XCRemoteSwiftPackageReference "swift-markdown" */;
-			productName = Markdown;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Test Runner/UI Tests/RepresentedUITextViewTests.swift
+++ b/Test Runner/UI Tests/RepresentedUITextViewTests.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
 import XCTest
 
 final class RepresentedUITextViewTests: XCTestCase {

--- a/Test Runner/UI Tests/RepresentedUITextViewTests.swift
+++ b/Test Runner/UI Tests/RepresentedUITextViewTests.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@testable import ArcGISToolkit
 import SwiftUI
 import XCTest
 


### PR DESCRIPTION
https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/844#discussion_r1735088668