### PR TITLE
Remove extraneous print statements

### DIFF
--- a/Sources/ArcGISToolkit/Utility/AsyncImageViewModel.swift
+++ b/Sources/ArcGISToolkit/Utility/AsyncImageViewModel.swift
@@ -105,11 +105,9 @@ import UIKit
         DispatchQueue.main.async { [weak self] in
             if let image = UIImage(data: data) {
                 self?.result = .success(image)
-                print("image success: \(url.absoluteString)")
             } else {
                 // We have data, but couldn't create an image.
                 self?.result = .failure(LoadImageError())
-                print("image failure: \(url.absoluteString)")
             }
         }
         


### PR DESCRIPTION
Closes #854 

I suspect these were just leftovers from implementation that didn't get pulled out. If not, we can change them to structured log messages instead.