### PR TITLE
Offline: Add support to view downloaded map areas offline

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
@@ -67,7 +67,7 @@ extension OfflineMapAreasView {
             }
         }
         
-        /// Makes offline preplanned map models with infomation from the downloaded mobile map 
+        /// Makes offline preplanned map models with information from the downloaded mobile map
         /// packages for the online map.
         func makeOfflinePreplannedMapModels() async {
             guard let portalItemID else { return }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
@@ -48,6 +48,10 @@ extension OfflineMapAreasView {
         func makePreplannedMapModels() async {
             guard let portalItemID else { return }
             
+            if offlineMapTask.loadStatus == .failed {
+                try? await offlineMapTask.retryLoad()
+            }
+            
             preplannedMapModels = await Result { @MainActor in
                 try await offlineMapTask.preplannedMapAreas
                     .filter { $0.portalItem.id != nil }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
@@ -31,7 +31,7 @@ extension OfflineMapAreasView {
         @Published private(set) var preplannedMapModels: Result<[PreplannedMapModel], Error>?
         
         /// The offline preplanned map information sourced from downloaded mobile map packages.
-        @Published private(set) var offlinePreplannedModels: [PreplannedMapModel]?
+        @Published private(set) var offlinePreplannedMapModels: [PreplannedMapModel]?
         
         init(map: Map) {
             offlineMapTask = OfflineMapTask(onlineMap: map)
@@ -63,7 +63,7 @@ extension OfflineMapAreasView {
             }
         }
         
-        /// Makes offline preplanned map models with infomation from the downloaded mobile map pacakges
+        /// Makes offline preplanned map models with infomation from the downloaded mobile map packages
         /// for the online map.
         func makeOfflinePreplannedMapModels() async {
             guard let portalItemID else { return }
@@ -84,7 +84,7 @@ extension OfflineMapAreasView {
                 }
             }
             
-            offlinePreplannedModels = mapAreas.map { mapArea in
+            offlinePreplannedMapModels = mapAreas.map { mapArea in
                 PreplannedMapModel(
                     offlineMapTask: offlineMapTask,
                     mapArea: mapArea,

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.MapViewModel.swift
@@ -63,8 +63,8 @@ extension OfflineMapAreasView {
             }
         }
         
-        /// Makes offline preplanned map models with infomation from the downloaded mobile map packages
-        /// for the online map.
+        /// Makes offline preplanned map models with infomation from the downloaded mobile map 
+        /// packages for the online map.
         func makeOfflinePreplannedMapModels() async {
             guard let portalItemID else { return }
             
@@ -95,9 +95,6 @@ extension OfflineMapAreasView {
             .sorted(using: KeyPathComparator(\.preplannedMapArea.title))
         }
         
-        /// Creates the offline preplanned map areas by using the preplanned map area IDs found in the
-        /// preplanned map areas directory to create preplanned map models.
-        ///
         /// Creates a preplanned map area using a given portal item and map area ID to search for a corresponding
         /// downloaded mobile map package. If the mobile map package is not found then `nil` is returned.
         /// - Parameters:
@@ -116,10 +113,9 @@ extension OfflineMapAreasView {
             // Make sure the directory is not empty because the directory will exist as soon as the
             // job starts, so if the job fails, it will look like the mmpk was downloaded.
             guard !FileManager.default.isDirectoryEmpty(atPath: fileURL) else { return nil }
-            let mmpk =  MobileMapPackage.init(fileURL: fileURL)
+            let mmpk = MobileMapPackage.init(fileURL: fileURL)
             
             try? await mmpk.load()
-            
             guard let item = mmpk.item else { return nil }
             
             return OfflinePreplannedMapArea(
@@ -134,19 +130,14 @@ extension OfflineMapAreasView {
 
 private struct OfflinePreplannedMapArea: PreplannedMapAreaProtocol {
     var packagingStatus: PreplannedMapArea.PackagingStatus?
-    
     var title: String
-    
     var description: String
-    
     var thumbnail: LoadableImage?
-    
     var id: PortalItem.ID?
     
     func retryLoad() async throws {}
-    
     func makeParameters(using offlineMapTask: OfflineMapTask) async throws -> DownloadPreplannedOfflineMapParameters {
-        DownloadPreplannedOfflineMapParameters()
+        throw CancellationError()
     }
     
     init(

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -63,7 +63,7 @@ public struct OfflineMapAreasView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .refreshable {
-            await mapViewModel.makePreplannedOfflineMapModels()
+            await makePreplannedMapModels()
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -81,13 +81,17 @@ public struct OfflineMapAreasView: View {
                 emptyPreplannedMapAreasView
             }
         case .failure(let error):
-            if let models = mapViewModel.offlinePreplannedMapModels,
-               !models.isEmpty {
-                List(models) { preplannedMapModel in
-                    PreplannedListItemView(model: preplannedMapModel) { newMap in
-                        selectedMap = newMap
-                        dismiss()
+            if error.localizedDescription == "The Internet connection appears to be offline." {
+                if let models = mapViewModel.offlinePreplannedMapModels,
+                   !models.isEmpty {
+                    List(models) { preplannedMapModel in
+                        PreplannedListItemView(model: preplannedMapModel) { newMap in
+                            selectedMap = newMap
+                            dismiss()
+                        }
                     }
+                } else {
+                    emptyOfflinePreplannedMapAreasView
                 }
             } else {
                 VStack(alignment: .center) {
@@ -109,6 +113,17 @@ public struct OfflineMapAreasView: View {
             Text("No offline map areas")
                 .bold()
             Text("You don't have any offline map areas yet.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+    
+    @ViewBuilder private var emptyOfflinePreplannedMapAreasView: some View {
+        VStack(alignment: .center) {
+            Text("No offline map areas")
+                .bold()
+            Text("You don't have any downloaded offline map areas yet.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -49,7 +49,7 @@ public struct OfflineMapAreasView: View {
                 .textCase(nil)
             }
             .task {
-                await mapViewModel.makePreplannedOfflineMapModels()
+               await makePreplannedMapModels()
             }
             .task {
                 await mapViewModel.requestUserNotificationAuthorization()
@@ -81,13 +81,26 @@ public struct OfflineMapAreasView: View {
                 emptyPreplannedMapAreasView
             }
         case .failure(let error):
-            VStack(alignment: .center) {
-                Image(systemName: "exclamationmark.circle")
-                    .imageScale(.large)
-                    .foregroundStyle(.red)
-                Text(error.localizedDescription)
+            if let models = mapViewModel.offlinePreplannedModels,
+               !models.isEmpty {
+                List(models) { preplannedMapModel in
+                    PreplannedListItemView(
+                        model: preplannedMapModel
+                    )
+                    .onMapSelectionChanged { newMap in
+                        onMapSelectionChanged?(newMap)
+                        dismiss()
+                    }
+                }
+            } else {
+                VStack(alignment: .center) {
+                    Image(systemName: "exclamationmark.circle")
+                        .imageScale(.large)
+                        .foregroundStyle(.red)
+                    Text(error.localizedDescription)
+                }
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
         case .none:
             ProgressView()
                 .frame(maxWidth: .infinity)
@@ -103,6 +116,12 @@ public struct OfflineMapAreasView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
+    }
+
+    /// Makes the preplanned map models.
+    private func makePreplannedMapModels() async {
+        await mapViewModel.makePreplannedMapModels()
+        await mapViewModel.makeOfflinePreplannedMapModels()
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -84,11 +84,8 @@ public struct OfflineMapAreasView: View {
             if let models = mapViewModel.offlinePreplannedMapModels,
                !models.isEmpty {
                 List(models) { preplannedMapModel in
-                    PreplannedListItemView(
-                        model: preplannedMapModel
-                    )
-                    .onMapSelectionChanged { newMap in
-                        onMapSelectionChanged?(newMap)
+                    PreplannedListItemView(model: preplannedMapModel) { newMap in
+                        selectedMap = newMap
                         dismiss()
                     }
                 }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -81,7 +81,7 @@ public struct OfflineMapAreasView: View {
                 emptyPreplannedMapAreasView
             }
         case .failure(let error):
-            if let models = mapViewModel.offlinePreplannedModels,
+            if let models = mapViewModel.offlinePreplannedMapModels,
                !models.isEmpty {
                 List(models) { preplannedMapModel in
                     PreplannedListItemView(

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -314,8 +314,23 @@ extension FileManager {
     }
     
     /// The path to the preplanned map areas directory for a specific portal item.
-    /// `Documents/OfflineMapAreas/<Portal Item ID>/Preplanned/<Preplanned Area ID>`
+    /// `Documents/OfflineMapAreas/<Portal Item ID>/Preplanned`
     /// - Parameter portalItemID: The ID of the web map portal item.
+    func preplannedDirectory(
+        forPortalItemID portalItemID: PortalItem.ID
+    ) -> URL {
+        portalItemDirectory(forPortalItemID: portalItemID)
+            .appending(
+                path: Self.preplannedDirectoryPath,
+                directoryHint: .isDirectory
+            )
+    }
+    
+    /// The path to the directory for a specific map area from the preplanned map areas directory for a specific portal item.
+    /// `Documents/OfflineMapAreas/<Portal Item ID>/Preplanned/<Preplanned Area ID>`
+    /// - Parameters:
+    ///   - portalItemID: The ID of the web map portal item.
+    ///   - preplannedMapAreaID: The ID of the preplanned map area.
     func preplannedDirectory(
         forPortalItemID portalItemID: PortalItem.ID,
         preplannedMapAreaID: PortalItem.ID


### PR DESCRIPTION
Closes `swift/5582`

- Adds support to view downloaded preplanned map areas when the device is offline
    - Creates preplanned map models by using downloaded mmpk files for the online map. Although a downloaded map area does not need the offline map task in the PreplannedMapModel, the logic for the downloaded state is needed. An OfflinePreplannedMapModel could be made but a significant portion of the PreplannedMapModel logic would be redundantly copied over. 