### PR TITLE
Improve selection logics

### DIFF
--- a/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
+++ b/OfflineMapAreasExample/OfflineMapAreasExample/OfflineMapAreasExampleView.swift
@@ -27,8 +27,25 @@ struct OfflineMapAreasExampleView: View {
     /// A Boolean value indicating whether the offline map ares view should be presented.
     @State private var isShowingOfflineMapAreasView = false
     
+    /// The height of the map view's attribution bar.
+    @State private var attributionBarHeight = 0.0
+    
     var body: some View {
         MapView(map: selectedMap ?? onlineMap)
+            .onAttributionBarHeightChanged { newHeight in
+                withAnimation { attributionBarHeight = newHeight }
+            }
+            .overlay(alignment: .bottom) {
+                if selectedMap != nil {
+                    Button("Go Online") {
+                        selectedMap = nil
+                    }
+                    .padding()
+                    .background(.regularMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .padding(.vertical, 10 + attributionBarHeight)
+                }
+            }
             .toolbar {
                 ToolbarItem(placement: .bottomBar) {
                     Button("Offline Maps") {

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -88,7 +88,7 @@ public struct OfflineMapAreasView: View {
                 List(models) { preplannedMapModel in
                     PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap) {
                         dismiss()
-                    } onDeletion: { }
+                    }
                 }
             } else {
                 emptyPreplannedMapAreasView

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -86,12 +86,9 @@ public struct OfflineMapAreasView: View {
         case .success(let models):
             if !models.isEmpty {
                 List(models) { preplannedMapModel in
-                    PreplannedListItemView(model: preplannedMapModel) { newMap in
-                        selectedMap = newMap
+                    PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap) {
                         dismiss()
-                    } onDeletion: {
-                        selectedMap = nil
-                    }
+                    } onDeletion: { }
                 }
             } else {
                 emptyPreplannedMapAreasView

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -86,9 +86,10 @@ public struct OfflineMapAreasView: View {
         case .success(let models):
             if !models.isEmpty {
                 List(models) { preplannedMapModel in
-                    PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap) {
-                        dismiss()
-                    }
+                    PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap)
+                        .onChange(of: selectedMap) { _ in
+                            dismiss()
+                        }
                 }
             } else {
                 emptyPreplannedMapAreasView

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -27,9 +27,6 @@ struct PreplannedListItemView: View {
     /// A Boolean value indicating whether the metadata view is presented.
     @State private var metadataViewIsPresented = false
     
-    /// The closure to perform when the map selection changes.
-    let onMapSelectionChanged: () -> Void
-    
     /// A Boolean value indicating whether the selected map area is the same
     /// as the map area from this model.
     var selectedMapFromThisModel: Bool {
@@ -98,7 +95,6 @@ struct PreplannedListItemView: View {
                 Task {
                     if let map = await model.loadMobileMapPackage() {
                         selectedMap = map
-                        onMapSelectionChanged()
                     }
                 }
             } label: {
@@ -193,6 +189,6 @@ struct PreplannedListItemView: View {
             preplannedMapAreaID: .init("preview")!
         ),
         selectedMap: .constant(nil)
-    ) { }
+    )
     .padding()
 }

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -31,7 +31,7 @@ struct PreplannedListItemView: View {
     /// as the map area from this model.
     /// The title of a preplanned map area is guaranteed to be unique when it
     /// is created.
-    var selectedMapFromThisModel: Bool {
+    var isSelected: Bool {
         selectedMap?.item?.title == model.preplannedMapArea.title
     }
     
@@ -82,7 +82,7 @@ struct PreplannedListItemView: View {
     
     @ViewBuilder private var deleteButton: some View {
         if model.status.allowsRemoval,
-           !selectedMapFromThisModel {
+           !isSelected {
             Button("Delete") {
                 model.removeDownloadedPreplannedMapArea()
             }
@@ -106,7 +106,7 @@ struct PreplannedListItemView: View {
             }
             .buttonStyle(.bordered)
             .buttonBorderShape(.capsule)
-            .disabled(selectedMapFromThisModel)
+            .disabled(isSelected)
         case .downloading:
             if let job = model.job {
                 ProgressView(job.progress)

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -29,8 +29,6 @@ struct PreplannedListItemView: View {
     
     /// The closure to perform when the map selection changes.
     let onMapSelectionChanged: () -> Void
-    /// The closure to perform when the map is removed from local disk.
-    let onDeletion: () -> Void
     
     /// A Boolean value indicating whether the selected map area is the same
     /// as the map area from this model.
@@ -88,7 +86,6 @@ struct PreplannedListItemView: View {
            !selectedMapFromThisModel {
             Button("Delete") {
                 model.removeDownloadedPreplannedMapArea()
-                onDeletion()
                 Task {
                     await model.load()
                 }
@@ -199,6 +196,6 @@ struct PreplannedListItemView: View {
             preplannedMapAreaID: .init("preview")!
         ),
         selectedMap: .constant(nil)
-    ) { } onDeletion: { }
+    ) { }
     .padding()
 }

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -29,8 +29,10 @@ struct PreplannedListItemView: View {
     
     /// A Boolean value indicating whether the selected map area is the same
     /// as the map area from this model.
+    /// The title of a preplanned map area is guaranteed to be unique when it
+    /// is created.
     var selectedMapFromThisModel: Bool {
-        selectedMap?.item?.tags.contains(model.preplannedMapAreaID.rawValue) ?? false
+        selectedMap?.item?.title == model.preplannedMapArea.title
     }
     
     var body: some View {
@@ -93,7 +95,7 @@ struct PreplannedListItemView: View {
         case .downloaded:
             Button {
                 Task {
-                    if let map = await model.loadMobileMapPackage() {
+                    if let map = await model.map {
                         selectedMap = map
                     }
                 }

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -22,6 +22,9 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     /// The preplanned map area.
     let preplannedMapArea: any PreplannedMapAreaProtocol
     
+    /// The ID of the preplanned map area.
+    let preplannedMapAreaID: PortalItem.ID
+    
     /// The mobile map package directory URL.
     private let mmpkDirectoryURL: URL
     
@@ -30,9 +33,6 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     
     /// The ID of the web map.
     private let portalItemID: PortalItem.ID
-    
-    /// The ID of the preplanned map area.
-    private let preplannedMapAreaID: PortalItem.ID
     
     /// The mobile map package for the preplanned map area.
     private(set) var mobileMapPackage: MobileMapPackage?
@@ -141,7 +141,14 @@ class PreplannedMapModel: ObservableObject, Identifiable {
         } catch {
             status = .mmpkLoadFailure(error)
         }
-        return mobileMapPackage.maps.first
+        if let map = mobileMapPackage.maps.first {
+            // Add the preplanned map area ID as a tag to differentiate between
+            // local map areas.
+            map.item!.addTag(preplannedMapAreaID.rawValue)
+            return map
+        } else {
+            return nil
+        }
     }
     
     /// Downloads the preplanned map area.

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -49,6 +49,7 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     /// A Boolean value indicating if a user notification should be shown when a job completes.
     let showsUserNotificationOnCompletion: Bool
     
+    /// The first map from the mobile map package.
     var map: Map? { 
         get async {
             if let mobileMapPackage {

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -313,7 +313,7 @@ class PreplannedMapModelTests: XCTestCase {
         _ = await model.job?.result
         
         // Verify that mobile map package can be loaded.
-        let map = await model.loadMobileMapPackage()
+        let map = await model.map
         XCTAssertNotNil(map)
         
         // Give the final status some time to be updated.


### PR DESCRIPTION
## Description

- Related to https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/843#discussion_r1747486303
- Close swift/issues/5968

For this PR, a few things have been done:

1. Test if the mmpk files are locked and cannot be deleted when a map created from it is being viewed
    - The result is that the files can be deleted, while the map being viewed cannot show the tiles beyond current LoD. The features can still be shown
    - Upon discussion, this behavior shouldn't be relied upon. Instead, we should disallow deletion when a map is being viewed.
2. How to go back online?
    - Upon discussion, it is not the component's responsibility to "unselect" a map area and go back to online webmap.
    - Thus, a button is added at the app level to go online to show this workflow.
3. Disallow opening again or deleting the map when it is being viewed.