### PR TITLE
Use replacement document picker method

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/DocumentPickerView.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/DocumentPickerView.swift
@@ -54,8 +54,10 @@ extension DocumentPickerView {
             onCancel()
         }
         
-        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentAt url: URL) {
-            onPickDocument(url)
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let firstURL = urls.first else { return }
+            
+            onPickDocument(firstURL)
         }
     }
 }


### PR DESCRIPTION
Swift issue #6012
This method is [deprecated](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/1618680-documentpicker) on iOS and unavailable on visionOS so we should use the [replacement](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/2902364-documentpicker). 