### PR TITLE
Add visionOS as a supported platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [
         .iOS(.v16),
-        .macCatalyst(.v16)
+        .macCatalyst(.v16),
+        .visionOSV2
     ],
     products: [
         .library(
@@ -59,4 +60,14 @@ for target in package.targets {
         // Upcoming Features.
         .enableUpcomingFeature("DisableOutwardActorInference")
     ]
+}
+
+private extension SupportedPlatform {
+    static var visionOSV2: Self {
+#if swift(>=6)
+        .visionOS(.v2)
+#else
+        .visionOS("2.0.0")
+#endif
+    }
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -21,7 +21,7 @@ import ArcGIS
 @preconcurrency
 @available(visionOS, unavailable)
 public struct FlyoverSceneView: View {
-#if !os(visionOS)
+#if os(iOS)
     /// The AR session.
     @StateObject private var session = ObservableARSession()
 #endif
@@ -137,7 +137,7 @@ public struct FlyoverSceneView: View {
         SceneViewReader { sceneViewProxy in
             sceneViewBuilder(sceneViewProxy)
                 .cameraController(cameraController)
-#if !os(visionOS)
+#if os(iOS)
                 .onAppear {
                     let configuration = ARPositionalTrackingConfiguration()
                     if shouldOrientToCompass {
@@ -166,7 +166,7 @@ public struct FlyoverSceneView: View {
     }
 }
 
-#if !os(visionOS)
+#if os(iOS)
 /// An observable object that wraps an `ARSession` and provides the current frame.
 private class ObservableARSession: NSObject, ObservableObject, ARSessionDelegate {
     /// The backing AR session.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -19,9 +19,12 @@ import ArcGIS
 /// A scene view that provides an augmented reality fly over experience.
 @MainActor
 @preconcurrency
+@available(visionOS, unavailable)
 public struct FlyoverSceneView: View {
+#if !os(visionOS)
     /// The AR session.
     @StateObject private var session = ObservableARSession()
+#endif
     /// The initial camera.
     let initialCamera: Camera
     /// The translation factor.
@@ -134,6 +137,7 @@ public struct FlyoverSceneView: View {
         SceneViewReader { sceneViewProxy in
             sceneViewBuilder(sceneViewProxy)
                 .cameraController(cameraController)
+#if !os(visionOS)
                 .onAppear {
                     let configuration = ARPositionalTrackingConfiguration()
                     if shouldOrientToCompass {
@@ -142,7 +146,7 @@ public struct FlyoverSceneView: View {
                     session.start(configuration: configuration)
                 }
                 .onDisappear { session.pause() }
-                .onChange(of: session.currentFrame) { frame in
+                .onChange(session.currentFrame) { frame in
                     guard let frame, let interfaceOrientation else { return }
                     sceneViewProxy.updateCamera(
                         frame: frame,
@@ -150,10 +154,11 @@ public struct FlyoverSceneView: View {
                         orientation: interfaceOrientation
                     )
                 }
-                .onChange(of: initialCamera) { initialCamera in
+#endif
+                .onChange(initialCamera) { initialCamera in
                     cameraController.originCamera = initialCamera
                 }
-                .onChange(of: translationFactor) { translationFactor in
+                .onChange(translationFactor) { translationFactor in
                     cameraController.translationFactor = translationFactor
                 }
                 .observingInterfaceOrientation($interfaceOrientation)
@@ -161,6 +166,7 @@ public struct FlyoverSceneView: View {
     }
 }
 
+#if !os(visionOS)
 /// An observable object that wraps an `ARSession` and provides the current frame.
 private class ObservableARSession: NSObject, ObservableObject, ARSessionDelegate {
     /// The backing AR session.
@@ -190,3 +196,4 @@ private class ObservableARSession: NSObject, ObservableObject, ARSessionDelegate
         currentFrame = frame
     }
 }
+#endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -21,7 +21,7 @@ import ArcGIS
 @preconcurrency
 @available(visionOS, unavailable)
 public struct TableTopSceneView: View {
-#if !os(visionOS)
+#if os(iOS)
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSwiftUIViewProxy()
 #endif
@@ -39,7 +39,7 @@ public struct TableTopSceneView: View {
     var coachingOverlayIsHidden: Bool = false
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
-#if !os(visionOS)
+#if os(iOS)
     /// The configuration for the AR session.
     private let configuration: ARWorldTrackingConfiguration
 #endif
@@ -81,7 +81,7 @@ public struct TableTopSceneView: View {
         cameraController.clippingDistance = clippingDistance
         _cameraController = .init(initialValue: cameraController)
         
-#if !os(visionOS)
+#if os(iOS)
         configuration = ARWorldTrackingConfiguration()
         configuration.worldAlignment = .gravityAndHeading
         configuration.planeDetection = [.horizontal]
@@ -91,7 +91,7 @@ public struct TableTopSceneView: View {
     public var body: some View {
         SceneViewReader { sceneViewProxy in
             ZStack {
-#if !os(visionOS)
+#if os(iOS)
                 ARSwiftUIView(proxy: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation else { return }
@@ -167,7 +167,7 @@ public struct TableTopSceneView: View {
         .observingInterfaceOrientation($interfaceOrientation)
     }
     
-#if !os(visionOS)
+#if os(iOS)
     /// Visualizes a new node added to the scene as an AR Plane.
     /// - Parameters:
     ///   - renderer: The renderer for the scene.
@@ -239,7 +239,7 @@ public struct TableTopSceneView: View {
     }
 }
 
-#if !os(visionOS)
+#if os(iOS)
 private extension SceneViewProxy {
     /// Sets the initial transformation used to offset the originCamera.  The initial transformation is based on an AR point determined
     /// via existing plane hit detection from `screenPoint`.  If an AR point cannot be determined, this method will return `false`.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -19,9 +19,12 @@ import ArcGIS
 /// A scene view that provides an augmented reality table top experience.
 @MainActor
 @preconcurrency
+@available(visionOS, unavailable)
 public struct TableTopSceneView: View {
+#if !os(visionOS)
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSwiftUIViewProxy()
+#endif
     /// The initial transformation for the scene's camera controller.
     @State private var initialTransformation: TransformationMatrix? = nil
     /// The camera controller that will be set on the scene view.
@@ -36,8 +39,10 @@ public struct TableTopSceneView: View {
     var coachingOverlayIsHidden: Bool = false
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
+#if !os(visionOS)
     /// The configuration for the AR session.
     private let configuration: ARWorldTrackingConfiguration
+#endif
     /// A Boolean value indicating that the scene's initial transformation has been set.
     var initialTransformationIsSet: Bool { initialTransformation != nil }
     /// The anchor point for the scene view.
@@ -76,14 +81,17 @@ public struct TableTopSceneView: View {
         cameraController.clippingDistance = clippingDistance
         _cameraController = .init(initialValue: cameraController)
         
+#if !os(visionOS)
         configuration = ARWorldTrackingConfiguration()
         configuration.worldAlignment = .gravityAndHeading
         configuration.planeDetection = [.horizontal]
+#endif
     }
     
     public var body: some View {
         SceneViewReader { sceneViewProxy in
             ZStack {
+#if !os(visionOS)
                 ARSwiftUIView(proxy: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation else { return }
@@ -138,7 +146,7 @@ public struct TableTopSceneView: View {
                             }
                         }
                 }
-                
+#endif
                 sceneViewBuilder(sceneViewProxy)
                     .cameraController(cameraController)
                     .attributionBarHidden(true)
@@ -147,18 +155,19 @@ public struct TableTopSceneView: View {
                     .opacity(initialTransformationIsSet ? 1 : 0)
             }
         }
-        .onChange(of: anchorPoint) { anchorPoint in
+        .onChange(anchorPoint) { anchorPoint in
             cameraController.originCamera = Camera(location: anchorPoint, heading: 0, pitch: 90, roll: 0)
         }
-        .onChange(of: translationFactor) { translationFactor in
+        .onChange(translationFactor) { translationFactor in
             cameraController.translationFactor = translationFactor
         }
-        .onChange(of: clippingDistance) { clippingDistance in
+        .onChange(clippingDistance) { clippingDistance in
             cameraController.clippingDistance = clippingDistance
         }
         .observingInterfaceOrientation($interfaceOrientation)
     }
     
+#if !os(visionOS)
     /// Visualizes a new node added to the scene as an AR Plane.
     /// - Parameters:
     ///   - renderer: The renderer for the scene.
@@ -218,6 +227,7 @@ public struct TableTopSceneView: View {
             helpText = .planeFound
         }
     }
+#endif
     
     /// Sets the visibility of the coaching overlay view for the AR experince.
     /// - Parameter hidden: A Boolean value that indicates whether to hide the
@@ -229,6 +239,7 @@ public struct TableTopSceneView: View {
     }
 }
 
+#if !os(visionOS)
 private extension SceneViewProxy {
     /// Sets the initial transformation used to offset the originCamera.  The initial transformation is based on an AR point determined
     /// via existing plane hit detection from `screenPoint`.  If an AR point cannot be determined, this method will return `false`.
@@ -250,6 +261,7 @@ private extension SceneViewProxy {
         return initialTransformation
     }
 }
+#endif
 
 private extension String {
     static var planeFound: String {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ARKit
 import SwiftUI
 
@@ -119,3 +120,4 @@ extension ARCoachingOverlay {
         }
     }
 }
+#endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !os(visionOS)
+#if os(iOS)
 import ARKit
 import SwiftUI
 

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 import ARKit
 import SwiftUI
@@ -197,3 +198,4 @@ extension ARSwiftUIViewProxy {
         return raycastMatrix
     }
 }
+#endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !os(visionOS)
+#if os(iOS)
 import ArcGIS
 import ARKit
 import SwiftUI

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
@@ -61,6 +61,7 @@ class WorldScaleCalibrationViewModel: ObservableObject {
     }
 }
 
+@available(visionOS, unavailable)
 extension WorldScaleSceneView {
     /// A view that allows the user to calibrate the heading of the scene view camera controller.
     @MainActor
@@ -179,6 +180,7 @@ extension WorldScaleSceneView {
     }
 }
 
+@available(visionOS, unavailable)
 private extension WorldScaleSceneView.CalibrationView {
     var calibrationLabel: String {
         String(

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -25,7 +25,7 @@ public struct GeoTrackingSceneView: View {
     @Binding var initialCameraIsSet: Bool
     /// The view model for the calibration view.
     @ObservedObject private var calibrationViewModel: WorldScaleCalibrationViewModel
-#if !os(visionOS)
+#if os(iOS)
     /// The geo-tracking configuration for the AR session.
     private let configuration = ARGeoTrackingConfiguration()
 #endif
@@ -35,7 +35,7 @@ public struct GeoTrackingSceneView: View {
     private let locationDataSource: LocationDataSource
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
-#if !os(visionOS)
+#if os(iOS)
     /// The proxy for the ARSwiftUIView.
     private let arViewProxy: ARSwiftUIViewProxy
 #endif
@@ -49,7 +49,7 @@ public struct GeoTrackingSceneView: View {
     @State private var currentLocation: Location?
     /// The current interface orientation.
     @State private var interfaceOrientation: InterfaceOrientation?
-#if !os(visionOS)
+#if os(iOS)
     /// The closure to perform when the camera tracking state changes.
     private var onCameraTrackingStateChangedAction: ((ARCamera.TrackingState) -> Void)?
     /// The closure to perform when the geo tracking status changes.
@@ -92,7 +92,7 @@ public struct GeoTrackingSceneView: View {
     public var body: some View {
         SceneViewReader { sceneViewProxy in
             ZStack {
-#if !os(visionOS)
+#if os(iOS)
                 ARSwiftUIView(proxy: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation, initialCameraIsSet else { return }
@@ -120,7 +120,7 @@ public struct GeoTrackingSceneView: View {
                     .worldScaleSetup(cameraController: cameraController)
                     .opacity(initialCameraIsSet ? 1 : 0)
             }
-#if !os(visionOS)
+#if os(iOS)
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)
@@ -139,7 +139,7 @@ public struct GeoTrackingSceneView: View {
 #endif
         }
         .observingInterfaceOrientation($interfaceOrientation)
-#if !os(visionOS)
+#if os(iOS)
         .onAppear {
             arViewProxy.session.run(configuration)
         }
@@ -178,7 +178,7 @@ public struct GeoTrackingSceneView: View {
         cameraController.transformationMatrix = .identity
     }
     
-#if !os(visionOS)
+#if os(iOS)
     @MainActor
     private func handleGeoTrackingStatusChange(_ status: ARGeoTrackingStatus) {
         switch status.state {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -19,21 +19,26 @@ import ArcGIS
 /// A scene view that provides an augmented reality world scale experience using geo-tracking.
 @MainActor
 @preconcurrency
+@available(visionOS, unavailable)
 public struct GeoTrackingSceneView: View {
     /// A Boolean value indicating if the camera was initially set.
     @Binding var initialCameraIsSet: Bool
     /// The view model for the calibration view.
     @ObservedObject private var calibrationViewModel: WorldScaleCalibrationViewModel
+#if !os(visionOS)
     /// The geo-tracking configuration for the AR session.
     private let configuration = ARGeoTrackingConfiguration()
+#endif
     /// A Boolean value that indicates if the user is calibrating.
     private let calibrationViewIsPresented: Bool
     /// The location datasource that is used to access the device location.
     private let locationDataSource: LocationDataSource
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
+#if !os(visionOS)
     /// The proxy for the ARSwiftUIView.
     private let arViewProxy: ARSwiftUIViewProxy
+#endif
     /// The camera controller that will be set on the scene view.
     private let cameraController: TransformationMatrixCameraController
     /// A Boolean value that indicates whether the coaching overlay view is active.
@@ -44,6 +49,7 @@ public struct GeoTrackingSceneView: View {
     @State private var currentLocation: Location?
     /// The current interface orientation.
     @State private var interfaceOrientation: InterfaceOrientation?
+#if !os(visionOS)
     /// The closure to perform when the camera tracking state changes.
     private var onCameraTrackingStateChangedAction: ((ARCamera.TrackingState) -> Void)?
     /// The closure to perform when the geo tracking status changes.
@@ -81,10 +87,12 @@ public struct GeoTrackingSceneView: View {
         
         sceneViewBuilder = sceneView
     }
+#endif
     
     public var body: some View {
         SceneViewReader { sceneViewProxy in
             ZStack {
+#if !os(visionOS)
                 ARSwiftUIView(proxy: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation, initialCameraIsSet else { return }
@@ -107,10 +115,12 @@ public struct GeoTrackingSceneView: View {
                     .onCameraDidChangeTrackingState { _, trackingState in
                         onCameraTrackingStateChangedAction?(trackingState)
                     }
+#endif
                 sceneViewBuilder(sceneViewProxy)
                     .worldScaleSetup(cameraController: cameraController)
                     .opacity(initialCameraIsSet ? 1 : 0)
             }
+#if !os(visionOS)
             .overlay {
                 ARCoachingOverlay(goal: .geoTracking)
                     .sessionProvider(arViewProxy)
@@ -126,14 +136,17 @@ public struct GeoTrackingSceneView: View {
                     }
                     .allowsHitTesting(false)
             }
+#endif
         }
         .observingInterfaceOrientation($interfaceOrientation)
+#if !os(visionOS)
         .onAppear {
             arViewProxy.session.run(configuration)
         }
         .onDisappear {
             arViewProxy.session.pause()
         }
+#endif
         .task {
             for await location in locationDataSource.locations {
                 currentLocation = location
@@ -165,6 +178,7 @@ public struct GeoTrackingSceneView: View {
         cameraController.transformationMatrix = .identity
     }
     
+#if !os(visionOS)
     @MainActor
     private func handleGeoTrackingStatusChange(_ status: ARGeoTrackingStatus) {
         switch status.state {
@@ -211,4 +225,5 @@ public struct GeoTrackingSceneView: View {
         view.onGeoTrackingStatusChangedAction = action
         return view
     }
+#endif
 }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !os(visionOS)
+#if os(iOS)
 import ARKit
 import SwiftUI
 import ArcGIS

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ARKit
 import SwiftUI
 import ArcGIS
@@ -248,3 +249,4 @@ struct WorldTrackingSceneView: View {
         return view
     }
 }
+#endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -15,10 +15,14 @@
 import ARKit
 import SwiftUI
 import ArcGIS
+#if os(visionOS)
+import CoreLocation
+#endif
 
 /// A scene view that provides an augmented reality world scale experience.
 @MainActor
 @preconcurrency
+@available(visionOS, unavailable)
 public struct WorldScaleSceneView: View {
     /// The clipping distance of the scene view.
     let clippingDistance: Double?
@@ -30,8 +34,10 @@ public struct WorldScaleSceneView: View {
     var calibrationButtonAlignment: Alignment = .bottom
     /// A Boolean value that indicates whether the calibration view is hidden.
     var calibrationViewIsHidden = false
+#if !os(visionOS)
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSwiftUIViewProxy()
+#endif
     /// The view model for the calibration view.
     @StateObject private var calibrationViewModel = WorldScaleCalibrationViewModel()
     /// A Boolean value that indicates whether the geo-tracking configuration is available.
@@ -49,10 +55,11 @@ public struct WorldScaleSceneView: View {
     /// The closure to perform when the `isCalibrating` property has changed.
     private var onCalibratingChangedAction: ((Bool) -> Void)?
     /// The closure to perform when the camera tracking state changes.
+#if !os(visionOS)
     private var onCameraTrackingStateChangedAction: ((ARCamera.TrackingState) -> Void)?
     /// The closure to perform when the geo tracking status changes.
     private var onGeoTrackingStatusChangedAction: ((ARGeoTrackingStatus) -> Void)?
-    
+#endif
     /// Creates a world scale scene view.
     /// - Parameters:
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
@@ -75,6 +82,7 @@ public struct WorldScaleSceneView: View {
     
     public var body: some View {
         Group {
+#if !os(visionOS)
             switch trackingMode {
             case .preferGeoTracking:
                 // By default we try the geo-tracking configuration. If it is not available at
@@ -89,11 +97,12 @@ public struct WorldScaleSceneView: View {
             case .worldTracking:
                 worldTrackingSceneView
             }
+#endif
         }
         .onAppear {
             calibrationViewModel.cameraController.clippingDistance = clippingDistance
         }
-        .onChange(of: clippingDistance) { newClippingDistance in
+        .onChange(clippingDistance) { newClippingDistance in
             calibrationViewModel.cameraController.clippingDistance = newClippingDistance
         }
         .onDisappear {
@@ -117,6 +126,7 @@ public struct WorldScaleSceneView: View {
                 self.error = error
             }
         }
+#if !os(visionOS)
         .task {
             do {
                 geoTrackingIsAvailable = try await checkGeoTrackingAvailability()
@@ -124,6 +134,7 @@ public struct WorldScaleSceneView: View {
                 self.error = error
             }
         }
+#endif
         .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         .overlay(alignment: calibrationButtonAlignment) {
             if !calibrationViewIsHidden && !isCalibrating {
@@ -149,11 +160,12 @@ public struct WorldScaleSceneView: View {
             }
         }
         .animation(.default.speed(0.25), value: initialCameraIsSet)
-        .onChange(of: isCalibrating) { value in
+        .onChange(isCalibrating) { value in
             onCalibratingChangedAction?(value)
         }
     }
     
+#if !os(visionOS)
     /// A world scale geo-tracking scene view.
     @ViewBuilder private var geoTrackingSceneView: some View {
         GeoTrackingSceneView(
@@ -203,6 +215,7 @@ public struct WorldScaleSceneView: View {
         let scenePoint = arScreenToLocation(screenPoint: tapPoint)
         onSingleTapGestureAction?(tapPoint, scenePoint)
     }
+#endif
     
     /// Sets the visibility of the calibration view for the AR experience.
     /// - Parameter hidden: A Boolean value that indicates whether to hide the
@@ -232,7 +245,7 @@ public struct WorldScaleSceneView: View {
         view.onCalibratingChangedAction = action
         return view
     }
-    
+#if !os(visionOS)
     /// Sets a closure to perform when the camera tracking state changes.
     /// - Parameter action: The closure to perform when the camera tracking state has changed.
     public func onCameraTrackingStateChanged(
@@ -256,6 +269,7 @@ public struct WorldScaleSceneView: View {
         view.onGeoTrackingStatusChangedAction = action
         return view
     }
+#endif
     
     /// Checks if GPS is providing the most accurate location and heading.
     /// - Parameter locationManager: The location manager to determine the accuracy authorization.
@@ -273,6 +287,7 @@ public struct WorldScaleSceneView: View {
         return headingAvailable && fullAccuracy
     }
     
+#if !os(visionOS)
     /// Checks if the hardware and the current location supports geo-tracking.
     /// - Returns: A Boolean value that indicates whether geo-tracking is available.
     private func checkGeoTrackingAvailability() async throws -> Bool {
@@ -282,8 +297,10 @@ public struct WorldScaleSceneView: View {
         }
         return try await ARGeoTrackingConfiguration.checkAvailability()
     }
+#endif
 }
 
+@available(visionOS, unavailable)
 public extension WorldScaleSceneView {
     /// The type of tracking configuration used by the view.
     enum TrackingMode {
@@ -296,6 +313,7 @@ public extension WorldScaleSceneView {
     }
 }
 
+#if !os(visionOS)
 private extension ARGeoTrackingConfiguration {
     /// Determines the availability of geo tracking at the current location.
     /// - Returns: A Boolean that indicates whether geo-tracking is available at the current
@@ -313,7 +331,9 @@ private extension ARGeoTrackingConfiguration {
         }
     }
 }
+#endif
 
+@available(visionOS, unavailable)
 private extension WorldScaleSceneView {
     var calibrateLabel: String {
         String(
@@ -326,7 +346,9 @@ private extension WorldScaleSceneView {
     }
 }
 
+@available(visionOS, unavailable)
 public extension WorldScaleSceneView {
+#if !os(visionOS)
     /// Determines the scene point for the given screen point.
     ///
     /// If the raycast fails due to certain reasons, this method returns `nil`.
@@ -340,6 +362,7 @@ public extension WorldScaleSceneView {
         // Create a camera from transformationMatrix and return its location.
         return Camera(transformationMatrix: scenePointMatrix).location
     }
+#endif
     
     /// Sets a closure to perform when a single tap occurs on the view.
     func onSingleTapGesture(

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -15,9 +15,7 @@
 import ARKit
 import SwiftUI
 import ArcGIS
-#if os(visionOS)
 import CoreLocation
-#endif
 
 /// A scene view that provides an augmented reality world scale experience.
 @MainActor
@@ -34,7 +32,7 @@ public struct WorldScaleSceneView: View {
     var calibrationButtonAlignment: Alignment = .bottom
     /// A Boolean value that indicates whether the calibration view is hidden.
     var calibrationViewIsHidden = false
-#if !os(visionOS)
+#if os(iOS)
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSwiftUIViewProxy()
 #endif
@@ -55,7 +53,7 @@ public struct WorldScaleSceneView: View {
     /// The closure to perform when the `isCalibrating` property has changed.
     private var onCalibratingChangedAction: ((Bool) -> Void)?
     /// The closure to perform when the camera tracking state changes.
-#if !os(visionOS)
+#if os(iOS)
     private var onCameraTrackingStateChangedAction: ((ARCamera.TrackingState) -> Void)?
     /// The closure to perform when the geo tracking status changes.
     private var onGeoTrackingStatusChangedAction: ((ARGeoTrackingStatus) -> Void)?
@@ -82,7 +80,7 @@ public struct WorldScaleSceneView: View {
     
     public var body: some View {
         Group {
-#if !os(visionOS)
+#if os(iOS)
             switch trackingMode {
             case .preferGeoTracking:
                 // By default we try the geo-tracking configuration. If it is not available at
@@ -126,7 +124,7 @@ public struct WorldScaleSceneView: View {
                 self.error = error
             }
         }
-#if !os(visionOS)
+#if os(iOS)
         .task {
             do {
                 geoTrackingIsAvailable = try await checkGeoTrackingAvailability()
@@ -165,7 +163,7 @@ public struct WorldScaleSceneView: View {
         }
     }
     
-#if !os(visionOS)
+#if os(iOS)
     /// A world scale geo-tracking scene view.
     @ViewBuilder private var geoTrackingSceneView: some View {
         GeoTrackingSceneView(
@@ -245,7 +243,7 @@ public struct WorldScaleSceneView: View {
         view.onCalibratingChangedAction = action
         return view
     }
-#if !os(visionOS)
+#if os(iOS)
     /// Sets a closure to perform when the camera tracking state changes.
     /// - Parameter action: The closure to perform when the camera tracking state has changed.
     public func onCameraTrackingStateChanged(
@@ -287,7 +285,7 @@ public struct WorldScaleSceneView: View {
         return headingAvailable && fullAccuracy
     }
     
-#if !os(visionOS)
+#if os(iOS)
     /// Checks if the hardware and the current location supports geo-tracking.
     /// - Returns: A Boolean value that indicates whether geo-tracking is available.
     private func checkGeoTrackingAvailability() async throws -> Bool {
@@ -313,7 +311,7 @@ public extension WorldScaleSceneView {
     }
 }
 
-#if !os(visionOS)
+#if os(iOS)
 private extension ARGeoTrackingConfiguration {
     /// Determines the availability of geo tracking at the current location.
     /// - Returns: A Boolean that indicates whether geo-tracking is available at the current
@@ -348,7 +346,7 @@ private extension WorldScaleSceneView {
 
 @available(visionOS, unavailable)
 public extension WorldScaleSceneView {
-#if !os(visionOS)
+#if os(iOS)
     /// Determines the scene point for the given screen point.
     ///
     /// If the raycast fails due to certain reasons, this method returns `nil`.

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -85,7 +85,7 @@ public struct Compass: View {
                 .opacity(opacity)
                 .frame(width: size, height: size)
                 .onAppear { opacity = shouldHide(forHeading: heading) ? 0 : 1 }
-                .onChange(of: heading) { newHeading in
+                .onChange(heading) { newHeading in
                     let newOpacity: Double = shouldHide(forHeading: newHeading) ? .zero : 1
                     guard opacity != newOpacity else { return }
                     withAnimation(.default.delay(shouldHide(forHeading: newHeading) ? 0.25 : 0)) {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -112,3 +113,4 @@ class AttachmentUIImagePickerController: UIImagePickerController {
         }
     }
 }
+#endif

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentCameraController.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !os(visionOS)
+#if os(iOS)
 import SwiftUI
 import UniformTypeIdentifiers
 

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -197,6 +197,7 @@ struct AttachmentImportMenu: View {
                 importState = .errored(.system(error.localizedDescription))
             }
         }
+#if !os(visionOS)
         .fullScreenCover(isPresented: $cameraIsShowing) {
             AttachmentCameraController(
                 importState: $importState
@@ -215,6 +216,7 @@ struct AttachmentImportMenu: View {
                 }
             }
         }
+#endif
         .modifier(
             AttachmentPhotoPicker(
                 importState: $importState,

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -71,6 +71,7 @@ struct AttachmentImportMenu: View {
         }
     }
     
+    @available(visionOS, unavailable)
     private func takePhotoOrVideoButton() -> Button<some View> {
         Button {
             if AVCaptureDevice.authorizationStatus(for: .video) == .authorized {
@@ -117,7 +118,9 @@ struct AttachmentImportMenu: View {
         }
         Menu {
             // Show photo/video and library picker.
+#if !os(visionOS)
             takePhotoOrVideoButton()
+#endif
             chooseFromLibraryButton()
             // Always show file picker, no matter the input type.
             chooseFromFilesButton()

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -200,7 +200,7 @@ struct AttachmentImportMenu: View {
                 importState = .errored(.system(error.localizedDescription))
             }
         }
-#if !os(visionOS)
+#if os(iOS)
         .fullScreenCover(isPresented: $cameraIsShowing) {
             AttachmentCameraController(
                 importState: $importState

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -121,7 +121,7 @@ public struct FeatureFormView: View {
                 title = newTitle
             }
         }
-#if !os(visionOS)
+#if os(iOS)
         .scrollDismissesKeyboard(.immediately)
 #endif
         .environmentObject(model)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -112,7 +112,7 @@ public struct FeatureFormView: View {
                     }
                 }
             }
-            .onChange(of: model.focusedElement) { _ in
+            .onChange(model.focusedElement) { _ in
                 if let focusedElement = model.focusedElement {
                     withAnimation { scrollViewProxy.scrollTo(focusedElement, anchor: .top) }
                 }
@@ -121,7 +121,9 @@ public struct FeatureFormView: View {
                 title = newTitle
             }
         }
+#if !os(visionOS)
         .scrollDismissesKeyboard(.immediately)
+#endif
         .environmentObject(model)
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
@@ -117,7 +117,7 @@ struct ComboBoxInput: View {
             model.focusedElement = element
             isPresented = true
         }
-        .onChange(of: selectedValue) { selectedValue in
+        .onChange(selectedValue) { selectedValue in
             element.updateValue(selectedValue?.code)
             model.evaluateExpressions()
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
@@ -53,10 +53,10 @@ struct DateTimeInput: View {
     
     var body: some View {
         dateEditor
-            .onChange(of: model.focusedElement) { focusedElement in
+            .onChange(model.focusedElement) { focusedElement in
                 isEditing = focusedElement == element
             }
-            .onChange(of: date) { date in
+            .onChange(date) { date in
                 element.updateValue(date)
                 formattedValue = element.formattedValue
                 model.evaluateExpressions()

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
@@ -96,7 +96,7 @@ struct RadioButtonsInput: View {
                     || (input.noValueOption == .hide && !element.formattedValue.isEmpty)
                 }
             }
-            .onChange(of: selectedValue) { selectedValue in
+            .onChange(selectedValue) { selectedValue in
                 element.updateValue(selectedValue?.code)
                 model.evaluateExpressions()
             }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/SwitchInput.swift
@@ -74,7 +74,7 @@ struct SwitchInput: View {
                     fallbackToComboBox = true
                 }
             }
-            .onChange(of: isOn) { isOn in
+            .onChange(isOn) { isOn in
                 element.updateValue(isOn ? input.onValue.code : input.offValue.code)
                 model.evaluateExpressions()
             }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -136,7 +136,23 @@ private extension TextInput {
     /// The keyboard type to use depending on where the input is numeric and decimal.
     var keyboardType: UIKeyboardType {
         guard let fieldType = element.fieldType else { return .default }
-        return fieldType.isNumeric ? (fieldType.isFloatingPoint ? .decimalPad : .numberPad) : .default
+        
+        if fieldType.isNumeric {
+#if os(visionOS)
+            // The 'positiveNegativeButton' doesn't show on visionOS
+            // so we need to show this keyboard so the user can type
+            // a negative number.
+            return .numbersAndPunctuation
+#else
+            if fieldType.isFloatingPoint {
+                return .decimalPad
+            } else {
+                return .numberPad
+            }
+#endif
+        } else {
+            return .default
+        }
     }
     
     /// The button that allows a user to switch the numeric value between positive and negative.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -106,14 +106,16 @@ private extension TextInput {
             }
             .focused($isFocused)
             .frame(maxWidth: .infinity, alignment: .leading)
+#if !os(visionOS)
             .toolbar {
-                ToolbarItemGroup(placement: keyboardOrBottomOrnament) {
+                ToolbarItemGroup(placement: .keyboard) {
                     if UIDevice.current.userInterfaceIdiom == .phone, isFocused, (element.fieldType?.isNumeric ?? false) {
                         positiveNegativeButton
                         Spacer()
                     }
                 }
             }
+#endif
             .scrollContentBackground(.hidden)
             if !text.isEmpty {
                 ClearButton {
@@ -129,16 +131,6 @@ private extension TextInput {
             }
         }
         .formInputStyle()
-    }
-    
-    /// A toolbar item placement that will either be on the keyboard or bottom
-    /// ornament depending on the platform.
-    private var keyboardOrBottomOrnament: ToolbarItemPlacement {
-#if !os(visionOS)
-        .keyboard
-#else
-        .bottomOrnament
-#endif
     }
     
     /// The keyboard type to use depending on where the input is numeric and decimal.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -106,7 +106,7 @@ private extension TextInput {
             }
             .focused($isFocused)
             .frame(maxWidth: .infinity, alignment: .leading)
-#if !os(visionOS)
+#if os(iOS)
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
                     if UIDevice.current.userInterfaceIdiom == .phone, isFocused, (element.fieldType?.isNumeric ?? false) {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -46,20 +46,20 @@ struct TextInput: View {
     
     var body: some View {
         textWriter
-            .onChange(of: isFocused) { isFocused in
+            .onChange(isFocused) { isFocused in
                 if isFocused {
                     model.focusedElement = element
                 } else if model.focusedElement == element {
                     model.focusedElement = nil
                 }
             }
-            .onChange(of: model.focusedElement) { focusedElement in
+            .onChange(model.focusedElement) { focusedElement in
                 // Another form input took focus
                 if focusedElement != element {
                     isFocused  = false
                 }
             }
-            .onChange(of: text) { text in
+            .onChange(text) { text in
                 element.convertAndUpdateValue(text)
                 model.evaluateExpressions()
             }
@@ -107,7 +107,7 @@ private extension TextInput {
             .focused($isFocused)
             .frame(maxWidth: .infinity, alignment: .leading)
             .toolbar {
-                ToolbarItemGroup(placement: .keyboard) {
+                ToolbarItemGroup(placement: keyboardOrBottomOrnament) {
                     if UIDevice.current.userInterfaceIdiom == .phone, isFocused, (element.fieldType?.isNumeric ?? false) {
                         positiveNegativeButton
                         Spacer()
@@ -129,6 +129,16 @@ private extension TextInput {
             }
         }
         .formInputStyle()
+    }
+    
+    /// A toolbar item placement that will either be on the keyboard or bottom
+    /// ornament depending on the platform.
+    private var keyboardOrBottomOrnament: ToolbarItemPlacement {
+#if !os(visionOS)
+        .keyboard
+#else
+        .bottomOrnament
+#endif
     }
     
     /// The keyboard type to use depending on where the input is numeric and decimal.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -137,21 +137,17 @@ private extension TextInput {
     var keyboardType: UIKeyboardType {
         guard let fieldType = element.fieldType else { return .default }
         
-        if fieldType.isNumeric {
+        return if fieldType.isNumeric {
 #if os(visionOS)
             // The 'positiveNegativeButton' doesn't show on visionOS
             // so we need to show this keyboard so the user can type
             // a negative number.
-            return .numbersAndPunctuation
+            .numbersAndPunctuation
 #else
-            if fieldType.isFloatingPoint {
-                return .decimalPad
-            } else {
-                return .numberPad
-            }
+            if fieldType.isFloatingPoint { .decimalPad } else { .numberPad }
 #endif
         } else {
-            return .default
+            .default
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -92,14 +92,14 @@ struct FloatingPanel<Content>: View where Content: View {
                 maximumHeight = geometryProxy.size.height
                 updateHeight()
             }
-            .onChange(of: geometryProxy.size.height) { height in
+            .onChange(geometryProxy.size.height) { height in
                 maximumHeight = height
                 updateHeight()
             }
-            .onChange(of: isPresented) { _ in
+            .onChange(isPresented) { _ in
                 updateHeight()
             }
-            .onChange(of: selectedDetent) { _ in
+            .onChange(selectedDetent) { _ in
                 updateHeight()
             }
             .onKeyboardStateChanged { state, height in

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -209,7 +209,7 @@ public struct FloorFilter: View {
         .frame(minHeight: 100)
         .environmentObject(viewModel)
         .disabled(viewModel.isLoading)
-        .onChange(of: selection?.wrappedValue) { newValue in
+        .onChange(selection?.wrappedValue) { newValue in
             // Prevent a double-set if the view model triggered the original change.
             guard newValue != viewModel.selection else { return }
             switch newValue {
@@ -219,12 +219,12 @@ public struct FloorFilter: View {
             case .none: viewModel.clearSelection()
             }
         }
-        .onChange(of: viewModel.selection) { newValue in
+        .onChange(viewModel.selection) { newValue in
             // Prevent a double-set if the user triggered the original change.
             guard selection?.wrappedValue != newValue else { return }
             selection?.wrappedValue = newValue
         }
-        .onChange(of: viewpoint.wrappedValue) { newViewpoint in
+        .onChange(viewpoint.wrappedValue) { newViewpoint in
             guard isNavigating.wrappedValue else { return }
             if let newViewpoint {
                 viewModel.onViewpointChanged(newViewpoint)

--- a/Sources/ArcGISToolkit/Components/FloorFilter/LevelSelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/LevelSelector.swift
@@ -122,7 +122,7 @@ extension LevelSelector {
             }
             .frame(maxHeight: contentHeight)
             .onAppear { scrollToSelectedLevel(with: proxy) }
-            .onChange(of: isCollapsed) { _ in scrollToSelectedLevel(with: proxy) }
+            .onChange(isCollapsed) { _ in scrollToSelectedLevel(with: proxy) }
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -97,7 +97,7 @@ struct SiteAndFacilitySelector: View {
                 }
             }
             .listStyle(.plain)
-            .onChange(of: viewModel.selection) { _ in
+            .onChange(viewModel.selection) { _ in
                 if let floorFacility = viewModel.selection?.facility {
                     withAnimation {
                         proxy.scrollTo(
@@ -130,7 +130,7 @@ struct SiteAndFacilitySelector: View {
                     .disableAutocorrection(true)
                     .focused($textFieldIsFocused)
                     .keyboardType(.alphabet)
-                    .onChange(of: facilityListIsVisible) { _ in
+                    .onChange(facilityListIsVisible) { _ in
                         query.removeAll()
                         textFieldIsFocused = false
                     }

--- a/Sources/ArcGISToolkit/Components/OverviewMap.swift
+++ b/Sources/ArcGISToolkit/Components/OverviewMap.swift
@@ -138,19 +138,19 @@ public struct OverviewMap: View {
             dataModel.graphic.geometry = visibleArea
             dataModel.graphic.symbol = symbol
         }
-        .onChange(of: visibleArea) { visibleArea in
+        .onChange(visibleArea) { visibleArea in
             if let visibleArea = visibleArea {
                 dataModel.graphic.geometry = visibleArea
             }
         }
-        .onChange(of: viewpoint) { viewpoint in
+        .onChange(viewpoint) { viewpoint in
             if visibleArea == nil,
                let viewpoint = viewpoint,
                let point = viewpoint.targetGeometry as? Point {
                 dataModel.graphic.geometry = point
             }
         }
-        .onChange(of: symbol) {
+        .onChange(symbol) {
             dataModel.graphic.symbol = $0
         }
     }

--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -175,9 +175,9 @@ public struct Scalebar: View {
             }
         }
         .opacity(opacity)
-        .onChange(of: spatialReference) { viewModel.update($0) }
-        .onChange(of: unitsPerPoint) { viewModel.update($0) }
-        .onChange(of: viewpoint) {
+        .onChange(spatialReference) { viewModel.update($0) }
+        .onChange(unitsPerPoint) { viewModel.update($0) }
+        .onChange(viewpoint) {
             viewModel.update($0)
             viewModel.updateScale()
             if settings.autoHide {

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -243,22 +243,22 @@ public struct SearchView: View {
             onQueryChangedAction?(viewModel.currentQuery)
             viewModel.updateSuggestions()
         }
-        .onChange(of: viewModel.selectedResult) { _ in
+        .onChange(viewModel.selectedResult) { _ in
             searchFieldIsFocused = false
         }
-        .onChange(of: viewModel.currentSuggestion) { _ in
+        .onChange(viewModel.currentSuggestion) { _ in
             searchFieldIsFocused = false
         }
-        .onChange(of: geoViewExtent) { _ in
+        .onChange(geoViewExtent) { _ in
             viewModel.geoViewExtent = geoViewExtent
         }
-        .onChange(of: isGeoViewNavigating) { _ in
+        .onChange(isGeoViewNavigating) { _ in
             viewModel.isGeoViewNavigating = isGeoViewNavigating
         }
-        .onChange(of: queryCenter) { _ in
+        .onChange(queryCenter) { _ in
             viewModel.queryCenter = queryCenter
         }
-        .onChange(of: queryArea) { _ in
+        .onChange(queryArea) { _ in
             viewModel.queryArea = queryArea
         }
         .onAppear {

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -694,7 +694,7 @@ public struct UtilityNetworkTrace: View {
         }
         .background(Color(uiColor: .systemGroupedBackground))
         .animation(.default, value: currentActivity)
-        .onChange(of: screenPoint) { newScreenPoint in
+        .onChange(screenPoint) { newScreenPoint in
             guard isFocused(traceCreationActivity: .addingStartingPoints),
                   let mapViewProxy = mapViewProxy,
                   let mapPoint = mapPoint,
@@ -711,7 +711,7 @@ public struct UtilityNetworkTrace: View {
                 )
             }
         }
-        .onChange(of: externalStartingPoints) { _ in
+        .onChange(externalStartingPoints) { _ in
             viewModel.externalStartingPoints = externalStartingPoints
         }
         .alert(

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
@@ -17,7 +17,7 @@ import ArcGIS
 import ARKit
 import SwiftUI
 
-#if !os(visionOS)
+#if os(iOS)
 extension SceneViewProxy {
     /// Updates the scene view's camera for a given augmented reality frame.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
@@ -17,6 +17,7 @@ import ArcGIS
 import ARKit
 import SwiftUI
 
+#if !os(visionOS)
 extension SceneViewProxy {
     /// Updates the scene view's camera for a given augmented reality frame.
     /// - Parameters:
@@ -108,3 +109,4 @@ private extension ARCamera {
         }
     }
 }
+#endif

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View+OnChange.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View+OnChange.swift
@@ -1,0 +1,40 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension View {
+    /// Performs an action when a specified value changes.
+    /// - Parameters:
+    ///   - value: The value to check when determining whether to run the
+    ///     closure.
+    ///   - action: A closure to run when the value changes. The closure
+    ///     takes a `newValue` parameter that indicates the updated
+    ///     value.
+    /// - Returns: A view that runs an action when the specified value changes.
+    func onChange<V>(
+        _ value: V,
+        perform action: @escaping (_ newValue: V) -> Void
+    ) -> some View where V: Equatable {
+        if #available(iOS 17.0, macCatalyst 17.0, visionOS 2.0, *) {
+            return onChange(of: value) { _, newValue in
+                action(newValue)
+            }
+        } else {
+            return onChange(of: value) { newValue in
+                action(newValue)
+            }
+        }
+    }
+}

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -63,7 +63,7 @@ struct Carousel<Content: View>: View {
             .onAppear {
                 updateCellSizeForContainer(geometry.size.width)
             }
-            .onChange(of: geometry.size.width) { width in
+            .onChange(geometry.size.width) { width in
                 updateCellSizeForContainer(width)
             }
         }


### PR DESCRIPTION
Swift #6012

This PR is adding visionOS as a supported platform so the toolkit can build against visionOS. More work is coming after this to make sure all the components work and look correctly on this platform.

Components that are unavailable for visionOS:
- All AR components. Most of the ARKit API we are using isn't available on visionOS.
- Taking a photo or video for feature forms is not available on visionOS.

Xcode 16 must be used to build successfully.