### PR TITLE
Offline: Refactor UI

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -42,11 +42,7 @@ public struct OfflineMapAreasView: View {
             Form {
                 Section {
                     preplannedMapAreaViews
-                } header: {
-                    Text("Preplanned")
-                        .bold()
                 }
-                .textCase(nil)
             }
             .task {
                 await mapViewModel.makePreplannedOfflineMapModels()
@@ -59,7 +55,7 @@ public struct OfflineMapAreasView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .navigationTitle("Offline Maps")
+            .navigationTitle("Map Areas")
             .navigationBarTitleDisplayMode(.inline)
         }
         .refreshable {
@@ -96,9 +92,9 @@ public struct OfflineMapAreasView: View {
     
     @ViewBuilder private var emptyPreplannedMapAreasView: some View {
         VStack(alignment: .center) {
-            Text("No offline map areas")
+            Text("No map areas")
                 .bold()
-            Text("You don't have any offline map areas yet.")
+            Text("You don't have any map areas yet.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }


### PR DESCRIPTION
Closes `swift/6039`

- Renames "Offline Maps" title to "Map Areas"
- Removes "Preplanned" section header
- Rewords empty state view

<img src="https://github.com/user-attachments/assets/9c51ada6-7fbf-4460-b7ea-d2a993d946c9" width="300">

<img src="https://github.com/user-attachments/assets/66dce53d-9104-4d96-a57c-2d95d6e13c69" width="300">