### PR TITLE
Bookmark UI edits for visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -191,12 +191,16 @@ extension Bookmarks {
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                         .contentShape(Rectangle())
                 }
+#if !os(visionOS)
                 .buttonStyle(.plain)
+#endif
 #if targetEnvironment(macCatalyst)
                 .listRowBackground(bookmark == selection?.wrappedValue ? nil : Color.clear)
 #endif
             }
+#if !os(visionOS)
             .listStyle(.plain)
+#endif
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
@@ -54,8 +54,10 @@ struct BookmarksHeader: View {
                 Text.done
                     .fontWeight(.semibold)
             }
+#if !os(visionOS)
             .buttonStyle(.plain)
             .foregroundStyle(.tint)
+#endif
         }
     }
 }


### PR DESCRIPTION
Swift #6015

Before:
![Before](https://github.com/user-attachments/assets/d4584299-988b-487a-9ac9-5f3f801c4a15)

After:
![After](https://github.com/user-attachments/assets/864ac767-131e-488c-994b-9bd05aa2c468)

Per HIG guidelines on visionOS:

> A visionOS button typically includes a visible background that can help people see it ...