### PR TITLE
Fix warning in `TextFormElementView`

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/TextFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/TextFormElementView.swift
@@ -27,6 +27,8 @@ struct TextFormElementView: View {
                 MarkdownView(markdown: text)
             case .plainText:
                 Text(text)
+            @unknown default:
+                EmptyView()
             }
         }
         .task {


### PR DESCRIPTION
> Switch covers known cases, but 'FormTextFormat' may have additional unknown values

Silences this warning when using ArcGIS as a non-local-source dependency.