### PR TITLE
Offline: UI improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ for target in package.targets {
         .enableExperimentalFeature("AccessLevelOnImport"),
         .enableExperimentalFeature("StrictConcurrency"),
         // Upcoming Features.
+        .enableUpcomingFeature("BareSlashRegexLiterals"),
         .enableUpcomingFeature("DisableOutwardActorInference")
     ]
 }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -102,9 +102,10 @@ public struct OfflineMapAreasView: View {
         VStack(alignment: .center) {
             Text("No map areas")
                 .bold()
-            Text("You don't have any map areas yet.")
+            Text("There are no map areas defined for this web map.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
     }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -118,20 +118,22 @@ public struct OfflineMapAreasView: View {
         .frame(maxWidth: .infinity)
     }
     
-    private var offlineDisabledView: some View {
+    @ViewBuilder private var offlineDisabledView: some View {
+        let labelText = Text("Offline Disabled")
+        let descriptionText = Text("Please ensure the web map is offline enabled.")
         if #available(iOS 17, *) {
-            return ContentUnavailableView {
-                Text("Offline Disabled")
+            ContentUnavailableView {
+                labelText
                     .bold()
             } description: {
-                Text("Please ensure the web map is offline enabled.")
+                descriptionText
             }
         } else {
-            return VStack(alignment: .center) {
-                Text("Offline Disabled")
+            VStack(alignment: .center) {
+                labelText
                     .bold()
                     .font(.title2)
-                Text("Please ensure the web map is offline enabled.")
+                descriptionText
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -31,6 +31,11 @@ public struct OfflineMapAreasView: View {
     /// The currently selected map.
     @Binding private var selectedMap: Map?
     
+    /// A Boolean value indicating whether the web map is offline disabled.
+    private var mapIsOfflineDisabled: Bool {
+        onlineMap.loadStatus == .loaded && onlineMap.offlineSettings == nil
+    }
+    
     /// Creates a view with a given web map.
     /// - Parameters:
     ///   - online: The web map to be taken offline.
@@ -45,9 +50,7 @@ public struct OfflineMapAreasView: View {
         NavigationStack {
             Form {
                 Section {
-                    if onlineMap.loadStatus == .loaded && onlineMap.offlineSettings == nil {
-                        offlineDisabledView
-                    } else {
+                    if !mapIsOfflineDisabled {
                         preplannedMapAreaViews
                     }
                 }
@@ -65,6 +68,11 @@ public struct OfflineMapAreasView: View {
             }
             .navigationTitle("Map Areas")
             .navigationBarTitleDisplayMode(.inline)
+            .overlay {
+                if mapIsOfflineDisabled {
+                    offlineDisabledView
+                }
+            }
         }
         .refreshable {
             await mapViewModel.makePreplannedOfflineMapModels()
@@ -111,14 +119,24 @@ public struct OfflineMapAreasView: View {
     }
     
     private var offlineDisabledView: some View {
-        VStack(alignment: .center) {
-            Text("Offline disabled")
-                .bold()
-            Text("Please ensure the web map is offline enabled.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+        if #available(iOS 17, *) {
+            return ContentUnavailableView {
+                Text("Offline Disabled")
+                    .bold()
+            } description: {
+                Text("Please ensure the web map is offline enabled.")
+            }
+        } else {
+            return VStack(alignment: .center) {
+                Text("Offline Disabled")
+                    .bold()
+                    .font(.title2)
+                Text("Please ensure the web map is offline enabled.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
         }
-        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -28,16 +28,8 @@ struct PreplannedListItemView: View {
     @State private var metadataViewIsPresented = false
     
     /// The download state of the preplanned map model.
-    private enum DownloadState {
+    enum DownloadState {
         case notDownloaded, downloading, downloaded
-        
-        init(_ state: PreplannedMapModel.Status) {
-            self = switch state {
-            case .downloaded: .downloaded
-            case .downloading: .downloading
-            default: .notDownloaded
-            }
-        }
     }
     
     /// The current download state of the preplanned map model.
@@ -194,6 +186,18 @@ struct PreplannedListItemView: View {
         }
         .font(.caption2)
         .foregroundStyle(.tertiary)
+    }
+}
+
+private extension PreplannedListItemView.DownloadState {
+    /// Creates an instance.
+    /// - Parameter state: The preplanned map model download state.
+    init(_ state: PreplannedMapModel.Status) {
+        self = switch state {
+        case .downloaded: .downloaded
+        case .downloading: .downloading
+        default: .notDownloaded
+        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -27,6 +27,19 @@ struct PreplannedListItemView: View {
     /// A Boolean value indicating whether the metadata view is presented.
     @State private var metadataViewIsPresented = false
     
+    /// The download state of the preplanned map model.
+    private enum DownloadState {
+        case notDownloaded, downloading, downloaded
+        
+        init(_ state: PreplannedMapModel.Status) {
+            self = switch state {
+            case .downloaded: .downloaded
+            case .downloading: .downloading
+            default: .notDownloaded
+            }
+        }
+    }
+    
     /// The current download state of the preplanned map model.
     @State private var downloadState: DownloadState = .notDownloaded
     
@@ -181,21 +194,6 @@ struct PreplannedListItemView: View {
         }
         .font(.caption2)
         .foregroundStyle(.tertiary)
-    }
-}
-
-private extension PreplannedListItemView {
-    /// The download state of the preplanned map model.
-    enum DownloadState {
-        case notDownloaded, downloading, downloaded
-        
-        init(_ state: PreplannedMapModel.Status) {
-            self = switch state {
-            case .downloaded: .downloaded
-            case .downloading: .downloading
-            default: .notDownloaded
-            }
-        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -27,19 +27,6 @@ struct PreplannedListItemView: View {
     /// A Boolean value indicating whether the metadata view is presented.
     @State private var metadataViewIsPresented = false
     
-    /// The download state of the preplanned map model.
-    private enum DownloadState {
-        case notDownloaded, downloading, downloaded
-        
-        init(_ state: PreplannedMapModel.Status) {
-            self = switch state {
-            case .downloaded: .downloaded
-            case .downloading: .downloading
-            default: .notDownloaded
-            }
-        }
-    }
-    
     /// The current download state of the preplanned map model.
     @State private var downloadState: DownloadState = .notDownloaded
     
@@ -194,6 +181,21 @@ struct PreplannedListItemView: View {
         }
         .font(.caption2)
         .foregroundStyle(.tertiary)
+    }
+}
+
+private extension PreplannedListItemView {
+    /// The download state of the preplanned map model.
+    enum DownloadState {
+        case notDownloaded, downloading, downloaded
+        
+        init(_ state: PreplannedMapModel.Status) {
+            self = switch state {
+            case .downloaded: .downloaded
+            case .downloading: .downloading
+            default: .notDownloaded
+            }
+        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -28,7 +28,7 @@ struct PreplannedListItemView: View {
     @State private var metadataViewIsPresented = false
     
     /// The download state of the preplanned map model.
-    enum DownloadState {
+    fileprivate enum DownloadState {
         case notDownloaded, downloading, downloaded
     }
     

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -318,7 +318,8 @@ extension PreplannedMapArea: PreplannedMapAreaProtocol {
     }
     
     var description: String {
-        portalItem.description
+        // Remove HTML tags from description.
+        portalItem.description.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -130,7 +130,9 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     func updateDownloadStatus(for downloadResult: Result<DownloadPreplannedOfflineMapResult, any Error>) {
         switch downloadResult {
         case .success:
-            status = .downloaded
+            withAnimation(.easeInOut) {
+                status = .downloaded
+            }
         case .failure(let error):
             status = .downloadFailure(error)
         }

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -14,7 +14,7 @@
 
 import ArcGIS
 import OSLog
-import SwiftUI
+import Combine
 
 /// An object that encapsulates state about a preplanned map.
 @MainActor
@@ -130,9 +130,7 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     func updateDownloadStatus(for downloadResult: Result<DownloadPreplannedOfflineMapResult, any Error>) {
         switch downloadResult {
         case .success:
-            withAnimation(.easeInOut) {
-                status = .downloaded
-            }
+            status = .downloaded
         case .failure(let error):
             status = .downloadFailure(error)
         }

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 import ArcGIS
-import OSLog
 import Combine
+import Foundation
+
+internal import os
 
 /// An object that encapsulates state about a preplanned map.
 @MainActor

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMapModel.swift
@@ -321,7 +321,7 @@ extension PreplannedMapArea: PreplannedMapAreaProtocol {
     
     var description: String {
         // Remove HTML tags from description.
-        portalItem.description.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+        portalItem.description.replacing(/<[^>]+>/, with: "")
     }
 }
 

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -374,6 +374,34 @@ class PreplannedMapModelTests: XCTestCase {
             [.notLoaded, .loading, .packaged, .downloading, .downloading, .downloaded, .notLoaded, .loading, .packaged]
         )
     }
+    
+    @MainActor
+    func testPreplannedMapModelDescription() async throws {
+        let portalItem = PortalItem(
+            portal: .arcGISOnline(connection: .anonymous),
+            id: .init("acc027394bc84c2fb04d1ed317aac674")!
+        )
+        let task = OfflineMapTask(portalItem: portalItem)
+        let areas = try await task.preplannedMapAreas
+        let area = try XCTUnwrap(areas.first { $0.title == "Country Commons Area" })
+        let areaID = try XCTUnwrap(area.portalItem.id)
+
+        let model = PreplannedMapModel(
+            offlineMapTask: task,
+            mapArea: area,
+            portalItemID: portalItem.id!,
+            preplannedMapAreaID: areaID,
+            // User notifications in unit tests are not supported, must pass false here
+            // or the test process will crash.
+            showsUserNotificationOnCompletion: false
+        )
+        
+        // Verify description does not contain HTML tags.
+        XCTAssertEqual(model.preplannedMapArea.description,
+        """
+        A map that contains stormwater network within Naperville, IL, USA with cartography designed for web and mobile devices. This is a demo map to demonstrate offline capabilities with ArcGIS Runtime and is based on ArcGIS Solutions for Stormwater.
+        """)
+    }
 }
 
 extension PreplannedMapModel.Status: Equatable {

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -397,10 +397,10 @@ class PreplannedMapModelTests: XCTestCase {
         )
         
         // Verify description does not contain HTML tags.
-        XCTAssertEqual(model.preplannedMapArea.description,
-        """
-        A map that contains stormwater network within Naperville, IL, USA with cartography designed for web and mobile devices. This is a demo map to demonstrate offline capabilities with ArcGIS Runtime and is based on ArcGIS Solutions for Stormwater.
-        """)
+        XCTAssertEqual(
+            model.preplannedMapArea.description,
+            "A map that contains stormwater network within Naperville, IL, USA with cartography designed for web and mobile devices. This is a demo map to demonstrate offline capabilities with ArcGIS Runtime and is based on ArcGIS Solutions for Stormwater."
+        )
     }
 }
 


### PR DESCRIPTION
Related to `swift/6048`

- Rephrases empty state view text
- Uses `ContentUnavailableView` when map is offline disabled
- Removes HTML tags from map area description
- Animates open button

<img src="https://github.com/user-attachments/assets/386e180e-1fc6-4b60-99ad-92315eaf5513" width="300">
<img src="https://github.com/user-attachments/assets/dd8d95c5-6abb-48a6-9a12-a5e30e74233d" width="300">


