### PR TITLE
Offline: Remove delete swipe action

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -103,9 +103,7 @@ public struct OfflineMapAreasView: View {
         if let models = mapViewModel.offlinePreplannedMapModels {
             if !models.isEmpty {
                 List(models) { preplannedMapModel in
-                    PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap, onDeletion: {
-                        Task { await loadPreplannedMapModels() }
-                    })
+                    PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap)
                     .onChange(of: selectedMap) { _ in
                         dismiss()
                     }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -104,9 +104,9 @@ public struct OfflineMapAreasView: View {
             if !models.isEmpty {
                 List(models) { preplannedMapModel in
                     PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap)
-                    .onChange(of: selectedMap) { _ in
-                        dismiss()
-                    }
+                        .onChange(of: selectedMap) { _ in
+                            dismiss()
+                        }
                 }
             } else {
                 emptyOfflinePreplannedMapAreasView

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -43,9 +43,6 @@ struct PreplannedListItemView: View {
         selectedMap?.item?.title == model.preplannedMapArea.title
     }
     
-    /// The closure to perform when the map is removed from local disk.
-    var onDeletion: (() -> Void)?
-    
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
             thumbnailView
@@ -64,9 +61,6 @@ struct PreplannedListItemView: View {
             }
         }
         .contentShape(.rect)
-        .swipeActions {
-            deleteButton
-        }
         .onTapGesture {
             if model.status.isDownloaded {
                 metadataViewIsPresented = true
@@ -104,17 +98,6 @@ struct PreplannedListItemView: View {
     @ViewBuilder private var titleView: some View {
         Text(model.preplannedMapArea.title)
             .font(.body)
-    }
-    
-    @ViewBuilder private var deleteButton: some View {
-        if model.status.allowsRemoval,
-           !isSelected {
-            Button("Delete") {
-                model.removeDownloadedPreplannedMapArea()
-                onDeletion?()
-            }
-            .tint(.red)
-        }
     }
     
     @ViewBuilder private var downloadButton: some View {

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
@@ -72,7 +72,7 @@ struct PreplannedMetadataView: View {
                             .symbolRenderingMode(.palette)
                             .foregroundStyle(.red, .gray.opacity(0.1))
                             .font(.title)
-                        Button("Delete Map Area", role: .destructive) {
+                        Button("Remove Download", role: .destructive) {
                             dismiss()
                             model.removeDownloadedPreplannedMapArea()
                         }


### PR DESCRIPTION
Closes `swift/6071`

- Removes the "Delete" swipe action
- Rephrases the delete button in the MetadataView from "Delete Map Area" to "Remove Download"

Discussion:
Is a section footer under the "Remove Download" button with text such as "Removes downloaded map area from device." needed?

<img src="https://github.com/user-attachments/assets/09642580-c760-47ab-8770-2a19ac4a5afb" width="300">