### PR TITLE
`BarcodeScannerFormInput` - More refinements

### DIFF
--- a/Sources/ArcGISToolkit/Common/CameraRequester.swift
+++ b/Sources/ArcGISToolkit/Common/CameraRequester.swift
@@ -33,9 +33,7 @@ import SwiftUI
                 if granted {
                     onAccessGranted()
                 } else {
-                    Task { @MainActor in
-                        self.alertIsPresented = true
-                    }
+                    onAccessDenied()
                 }
             }
         default:

--- a/Sources/ArcGISToolkit/Common/CodeScanner.swift
+++ b/Sources/ArcGISToolkit/Common/CodeScanner.swift
@@ -370,6 +370,7 @@ class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadata
     
     @objc
     private func userDidTap(with tapGestureRecognizer: UITapGestureRecognizer) {
+        // Check if a recognized code was tapped. If so, select it.
         let point = tapGestureRecognizer.location(in: view)
         for metadataObjectOverlayLayer in metadataObjectOverlayLayers {
             if metadataObjectOverlayLayer.path?.contains(point) ?? false,
@@ -378,6 +379,22 @@ class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadata
                 break
             }
         }
+        
+        // Otherwise focus on and adjust exposure on the tapped point.
+        let convertedPoint = previewLayer.captureDevicePointConverted(fromLayerPoint: point)
+        guard let device = AVCaptureDevice.default(for: .video) else { return }
+        do {
+            try device.lockForConfiguration()
+            if device.isFocusModeSupported(.autoFocus) && device.isFocusPointOfInterestSupported {
+                device.focusPointOfInterest = convertedPoint
+                device.focusMode = .autoFocus
+            }
+            if device.isExposureModeSupported(.autoExpose) && device.isExposurePointOfInterestSupported {
+                device.exposurePointOfInterest = convertedPoint
+                device.exposureMode = .autoExpose
+            }
+            device.unlockForConfiguration()
+        } catch { }
     }
 }
 

--- a/Sources/ArcGISToolkit/Common/CodeScanner.swift
+++ b/Sources/ArcGISToolkit/Common/CodeScanner.swift
@@ -21,21 +21,37 @@ struct CodeScanner: View {
     
     @Binding var isPresented: Bool
     
+    @State private var cameraAccessIsAuthorized = false
+    
+    @StateObject private var cameraRequester = CameraRequester()
+    
     var body: some View {
-        CodeScannerRepresentable(scannerIsPresented: $isPresented, scanOutput: $code)
-            .overlay(alignment:.topTrailing) {
-                Button(String.cancel, role: .cancel) {
-                    isPresented = false
-                }
-                .buttonStyle(.borderedProminent)
-                .padding()
-            }
-            .overlay(alignment: .bottom) {
-                FlashlightButton()
-                    .hiddenIfUnavailable()
-                    .font(.title)
+        if cameraAccessIsAuthorized {
+            CodeScannerRepresentable(scannerIsPresented: $isPresented, scanOutput: $code)
+                .overlay(alignment:.topTrailing) {
+                    Button(String.cancel, role: .cancel) {
+                        isPresented = false
+                    }
+                    .buttonStyle(.borderedProminent)
                     .padding()
-            }
+                }
+                .overlay(alignment: .bottom) {
+                    FlashlightButton()
+                        .hiddenIfUnavailable()
+                        .font(.title)
+                        .padding()
+                }
+        } else {
+            Color.clear
+                .onAppear {
+                    cameraRequester.request {
+                        cameraAccessIsAuthorized = true
+                    } onAccessDenied: {
+                        isPresented = false
+                    }
+                }
+                .cameraRequester(cameraRequester)
+        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -33,9 +33,6 @@ struct TextInput: View {
     /// The current text value.
     @State private var text = ""
     
-    /// Performs camera authorization request handling.
-    @StateObject private var cameraRequester = CameraRequester()
-    
     /// A Boolean value indicating whether the device camera is accessible for scanning.
     private let cameraIsDisabled: Bool = {
 #if targetEnvironment(simulator)
@@ -92,7 +89,6 @@ struct TextInput: View {
             .onValueChange(of: element, when: !element.isMultiline || !fullScreenTextInputIsPresented) { _, newFormattedValue in
                 text = newFormattedValue
             }
-            .cameraRequester(cameraRequester)
     }
 }
 
@@ -151,10 +147,7 @@ private extension TextInput {
             if element.input is BarcodeScannerFormInput {
                 Button {
                     model.focusedElement = element
-                    cameraRequester.request {
-                        scannerIsPresented = true
-                    } onAccessDenied: {
-                    }
+                    scannerIsPresented = true
                 } label: {
                     Image(systemName: "barcode.viewfinder")
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
Ref Apollo 898

- Moves `CameraRequester` directly onto `CodeScanner` so camera permission checking is built into `CodeScanner`
- Adds tap to focus/expose on `CodeScanner`