### PR TITLE
Adds Barcode test case 11.1

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
@@ -217,11 +217,14 @@ extension InputFooter {
     var lengthRange: ClosedRange<Int>? {
         if let input = element.input as? TextAreaFormInput {
             return input.minLength...input.maxLength
-        } else if let input = element.input as? TextBoxFormInput, element.fieldType == .text {
-            return input.minLength...input.maxLength
-        } else {
-            return nil
+        } else if element.fieldType == .text {
+            if let input = element.input as? TextBoxFormInput {
+                return input.minLength...input.maxLength
+            } else if let input = element.input as? BarcodeScannerFormInput {
+                return input.minLength...input.maxLength
+            }
         }
+        return nil
     }
     
     /// The allowable numeric range the input.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -161,6 +161,7 @@ private extension TextInput {
                 }
                 .disabled(cameraIsDisabled)
                 .buttonStyle(.plain)
+                .accessibilityIdentifier("\(element.label) Scan Button")
             }
         }
         .formInputStyle()

--- a/Test Runner/Test Runner/TestViews/FeatureFormTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureFormTestView.swift
@@ -155,6 +155,7 @@ private extension FeatureFormTestView {
         .init("testCase_9_1", objectID: 1, portalID: .testCase9),
         .init("testCase_10_1", objectID: 1, portalID: .testCase10),
         .init("testCase_10_2", objectID: 1, portalID: .testCase10),
+        .init("testCase_11_1", objectID: 2, portalID: .testCase11),
     ]}
 }
 
@@ -170,4 +171,5 @@ private extension String {
     static let switchMapID = "ff98f13b32b349adb55da5528d9174dc"
     static let testCase9 = "5f71b243b37e43a5ace3190241db0ac9"
     static let testCase10 = "e10c0061182c4102a109dc6b030aa9ef"
+    static let testCase11 = "a14a825c22884dfe9998ac964bd1cf89"
 }

--- a/Test Runner/UI Tests/FormViewTests.swift
+++ b/Test Runner/UI Tests/FormViewTests.swift
@@ -1631,6 +1631,47 @@ final class FeatureFormViewTests: XCTestCase {
         
         XCTAssertTrue(plainText.exists)
     }
+    
+    /// Test case 11.1: Barcode Scan and Clear buttons
+    func testCase_11_1() {
+        let app = XCUIApplication()
+        let formTitle = app.staticTexts["Test case 11.1 Layer"]
+        let formViewTestsButton = app.buttons["Feature Form Tests"]
+        let scanButton = app.buttons["Barcode Scan Button"]
+        let clearButton = app.buttons["Barcode Clear Button"]
+        let barcodeValidationString = app.staticTexts["Barcode Footer"]
+        let fieldValue = app.textFields["Barcode Text Input"]
+        
+        app.launch()
+        
+        // Open the FeatureFormView component test view.
+        formViewTestsButton.tap()
+        
+        selectTestCase(app)
+        
+        // Wait and verify that the form is opened.
+        XCTAssertTrue(
+            formTitle.waitForExistence(timeout: 10),
+            "The form failed to open after 10 seconds."
+        )
+        
+        XCTAssertTrue(scanButton.exists, "The scan button doesn't exist.")
+        
+        XCTAssertFalse(clearButton.exists, "The clear button exists.")
+        
+        fieldValue.tap()
+        fieldValue.typeText("https://esri.com")
+
+        XCTAssertTrue(scanButton.exists, "The scan button doesn't exist.")
+        XCTAssertTrue(clearButton.exists, "The clear button doesn't exist.")
+        
+        clearButton.tap()
+        
+        fieldValue.tap()
+        fieldValue.typeText("https://runtimecoretest.maps.arcgis.com/apps/mapviewer/index.html?layers=a9155494098147b9be2fc52bcf825224")
+
+        XCTAssertEqual(barcodeValidationString.label, "Maximum 50 characters")
+    }
 }
 
 private extension String {


### PR DESCRIPTION
Adds Test Case 11.1. Needed to update the `InputFooter` to take into account the Barcode Input when retrieving the `lengthRange` property in order to correctly get the range.

I also added an `accessibilityIdentifier` to the scan button in the `TextInput` struct.