### PR TITLE
Fix unit tests for visionOS

### DIFF
--- a/Tests/ArcGISToolkitTests/ARTests.swift
+++ b/Tests/ArcGISToolkitTests/ARTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 import SwiftUI
 import XCTest
@@ -222,3 +223,4 @@ final class ARTests: XCTestCase {
         XCTAssertEqual(view.calibrationButtonAlignment, .bottomLeading)
     }
 }
+#endif

--- a/Tests/ArcGISToolkitTests/AttachmentsFeatureElementDisplayTypeTests.swift
+++ b/Tests/ArcGISToolkitTests/AttachmentsFeatureElementDisplayTypeTests.swift
@@ -16,6 +16,7 @@ import ArcGIS
 @testable import ArcGISToolkit
 import XCTest
 
+#if !os(visionOS)
 final class AttachmentsFeatureElementDisplayTypeTests: XCTestCase {
     func testInitWithAttachmentsPopupElementDisplayType() {
         XCTAssertEqual(AttachmentsFeatureElementDisplayType(kind: .list), .list)
@@ -23,3 +24,4 @@ final class AttachmentsFeatureElementDisplayTypeTests: XCTestCase {
         XCTAssertEqual(AttachmentsFeatureElementDisplayType(kind: .auto), .auto)
     }
 }
+#endif

--- a/Tests/ArcGISToolkitTests/CompassTests.swift
+++ b/Tests/ArcGISToolkitTests/CompassTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 import SwiftUI
 import XCTest
@@ -54,3 +55,4 @@ final class CompassTests: XCTestCase {
         XCTAssertTrue(compass3.shouldHide(forHeading: compass3Heading))
     }
 }
+#endif

--- a/Tests/ArcGISToolkitTests/FeatureAttachmentKindTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureAttachmentKindTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 @testable import ArcGISToolkit
 import XCTest
@@ -32,3 +33,4 @@ final class FeatureAttachmentKindTests: XCTestCase {
         XCTAssertEqual(FeatureAttachmentKind(kind: PopupAttachment.Kind.other), .other)
     }
 }
+#endif

--- a/Tests/ArcGISToolkitTests/FloorFilterViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FloorFilterViewModelTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 import Combine
 import SwiftUI
@@ -299,3 +300,4 @@ private extension Viewpoint {
         scale: 10_000
     )
 }
+#endif

--- a/Tests/ArcGISToolkitTests/LocatorSearchSourceTests.swift
+++ b/Tests/ArcGISToolkitTests/LocatorSearchSourceTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import XCTest
 import ArcGIS
 import ArcGISToolkit
@@ -57,3 +58,4 @@ final class LocatorSearchSourceTests: XCTestCase {
         XCTAssertEqual(suggestResults.count, 2)
     }
 }
+#endif

--- a/Tests/ArcGISToolkitTests/ScalebarTests.swift
+++ b/Tests/ArcGISToolkitTests/ScalebarTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 import Combine
 import SwiftUI
@@ -106,3 +107,4 @@ extension ScalebarTests {
         )
     }
 }
+#endif

--- a/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/SearchViewModelTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 @testable import ArcGISToolkit
 @preconcurrency import Combine
@@ -480,3 +481,4 @@ private extension SearchViewModel {
         }
     }
 }
+#endif

--- a/Tests/ArcGISToolkitTests/SmartLocatorSearchSourceTests.swift
+++ b/Tests/ArcGISToolkitTests/SmartLocatorSearchSourceTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import XCTest
 import ArcGIS
 import ArcGISToolkit
@@ -68,3 +69,4 @@ private extension Envelope {
         yRange: 7536778.456812576...7559866.706991681
     )
 }
+#endif

--- a/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !os(visionOS)
 import ArcGIS
 @testable import ArcGISToolkit
 import XCTest
@@ -308,3 +309,4 @@ private extension PortalItem {
 private extension URL {
     static let sampleServer7 = URL(string: "https://sampleserver7.arcgisonline.com/portal/sharing/rest")!
 }
+#endif


### PR DESCRIPTION
Since the toolkit package supports visionOS that means I can't stop someone from running the unit tests against visionOS even though most of the tests use components that aren't supported yet for visionOS.

So if someone tries to run the unit tests against visionOS they will see build errors for components that unavailable for visionOS. This fixes those and the tests that can be run I left alone and they succeed.

I wish marking a test class as `@available(visionOS, unavailable)` would prevent that class from being run on visionOS but it does not so I just hide those test classes behind `#if !os(visionOS)`.