### PR TITLE
Make OverviewMap available for visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/OverviewMap.swift
+++ b/Sources/ArcGISToolkit/Components/OverviewMap.swift
@@ -49,7 +49,6 @@ import SwiftUI
 /// in the project. To learn more about using the `OverviewMap` see the <doc:OverviewMapTutorial>.
 @MainActor
 @preconcurrency
-@available(visionOS, unavailable)
 public struct OverviewMap: View {
     /// The `Viewpoint` of the main `GeoView`.
     let viewpoint: Viewpoint?
@@ -214,7 +213,6 @@ private extension Symbol {
     }
 }
 
-@available(visionOS, unavailable)
 private extension OverviewMap {
     @MainActor
     private class DataModel: ObservableObject {


### PR DESCRIPTION
No edits needed I tested on a device and sim.
![Simulator Screenshot - Apple Vision Pro - 2024-10-14 at 11 24 49](https://github.com/user-attachments/assets/dc748bb5-4542-44ab-a11a-712df23a29fe)
