### PR TITLE
Make Scalebar available on visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -51,7 +51,6 @@ import SwiftUI
 /// in the project. To learn more about using the `Scalebar` see the <doc:ScalebarTutorial>.
 @MainActor
 @preconcurrency
-@available(visionOS, unavailable)
 public struct Scalebar: View {
     // - MARK: Internal/Private vars
     

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarLabel.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarLabel.swift
@@ -15,7 +15,6 @@
 import SwiftUI
 
 /// Models a label displayed along the edge of a scalebar
-@available(visionOS, unavailable)
 struct ScalebarLabel {
     /// The number of the label with the leftmost label ("0") starting at -1.
     let index: Int

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarModifiers.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarModifiers.swift
@@ -15,7 +15,6 @@
 import SwiftUI
 
 /// A modifier which "styles" a Text element's font, shadow color and radius.
-@available(visionOS, unavailable)
 struct ScalebarTextModifier: ViewModifier {
     /// Appearance settings.
     @Environment(\.scalebarSettings) var settings
@@ -31,7 +30,6 @@ struct ScalebarTextModifier: ViewModifier {
     }
 }
 
-@available(visionOS, unavailable)
 extension Text {
     func scalebarText() -> some View {
         modifier(
@@ -41,7 +39,6 @@ extension Text {
 }
 
 /// A modifier which "styles" a scalebar's shadow color and radius.
-@available(visionOS, unavailable)
 struct ScalebarGroupShadowModifier: ViewModifier {
     /// Appearance settings.
     @Environment(\.scalebarSettings) var settings
@@ -56,7 +53,6 @@ struct ScalebarGroupShadowModifier: ViewModifier {
     }
 }
     
-@available(visionOS, unavailable)
 extension View {
     func scalebarShadow() -> some View {
         modifier(

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
@@ -15,7 +15,6 @@
 import SwiftUI
 
 /// Customizes scalebar appearance and behavior.
-@available(visionOS, unavailable)
 public struct ScalebarSettings: Sendable {
     /// Determines if the scalebar should automatically hide/show itself.
     var autoHide: Bool
@@ -83,12 +82,10 @@ public struct ScalebarSettings: Sendable {
     }
 }
 
-@available(visionOS, unavailable)
 struct ScalebarSettingsKey: EnvironmentKey {
   static let defaultValue = ScalebarSettings()
 }
 
-@available(visionOS, unavailable)
 extension EnvironmentValues {
     var scalebarSettings: ScalebarSettings {
         get { self[ScalebarSettingsKey.self] }

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 /// Visual scalebar styles.
-@available(visionOS, unavailable)
 public enum ScalebarStyle: Sendable {
     /// Displays a single unit with segmented bars of alternating fill color.
     case alternatingBar

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyleRenderer.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyleRenderer.swift
@@ -14,7 +14,6 @@
 
 import SwiftUI
 
-@available(visionOS, unavailable)
 extension Scalebar {
     /// Renders all of the scalebar labels.
     var allLabelsView: some View {

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import Foundation
 
-@available(visionOS, unavailable)
 public enum ScalebarUnits: Sendable {
     /// Imperial units (feet, miles, etc)
     case imperial

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarViewModel.swift
@@ -17,7 +17,6 @@ import Combine
 import Foundation
 
 @MainActor
-@available(visionOS, unavailable)
 final class ScalebarViewModel: ObservableObject {
     // - MARK: Published vars
     

--- a/Tests/ArcGISToolkitTests/ScalebarTests.swift
+++ b/Tests/ArcGISToolkitTests/ScalebarTests.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !os(visionOS)
 import ArcGIS
 import Combine
 import SwiftUI
@@ -107,4 +106,3 @@ extension ScalebarTests {
         )
     }
 }
-#endif


### PR DESCRIPTION
No edits needed I tested on a device and sim.
![simulator_screenshot_CEB7A0EA-AF19-4A63-B812-46B108DE2570](https://github.com/user-attachments/assets/0f4caa48-dd3a-4309-873c-d15afe9c738b)
