### PR TITLE
Stop copying `PrivacyInfo.xcprivacy`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,9 +39,6 @@ let package = Package(
             dependencies: [
                 .product(name: "ArcGIS", package: "arcgis-maps-sdk-swift"),
                 .product(name: "Markdown", package: "swift-markdown")
-            ],
-            resources: [
-                .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Ref Swift 6183

@zkline101 discovered:

> Privacy manifests are automatically included as a copied resource for packages with tools version >= 6.0. (111119227)

In the [Xcode 16 Swift Package release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#Swift-Packages).

cc @mhdostal 