### PR TITLE
Fix rebase conflicts

### DIFF
--- a/Sources/ArcGISToolkit/Components/OverviewMap.swift
+++ b/Sources/ArcGISToolkit/Components/OverviewMap.swift
@@ -47,7 +47,6 @@ import SwiftUI
 /// the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [OverviewMapExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/OverviewMapExampleView.swift)
 /// in the project. To learn more about using the `OverviewMap` see the <doc:OverviewMapTutorial>.
-@available(visionOS, unavailable)
 public struct OverviewMap: View {
     /// The `Viewpoint` of the main `GeoView`.
     let viewpoint: Viewpoint?

--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -49,7 +49,6 @@ import SwiftUI
 /// To see it in action, try out the [Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Examples/Examples)
 /// and refer to [ScalebarExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/ScalebarExampleView.swift) 
 /// in the project. To learn more about using the `Scalebar` see the <doc:ScalebarTutorial>.
-@available(visionOS, unavailable)
 public struct Scalebar: View {
     // - MARK: Internal/Private vars
     


### PR DESCRIPTION
I rebased visionOS v.next with v.next and I resolved the conflicts but I accidently resolved these conflicts incorrectly. I forgot I recently marked these two components as available for visionOS.