### PR TITLE
Offline: Add line limit to the title

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -98,6 +98,7 @@ struct PreplannedListItemView: View {
     @ViewBuilder private var titleView: some View {
         Text(model.preplannedMapArea.title)
             .font(.body)
+            .lineLimit(2)
     }
     
     @ViewBuilder private var downloadButton: some View {


### PR DESCRIPTION
Limit the title to 2 lines per Ryan's feedback. I chose 2 lines to match what App Store does.