### PR TITLE
Support `TextFormElement`s inside a `GroupFormElement`

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -142,7 +142,7 @@ extension FeatureFormView {
             EmptyView()
         }
     }
-
+    
     /// Makes UI for a field form element or a text form element.
     /// - Parameter element: The element to generate UI for.
     @ViewBuilder func internalMakeElement(_ element: FormElement) -> some View {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -135,9 +135,22 @@ extension FeatureFormView {
         case let element as FieldFormElement:
             makeFieldElement(element)
         case let element as GroupFormElement:
-            GroupView(element: element, viewCreator: { makeFieldElement($0) })
+            GroupView(element: element, viewCreator: { internalMakeElement($0) })
         case let element as TextFormElement:
-            TextFormElementView(element: element)
+            makeTextElement(element)
+        default:
+            EmptyView()
+        }
+    }
+
+    /// Makes UI for a field form element or a text form element.
+    /// - Parameter element: The element to generate UI for.
+    @ViewBuilder func internalMakeElement(_ element: FormElement) -> some View {
+        switch element {
+        case let element as FieldFormElement:
+            makeFieldElement(element)
+        case let element as TextFormElement:
+            makeTextElement(element)
         default:
             EmptyView()
         }
@@ -152,6 +165,13 @@ extension FeatureFormView {
         }
     }
     
+    /// Makes UI for a text form element including a divider beneath it.
+    /// - Parameter element: The element to generate UI for.
+    @ViewBuilder func makeTextElement(_ element: TextFormElement) -> some View {
+        TextFormElementView(element: element)
+        Divider()
+    }
+
     /// The progress view to be shown while initial expression evaluation is running.
     ///
     /// This avoids flashing elements that may immediately be set hidden or have

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -171,7 +171,7 @@ extension FeatureFormView {
         TextFormElementView(element: element)
         Divider()
     }
-
+    
     /// The progress view to be shown while initial expression evaluation is running.
     ///
     /// This avoids flashing elements that may immediately be set hidden or have

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/GroupView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/GroupView.swift
@@ -30,7 +30,7 @@ struct GroupView<Content>: View where Content: View {
     let element: GroupFormElement
     
     /// The closure to perform to build an element in the group.
-    let viewCreator: (FieldFormElement) -> Content
+    let viewCreator: (FormElement) -> Content
     
     /// Filters the group's elements by visibility.
     private func updateVisibleElements() {
@@ -40,11 +40,9 @@ struct GroupView<Content>: View where Content: View {
     var body: some View {
         Group {
             DisclosureGroup(isExpanded: $isExpanded) {
-                ForEach(visibleElements, id: \.label) { formElement in
-                    if let element = formElement as? FieldFormElement {
-                        viewCreator(element)
-                            .padding(.leading, 16)
-                    }
+                ForEach(visibleElements, id: \.self) { element in
+                    viewCreator(element)
+                        .padding(.leading, 16)
                 }
             } label: {
                 VStack {


### PR DESCRIPTION
This adds support for `TextFormElement`s inside a `GroupFormElement`. Previously, only `FieldFormElement`s were supported, as that was the only element type available when the group element was implemented.

It also adds a `Divider` below the text form element.

Apollo/936