### PR TITLE
[Update] Table top `translationFactor` doc

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -53,8 +53,13 @@ public struct TableTopSceneView: View {
     /// Creates a table top scene view.
     /// - Parameters:
     ///   - anchorPoint: The location point of the ArcGIS Scene that is anchored on a physical surface.
-    ///   - translationFactor: The translation factor that defines how much the scene view translates
-    ///   as the device moves.
+    ///   - translationFactor: The translation factor that defines how much the scene view
+    ///   translates as the device moves. This value can be determined by dividing the virtual
+    ///   content width by the desired physical content width (translation factor = virtual content
+    ///   width / desired physical content width). The virtual content width is the real-world size
+    ///   of the scene content, and the desired physical content width is the physical tabletop
+    ///   width. The virtual content width is determined by the clipping distance in meters around
+    ///   the camera.
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
     ///   of `nil` means that no data will be clipped.
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -58,8 +58,8 @@ public struct TableTopSceneView: View {
     ///   content width by the desired physical content width (translation factor = virtual content
     ///   width / desired physical content width). The virtual content width is the real-world size
     ///   of the scene content, and the desired physical content width is the physical tabletop
-    ///   width. The virtual content width is determined by the clipping distance in meters around
-    ///   the camera.
+    ///   width; both measurements should be in meters. The virtual content width is determined 
+    ///   by the clipping distance in meters around the camera.
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
     ///   of `nil` means that no data will be clipped.
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/TableTopSceneView/TableTopSceneViewStep1.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/TableTopSceneView/TableTopSceneViewStep1.swift
@@ -12,7 +12,7 @@ struct TableTopExampleView: View {
     var body: some View {
         TableTopSceneView(
             anchorPoint: anchorPoint,
-            translationFactor: 1_000,
+            translationFactor: 400,
             clippingDistance: 400
         )
     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/TableTopSceneView/TableTopSceneViewStep2.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/TableTopSceneView/TableTopSceneViewStep2.swift
@@ -27,7 +27,7 @@ struct TableTopExampleView: View {
     var body: some View {
         TableTopSceneView(
             anchorPoint: anchorPoint,
-            translationFactor: 1_000,
+            translationFactor: 400,
             clippingDistance: 400
         ) { _ in
             SceneView(scene: scene)

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/TableTopSceneView/TableTopSceneViewStep3.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/TableTopSceneView/TableTopSceneViewStep3.swift
@@ -28,7 +28,7 @@ struct TableTopExampleView: View {
     var body: some View {
         TableTopSceneView(
             anchorPoint: anchorPoint,
-            translationFactor: 1_000,
+            translationFactor: 400,
             clippingDistance: 400
         ) { _ in
             SceneView(scene: scene)

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/TableTopSceneViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/TableTopSceneViewTutorial.tutorial
@@ -16,8 +16,10 @@
                 
                 The anchor point is the location point of the ArcGIS Scene that is anchored on a 
                 physical surface. The translation factor determines how many meters the scene view
-                translates as the device moves in the AR experience. The clipping distance is the 
-                distance in meters that the ArcGIS Scene data will be clipped to.
+                translates as the device moves in the AR experience. This value can be determined by
+                dividing the virtual content width by the desired physical content width. In this
+                case, 400 m / 1 m = 400 translation factor. The clipping distance is the distance in
+                meters that the ArcGIS Scene data will be clipped to.
                 @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep1.swift)
             }
             

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/TableTopSceneViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/TableTopSceneViewTutorial.tutorial
@@ -18,8 +18,9 @@
                 physical surface. The translation factor determines how many meters the scene view
                 translates as the device moves in the AR experience. This value can be determined by
                 dividing the virtual content width by the desired physical content width. In this
-                case, 400 m / 1 m = 400 translation factor. The clipping distance is the distance in
-                meters that the ArcGIS Scene data will be clipped to.
+                case, 400 m (ArcGIS Scene width) / 1 m (table top width) = 400 m (translation
+                factor). The clipping distance is the distance in clipping distance is the distance
+                in meters that the ArcGIS Scene data will be clipped to.
                 @Code(name: "TableTopExampleView.swift", file: TableTopSceneViewStep1.swift)
             }
             


### PR DESCRIPTION
This PR updates the `TableTopSceneView.init(anchorPoint:translationFactor:clippingDistance:sceneView:)` doc with more info that can be found in the [Implement tabletop AR](https://developers.arcgis.com/swift/scenes-3d/display-scenes-in-augmented-reality/#implement-tabletop-ar) conceptual doc.

## Linked Issue(s)

- `swift/issues/6175`
