### PR TITLE
Add visionOS support to `PopupView`

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentList.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentList.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import SwiftUI
 
 /// A view displaying a list of attachments, with a thumbnail, title, and download button.
-@available(visionOS, unavailable)
 struct AttachmentList: View {
     /// The attachment models displayed in the list.
     var attachmentModels: [AttachmentModel]
@@ -29,7 +28,6 @@ struct AttachmentList: View {
 }
 
 /// A view representing a single row in an `AttachmentList`.
-@available(visionOS, unavailable)
 struct AttachmentRow: View  {
     /// The model representing the attachment to display.
     @ObservedObject var attachmentModel: AttachmentModel
@@ -66,7 +64,6 @@ struct AttachmentRow: View  {
 }
 
 /// View displaying a button used to load an attachment.
-@available(visionOS, unavailable)
 struct AttachmentLoadButton: View  {
     @ObservedObject var attachmentModel: AttachmentModel
     
@@ -87,7 +84,9 @@ struct AttachmentLoadButton: View  {
                     Image(systemName: "square.and.arrow.down")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
+#if !os(visionOS)
                         .foregroundColor(.accentColor)
+#endif
                 case .loading:
                     ProgressView()
                 case .loaded:

--- a/Sources/ArcGISToolkit/Common/AttachmentModel.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentModel.swift
@@ -20,7 +20,6 @@ internal import os
 
 /// A view model representing the combination of a `FeatureAttachment` and
 /// an associated `UIImage` used as a thumbnail.
-@available(visionOS, unavailable)
 @MainActor class AttachmentModel: ObservableObject {
     /// The `FeatureAttachment`.
     nonisolated let attachment: FeatureAttachment
@@ -119,5 +118,4 @@ internal import os
     }
 }
 
-@available(visionOS, unavailable)
 extension AttachmentModel: Identifiable {}

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import SwiftUI
 
 /// A view displaying a list of attachments in a "carousel", with a thumbnail and title.
-@available(visionOS, unavailable)
 struct AttachmentPreview: View {
     /// An action which scrolls the Carousel to the front.
     @Binding var scrollToNewAttachmentAction: (() -> Void)?
@@ -244,7 +243,6 @@ struct AttachmentPreview: View {
 }
 
 /// A view displaying details for popup media.
-@available(visionOS, unavailable)
 struct ThumbnailViewFooter: View {
     /// The popup media to display.
     @ObservedObject var attachmentModel: AttachmentModel
@@ -274,7 +272,6 @@ struct ThumbnailViewFooter: View {
     }
 }
 
-@available(visionOS, unavailable)
 private extension AttachmentPreview.AttachmentCell {
     /// An error message explaining attachments larger than the provided maximum cannot be downloaded.
     var maximumSizeDownloadExceededErrorMessage: Text {

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -17,7 +17,6 @@ import QuickLook
 import SwiftUI
 
 /// A view displaying an `AttachmentsFeatureElement`.
-@available(visionOS, unavailable)
 struct AttachmentsFeatureElementView: View {
     /// The `AttachmentsFeatureElement` to display.
     let featureElement: AttachmentsFeatureElement
@@ -200,7 +199,6 @@ struct AttachmentsFeatureElementView: View {
     }
 }
 
-@available(visionOS, unavailable)
 private extension AttachmentsFeatureElement {
     /// Provides a default title to display if `title` is empty.
     var displayTitle: String {
@@ -212,7 +210,6 @@ private extension AttachmentsFeatureElement {
     }
 }
 
-@available(visionOS, unavailable)
 extension AttachmentsFeatureElementView {
     /// The size of thumbnail images, based on the attachment display type
     /// and the current size class of the view.
@@ -238,7 +235,6 @@ extension AttachmentsFeatureElementView {
     }
 }
 
-@available(visionOS, unavailable)
 extension View {
     /// Modifier for watching `AttachmentsFormElement.isEditable`.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Common/ThumbnailView.swift
+++ b/Sources/ArcGISToolkit/Common/ThumbnailView.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import SwiftUI
 
 /// A view displaying a thumbnail image for an attachment.
-@available(visionOS, unavailable)
 struct ThumbnailView: View  {
     /// The model represented by the thumbnail.
     @ObservedObject var attachmentModel: AttachmentModel

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -20,7 +20,6 @@ import UniformTypeIdentifiers
 internal import os
 
 /// The context menu shown when the new attachment button is pressed.
-@available(visionOS, unavailable)
 struct AttachmentImportMenu: View {
     /// The attachment form element displaying the menu.
     private let element: AttachmentsFormElement
@@ -213,7 +212,6 @@ struct AttachmentImportMenu: View {
     }
 }
 
-@available(visionOS, unavailable)
 private extension AttachmentImportMenu {
     /// A button that redirects the user to the application's entry in the iOS system Settings application.
     var appSettingsButton: some View {

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -72,8 +72,9 @@ struct FieldsPopupElementView: View {
         let formattedValue: String
         
         var body: some View {
-            if formattedValue.lowercased().starts(with: "http") {
-                Link("View", destination: URL(string: formattedValue)!)
+            if formattedValue.lowercased().starts(with: "http"),
+               let url = URL(string: formattedValue) {
+                Link("View", destination: url)
                     .buttonStyle(.bordered)
             } else {
                 Text(formattedValue)

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -73,7 +73,8 @@ struct FieldsPopupElementView: View {
         
         var body: some View {
             if formattedValue.lowercased().starts(with: "http") {
-                Text(.init("[View](\(formattedValue))"))
+                Link("View", destination: URL(string: formattedValue)!)
+                    .buttonStyle(.bordered)
             } else {
                 Text(formattedValue)
             }

--- a/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
@@ -16,7 +16,6 @@ import SwiftUI
 import ArcGIS
 
 /// A view displaying a `MediaPopupElement`.
-@available(visionOS, unavailable)
 struct MediaPopupElementView: View {
     /// The `PopupElement` to display.
     var popupElement: MediaPopupElement

--- a/Sources/ArcGISToolkit/Components/Popups/PopupElementHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupElementHeader.swift
@@ -38,8 +38,8 @@ struct PopupElementHeader: View {
                     .foregroundColor(.secondary)
             }
         }
-        #if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst) || os(visionOS)
         .padding(.leading, 4)
-        #endif
+#endif
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartMediaView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartMediaView.swift
@@ -16,7 +16,6 @@ import SwiftUI
 import ArcGIS
 
 /// A view displaying chart popup media.
-@available(visionOS, unavailable)
 struct ChartMediaView: View {
     /// The popup media to display.
     let popupMedia: PopupMedia
@@ -62,6 +61,7 @@ struct ChartMediaView: View {
         .onTapGesture {
             isShowingDetailView = true
         }
+        .hoverEffect()
         .sheet(isPresented: $isShowingDetailView) {
             MediaDetailView(
                 popupMedia: popupMedia,

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/ImageMediaView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/ImageMediaView.swift
@@ -15,7 +15,6 @@ import SwiftUI
 import ArcGIS
 
 /// A view displaying image popup media.
-@available(visionOS, unavailable)
 struct ImageMediaView: View {
     /// The popup media to display.
     let popupMedia: PopupMedia
@@ -55,6 +54,7 @@ struct ImageMediaView: View {
             .onTapGesture {
                 isShowingDetailView = true
             }
+            .hoverEffect()
             .sheet(isPresented: $isShowingDetailView) {
                 MediaDetailView(
                     popupMedia: popupMedia,

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
@@ -15,7 +15,6 @@ import SwiftUI
 import ArcGIS
 
 /// A view displaying a popup media in a large format.
-@available(visionOS, unavailable)
 struct MediaDetailView : View {
     /// The popup media to display.
     let popupMedia: PopupMedia
@@ -58,6 +57,7 @@ struct MediaDetailView : View {
                             UIApplication.shared.open(linkURL)
                         }
                     }
+                    .hoverEffect()
                     if popupMedia.value?.linkURL != nil {
                         HStack {
                             Text(

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -85,7 +85,7 @@ public struct PopupView: View {
                 }
                 Spacer()
                 if showCloseButton {
-                    Button("Close", systemImage: "xmark") {
+                    Button(String.close, systemImage: "xmark") {
                         isPresented?.wrappedValue = false
                     }
                     .labelStyle(.iconOnly)

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -51,7 +51,6 @@ import ArcGIS
 /// and refer to
 /// [PopupExampleView.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/Examples/Examples/PopupExampleView.swift)
 /// in the project. To learn more about using the `PopupView` see the <doc:PopupViewTutorial>.
-@available(visionOS, unavailable)
 public struct PopupView: View {
     /// Creates a `PopupView` with the given popup.
     /// - Parameters:
@@ -89,11 +88,19 @@ public struct PopupView: View {
                     Button(action: {
                         isPresented?.wrappedValue = false
                     }, label: {
-                        Image(systemName: "xmark.circle")
+                        let imageName: String
+#if !os(visionOS)
+                        imageName = "xmark.circle"
+#else
+                        imageName = "xmark"
+#endif
+                        return Image(systemName: imageName)
                             .foregroundColor(.secondary)
                             .padding([.top, .bottom, .trailing], 4)
                     })
+#if !os(visionOS)
                     .buttonStyle(.plain)
+#endif
                 }
             }
             Divider()
@@ -155,7 +162,6 @@ public struct PopupView: View {
     }
 }
 
-@available(visionOS, unavailable)
 extension PopupView {
     private struct PopupElementList: View {
         let popupElements: [PopupElement]
@@ -183,7 +189,6 @@ extension PopupView {
     }
 }
 
-@available(visionOS, unavailable)
 extension PopupView {
     /// An object used to hold the result of evaluating the expressions of a popup.
     private final class Evaluation {
@@ -203,7 +208,6 @@ extension PopupView {
     }
 }
 
-@available(visionOS, unavailable)
 extension PopupView {
     /// Specifies whether a "close" button should be shown to the right of the popup title. If the "close"
     /// button is shown, you should pass in the `isPresented` argument to the `PopupView`

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -88,17 +88,12 @@ public struct PopupView: View {
                     Button(action: {
                         isPresented?.wrappedValue = false
                     }, label: {
-                        let imageName: String
-#if !os(visionOS)
-                        imageName = "xmark.circle"
-#else
-                        imageName = "xmark"
-#endif
-                        return Image(systemName: imageName)
-                            .foregroundColor(.secondary)
-                            .padding([.top, .bottom, .trailing], 4)
+                        Image(systemName: "xmark")
                     })
 #if !os(visionOS)
+                    .foregroundColor(.secondary)
+                    .padding([.top, .bottom, .trailing], 4)
+                    .symbolVariant(.circle)
                     .buttonStyle(.plain)
 #endif
                 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -85,11 +85,10 @@ public struct PopupView: View {
                 }
                 Spacer()
                 if showCloseButton {
-                    Button(action: {
+                    Button("Close", systemImage: "xmark") {
                         isPresented?.wrappedValue = false
-                    }, label: {
-                        Image(systemName: "xmark")
-                    })
+                    }
+                    .labelStyle(.iconOnly)
 #if !os(visionOS)
                     .foregroundColor(.secondary)
                     .padding([.top, .bottom, .trailing], 4)

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFeatureElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFeatureElement.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import Foundation
 
 /// Indicates how to display the attachments.
-@available(visionOS, unavailable)
 public enum AttachmentsFeatureElementDisplayType: Sendable {
     /// Show attachments as links.
     case list
@@ -27,7 +26,6 @@ public enum AttachmentsFeatureElementDisplayType: Sendable {
 }
 
 /// Common properties for elements which display feature attachments.
-@available(visionOS, unavailable)
 public protocol AttachmentsFeatureElement: Sendable {
     /// Indicates how to display the attachments.
     var attachmentsDisplayType: AttachmentsFeatureElementDisplayType { get }
@@ -44,7 +42,6 @@ public protocol AttachmentsFeatureElement: Sendable {
     var title: String { get }
 }
 
-@available(visionOS, unavailable)
 extension AttachmentsFeatureElementDisplayType {
     /// Creates a display type from an attachment popup element's display type.
     /// - Parameter kind: The display type of the popup element.

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsPopupElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsPopupElement.swift
@@ -14,7 +14,6 @@
 
 import ArcGIS
 
-@available(visionOS, unavailable)
 extension AttachmentsPopupElement: AttachmentsFeatureElement {
     /// Indicates how to display the attachments.
     public var attachmentsDisplayType: AttachmentsFeatureElementDisplayType {

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FeatureAttachment.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import UIKit
 
 /// The type of an attachment in a FeatureAttachment.
-@available(visionOS, unavailable)
 public enum FeatureAttachmentKind: Sendable {
     /// An attachment of another type.
     case other
@@ -30,7 +29,6 @@ public enum FeatureAttachmentKind: Sendable {
     case audio
 }
 
-@available(visionOS, unavailable)
 public protocol FeatureAttachment: Loadable {
     /// The type of the attachment.
     var featureAttachmentKind: FeatureAttachmentKind { get }
@@ -68,7 +66,6 @@ public protocol FeatureAttachment: Loadable {
     func makeThumbnail(width: Int, height: Int) async throws -> UIImage
 }
 
-@available(visionOS, unavailable)
 extension FeatureAttachmentKind {
     /// Creates a feature attachment kind from a popup attachment kind.
     /// - Parameter kind: The popup attachment kind.

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FormAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/FormAttachment.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import Foundation
 
-@available(visionOS, unavailable)
 extension FormAttachment: FeatureAttachment {
     /// The type of the attachment.
     public var featureAttachmentKind: FeatureAttachmentKind {

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/PopupAttachment.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/PopupAttachment.swift
@@ -15,7 +15,6 @@
 import ArcGIS
 import Foundation
 
-@available(visionOS, unavailable)
 extension PopupAttachment: FeatureAttachment {
     /// The type of the attachment.
     public var featureAttachmentKind: FeatureAttachmentKind {

--- a/Sources/ArcGISToolkit/Extensions/Swift/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/String.swift
@@ -24,6 +24,15 @@ extension String {
         )
     }
     
+    /// A localized string for the word "Close".
+    static var close: Self {
+        .init(
+            localized: "Close",
+            bundle: .toolkitModule,
+            comment: "A label for a button indicating that the view should be closed."
+        )
+    }
+    
     /// An error message explaining attachments with empty files (0 bytes) cannot be downloaded.
     static var emptyAttachmentDownloadErrorMessage: Self {
         .init(

--- a/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
+++ b/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
@@ -16,7 +16,6 @@ import SwiftUI
 import ArcGIS
 
 /// A view displaying an async image, with error display and progress view.
-@available(visionOS, unavailable)
 public struct AsyncImageView: View {
     /// The `URL` of the image.
     private var url: URL?


### PR DESCRIPTION
Swift #6156

I tried multiple pop up data sets with these changes to make sure I covered all the bases but I would still recommend looking at these changes yourself. You can test this by adding visionOS as a destination to the Examples app and just comment out the examples that aren't available on visionOS or mark the examples as `@available(visionOS, unavailable)`.

Here are some screenshots:
![Simulator Screenshot - Apple Vision Pro - 2024-10-29 at 13 35 45](https://github.com/user-attachments/assets/80a7a1f9-a40e-4d07-a49e-26e0a8fcf691)
![Simulator Screenshot - Apple Vision Pro - 2024-10-29 at 13 32 10](https://github.com/user-attachments/assets/6d219e33-94fa-4b43-8eb7-09eec5555286)
![Simulator Screenshot - Apple Vision Pro - 2024-10-29 at 09 02 59](https://github.com/user-attachments/assets/0ca233a3-f7cd-4c69-b42c-8369d816a215)
