### PR TITLE
Remove unneeded localized string initializers

### DIFF
--- a/Sources/ArcGISToolkit/Utility/MarkdownView.swift
+++ b/Sources/ArcGISToolkit/Utility/MarkdownView.swift
@@ -74,7 +74,7 @@ struct Visitor: MarkupVisitor {
     
     mutating func visitChildren(_ children: MarkupChildren) -> Result {
         var results = [Result]()
-        var combinedText = SwiftUI.Text("")
+        var combinedText = SwiftUI.Text(verbatim: "")
         var isPureText = false
         var containsBreak = false
         children.forEach {
@@ -87,7 +87,7 @@ struct Visitor: MarkupVisitor {
                 if isPureText {
                     results.append(.text(combinedText))
                 }
-                combinedText = SwiftUI.Text("")
+                combinedText = SwiftUI.Text(verbatim: "")
                 isPureText = false
                 results.append(child)
             }
@@ -170,7 +170,7 @@ struct Visitor: MarkupVisitor {
     }
     
     mutating func visitLineBreak(_ lineBreak: LineBreak) -> Result {
-        .text(SwiftUI.Text("\n"))
+        .text(SwiftUI.Text(verbatim: "\n"))
     }
     
     mutating func visitLink(_ link: Markdown.Link) -> Result {
@@ -191,7 +191,7 @@ struct Visitor: MarkupVisitor {
             AnyView(
                 ForEach(results.indices, id: \.self) { index in
                     HStack(alignment: .firstTextBaseline) {
-                        Text((index + 1).description) + Text(".")
+                        Text((index + 1).description) + Text(verbatim: ".")
                         results[index].resolve()
                     }
                     .padding(
@@ -209,7 +209,7 @@ struct Visitor: MarkupVisitor {
             if paragraph.isInList {
                 return .text(text)
             } else {
-                return .text(text + SwiftUI.Text("\n"))
+                return .text(text + SwiftUI.Text(verbatim: "\n"))
             }
         } else {
             return children


### PR DESCRIPTION
Stops these unneeded entries from being generated in the localized strings file:

<p align="center">
  <img width="50%" src="https://github.com/user-attachments/assets/547fb127-16ef-42a7-b8df-1d16bbdd5aec">
</p>