### PR TITLE
`CertificatePickerViewModelTests` - Remove outdated expected failure

### DIFF
--- a/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/CertificatePickerViewModelTests.swift
@@ -30,12 +30,6 @@ final class CertificatePickerViewModelTests: XCTestCase {
         
         model.proceedToPicker()
         
-#if swift(<5.10)
-        XCTExpectFailure(
-            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Swift 5.9. Ref Toolkit #699",
-            options: .nonStrict()
-        )
-#endif
         // Have to wait here because the proceed function is delayed to avoid a bug.
         await fulfillment(
             of: [
@@ -54,12 +48,6 @@ final class CertificatePickerViewModelTests: XCTestCase {
         
         model.proceedToUseCertificate(withPassword: "1234")
         
-#if swift(<5.10)
-        XCTExpectFailure(
-            "fulfillment(of:timeout:enforceOrder:) doesn't work properly with Swift 5.9. Ref Toolkit #699",
-            options: .nonStrict()
-        )
-#endif
         await fulfillment(
             of: [
                 expectation(


### PR DESCRIPTION
Closes #699 

Swift 6.0 is the current minimum