### PR TITLE
Revert "Drop AR components from Catalyst"

### DIFF
--- a/Examples/Examples/FlyoverExampleView.swift
+++ b/Examples/Examples/FlyoverExampleView.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
-@available(macCatalyst, unavailable)
 struct FlyoverExampleView: View {
     @State private var scene = Scene(
         item: PortalItem(

--- a/Examples/Examples/TableTopExampleView.swift
+++ b/Examples/Examples/TableTopExampleView.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
-@available(macCatalyst, unavailable)
 struct TableTopExampleView: View {
     @State private var scene: ArcGIS.Scene = {
         // Creates a scene layer from buildings REST service.

--- a/Examples/Examples/WorldScaleExampleView.swift
+++ b/Examples/Examples/WorldScaleExampleView.swift
@@ -20,7 +20,6 @@ import SwiftUI
 /// An example that utilizes the `WorldScaleSceneView` to show an augmented reality view
 /// of your current location. Because this is an example that can be run from anywhere,
 /// it places a red circle around your initial location which can be explored.
-@available(macCatalyst, unavailable)
 struct WorldScaleExampleView: View {
     @State private var scene: ArcGIS.Scene = {
         // Creates an elevation source from Terrain3D REST service.

--- a/Examples/ExamplesApp/Examples.swift
+++ b/Examples/ExamplesApp/Examples.swift
@@ -16,7 +16,11 @@ import SwiftUI
 
 struct Examples: View {
     /// The list of example lists.  Allows for a hierarchical navigation model for examples.
-    let lists = makeExamples()
+    let lists: [ExampleList] = [
+        .augmentedReality,
+        .geoview,
+        .views
+    ]
     
     var body: some View {
         NavigationStack {
@@ -27,22 +31,9 @@ struct Examples: View {
             .navigationBarTitleDisplayMode(.inline)
         }
     }
-    
-    static func makeExamples() -> [ExampleList] {
-        let common: [ExampleList] = [
-            .geoview,
-            .views
-        ]
-#if !targetEnvironment(macCatalyst)
-        return [.augmentedReality] + common
-#else
-        return common
-#endif
-    }
 }
 
 extension ExampleList {
-    @available(macCatalyst, unavailable)
     static let augmentedReality = Self(
         name: "Augmented Reality",
         examples: [

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -17,7 +17,6 @@ import SwiftUI
 import ArcGIS
 
 /// A scene view that provides an augmented reality fly over experience.
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public struct FlyoverSceneView: View {
 #if os(iOS)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -17,7 +17,6 @@ import SwiftUI
 import ArcGIS
 
 /// A scene view that provides an augmented reality table top experience.
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public struct TableTopSceneView: View {
 #if os(iOS)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
@@ -61,7 +61,6 @@ class WorldScaleCalibrationViewModel: ObservableObject {
     }
 }
 
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 extension WorldScaleSceneView {
     /// A view that allows the user to calibrate the heading of the scene view camera controller.
@@ -180,7 +179,6 @@ extension WorldScaleSceneView {
     }
 }
 
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 private extension WorldScaleSceneView.CalibrationView {
     var calibrationLabel: String {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -18,7 +18,6 @@ import ArcGIS
 import CoreLocation
 
 /// A scene view that provides an augmented reality world scale experience.
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public struct WorldScaleSceneView: View {
     /// The clipping distance of the scene view.
@@ -297,7 +296,6 @@ public struct WorldScaleSceneView: View {
 #endif
 }
 
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public extension WorldScaleSceneView {
     /// The type of tracking configuration used by the view.
@@ -331,7 +329,6 @@ private extension ARGeoTrackingConfiguration {
 }
 #endif
 
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 private extension WorldScaleSceneView {
     var calibrateLabel: String {
@@ -345,7 +342,6 @@ private extension WorldScaleSceneView {
     }
 }
 
-@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public extension WorldScaleSceneView {
 #if os(iOS)


### PR DESCRIPTION
Temporarily reverts #946 to allow the Samples app time to prepare.