### PR TITLE
Drop AR components from Catalyst

### DIFF
--- a/Examples/Examples/FlyoverExampleView.swift
+++ b/Examples/Examples/FlyoverExampleView.swift
@@ -16,6 +16,7 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
+@available(macCatalyst, unavailable)
 struct FlyoverExampleView: View {
     @State private var scene = Scene(
         item: PortalItem(

--- a/Examples/Examples/TableTopExampleView.swift
+++ b/Examples/Examples/TableTopExampleView.swift
@@ -16,6 +16,7 @@ import ArcGIS
 import ArcGISToolkit
 import SwiftUI
 
+@available(macCatalyst, unavailable)
 struct TableTopExampleView: View {
     @State private var scene: ArcGIS.Scene = {
         // Creates a scene layer from buildings REST service.

--- a/Examples/Examples/WorldScaleExampleView.swift
+++ b/Examples/Examples/WorldScaleExampleView.swift
@@ -20,6 +20,7 @@ import SwiftUI
 /// An example that utilizes the `WorldScaleSceneView` to show an augmented reality view
 /// of your current location. Because this is an example that can be run from anywhere,
 /// it places a red circle around your initial location which can be explored.
+@available(macCatalyst, unavailable)
 struct WorldScaleExampleView: View {
     @State private var scene: ArcGIS.Scene = {
         // Creates an elevation source from Terrain3D REST service.

--- a/Examples/ExamplesApp/Examples.swift
+++ b/Examples/ExamplesApp/Examples.swift
@@ -16,11 +16,7 @@ import SwiftUI
 
 struct Examples: View {
     /// The list of example lists.  Allows for a hierarchical navigation model for examples.
-    let lists: [ExampleList] = [
-        .augmentedReality,
-        .geoview,
-        .views
-    ]
+    let lists = makeExamples()
     
     var body: some View {
         NavigationStack {
@@ -31,9 +27,22 @@ struct Examples: View {
             .navigationBarTitleDisplayMode(.inline)
         }
     }
+    
+    static func makeExamples() -> [ExampleList] {
+        let common: [ExampleList] = [
+            .geoview,
+            .views
+        ]
+#if !targetEnvironment(macCatalyst)
+        return [.augmentedReality] + common
+#else
+        return common
+#endif
+    }
 }
 
 extension ExampleList {
+    @available(macCatalyst, unavailable)
     static let augmentedReality = Self(
         name: "Augmented Reality",
         examples: [

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -17,6 +17,7 @@ import SwiftUI
 import ArcGIS
 
 /// A scene view that provides an augmented reality fly over experience.
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public struct FlyoverSceneView: View {
 #if os(iOS)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -17,6 +17,7 @@ import SwiftUI
 import ArcGIS
 
 /// A scene view that provides an augmented reality table top experience.
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public struct TableTopSceneView: View {
 #if os(iOS)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
@@ -61,6 +61,7 @@ class WorldScaleCalibrationViewModel: ObservableObject {
     }
 }
 
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 extension WorldScaleSceneView {
     /// A view that allows the user to calibrate the heading of the scene view camera controller.
@@ -179,6 +180,7 @@ extension WorldScaleSceneView {
     }
 }
 
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 private extension WorldScaleSceneView.CalibrationView {
     var calibrationLabel: String {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -18,6 +18,7 @@ import ArcGIS
 import CoreLocation
 
 /// A scene view that provides an augmented reality world scale experience.
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public struct WorldScaleSceneView: View {
     /// The clipping distance of the scene view.
@@ -296,6 +297,7 @@ public struct WorldScaleSceneView: View {
 #endif
 }
 
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public extension WorldScaleSceneView {
     /// The type of tracking configuration used by the view.
@@ -329,6 +331,7 @@ private extension ARGeoTrackingConfiguration {
 }
 #endif
 
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 private extension WorldScaleSceneView {
     var calibrateLabel: String {
@@ -342,6 +345,7 @@ private extension WorldScaleSceneView {
     }
 }
 
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public extension WorldScaleSceneView {
 #if os(iOS)

--- a/Tests/ArcGISToolkitTests/ARTests.swift
+++ b/Tests/ArcGISToolkitTests/ARTests.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !os(visionOS)
+#if !os(visionOS) && !targetEnvironment(macCatalyst)
 import ArcGIS
 import SwiftUI
 import XCTest


### PR DESCRIPTION
Closes #889 

Re-removes AR support for Mac Catalyst after it had to be reverted in #955 to allow the Samples app to prepare.