### PR TITLE
Barcode UI improvements

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
@@ -101,6 +101,7 @@ struct DateTimeInput: View {
             } else {
                 if date == nil {
                     Image(systemName: "calendar")
+                        .font(.title2)
                         .accessibilityIdentifier("\(element.label) Calendar Image")
                         .foregroundColor(.secondary)
                 } else if !isRequired {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -135,7 +135,8 @@ private extension TextInput {
             }
 #endif
             .scrollContentBackground(.hidden)
-            if !text.isEmpty {
+            if !text.isEmpty,
+               !isBarcodeScanner {
                 ClearButton {
                     if !isFocused {
                         // If the user wasn't already editing the field provide
@@ -147,13 +148,14 @@ private extension TextInput {
                 }
                 .accessibilityIdentifier("\(element.label) Clear Button")
             }
-            if element.input is BarcodeScannerFormInput {
+            if isBarcodeScanner {
                 Button {
                     model.focusedElement = element
                     scannerIsPresented = true
                 } label: {
                     Image(systemName: "barcode.viewfinder")
-                        .foregroundStyle(.secondary)
+                        .font(.title2)
+                        .foregroundStyle(Color.accentColor)
                 }
                 .disabled(cameraIsDisabled)
                 .buttonStyle(.plain)
@@ -241,6 +243,12 @@ private extension TextInput {
             Spacer()
             InputFooter(element: element)
         }
+    }
+}
+
+private extension TextInput {
+    private var isBarcodeScanner: Bool {
+        element.input is BarcodeScannerFormInput
     }
 }
 


### PR DESCRIPTION
Adjust scan button size and color; remove Clear button for barcode input type:

![image](https://github.com/user-attachments/assets/5be61c17-8c21-4c35-8a0d-8cbe899b43d8)

For Apollo 958
