### PR TITLE
Mark `TextInput` extension unavailable for visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -248,6 +248,7 @@ private extension TextInput {
     }
 }
 
+@available(visionOS, unavailable)
 private extension TextInput {
     private var isBarcodeScanner: Bool {
         element.input is BarcodeScannerFormInput


### PR DESCRIPTION
Followup to #960 