### PR TITLE
Update corner radius for floating panel on visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -81,7 +81,7 @@ struct FloatingPanel<Content>: View where Content: View {
             .clipShape(
                 RoundedCorners(
                     corners: isPortraitOrientation ? [.topLeft, .topRight] : .allCorners,
-                    radius: 10
+                    radius: .cornerRadius
                 )
             )
             .shadow(radius: 10)
@@ -223,6 +223,15 @@ private extension CGFloat {
     static let handleFrameHeight: CGFloat = 30
     
     static let minHeight: CGFloat = 66
+    
+    /// The corner radius of the floating panel.
+    static let cornerRadius: CGFloat = {
+#if os(visionOS)
+        32
+#else
+        10
+#endif
+    }()
 }
 
 private extension Color {


### PR DESCRIPTION
Thanks, @PeggyDu09 for this idea!

Before, if you used the floating panel in a window that didn't have a navigation bar, it would look like this. The upper left corner is getting cut off.
![simulator_screenshot_8FD466B1-4624-486D-B254-0F9E29F8B73F (1)](https://github.com/user-attachments/assets/04748219-2088-4cfa-969a-8e8202aa3667)

With this change it now looks like this:
![simulator_screenshot_B7870BF3-DF4A-4C61-AA3C-3ABE6B02639C (1)](https://github.com/user-attachments/assets/4cc1a346-631d-4346-8099-556e26de8eaf)
![Simulator Screenshot - Apple Vision Pro - 2024-11-08 at 15 48 42](https://github.com/user-attachments/assets/6f2086eb-6d72-47a6-adb5-216d7d8b44a8)
