### PR TITLE
Fix visionOS 2.1 compile errors

### DIFF
--- a/Sources/ArcGISToolkit/Common/CodeScanner.swift
+++ b/Sources/ArcGISToolkit/Common/CodeScanner.swift
@@ -155,7 +155,7 @@ class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadata
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+#if !os(visionOS)
         guard let videoCaptureDevice = AVCaptureDevice.default(for: .video) else { return }
         let videoInput: AVCaptureDeviceInput
         
@@ -212,6 +212,7 @@ class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadata
         if #available(iOS 17.0, *) {
             videoRotationProvider = RotationCoordinator(videoCaptureDevice: videoCaptureDevice, previewLayer: previewLayer)
         }
+#endif
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -362,6 +363,7 @@ class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadata
     
     /// Focus on and adjust exposure at the point of interest.
     private func updateAutoFocus(for point: CGPoint) {
+#if !os(visionOS)
         let convertedPoint = previewLayer.captureDevicePointConverted(fromLayerPoint: point)
         guard let device = AVCaptureDevice.default(for: .video) else { return }
         do {
@@ -376,6 +378,7 @@ class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadata
             }
             device.unlockForConfiguration()
         } catch { }
+#endif
     }
     
     private func updateReticle(for point: CGPoint) {

--- a/Sources/ArcGISToolkit/Common/FlashlightButton.swift
+++ b/Sources/ArcGISToolkit/Common/FlashlightButton.swift
@@ -20,7 +20,11 @@ struct FlashlightButton: View {
     @State private var torchIsOn = false
     
     var device: AVCaptureDevice? {
+#if os(visionOS)
+        nil
+#else
         .default(for: .video)
+#endif
     }
     
     var hasTorch: Bool {


### PR DESCRIPTION
It looks like this API was added in visionOS 2.1 which is interesting because by default we don't have access to the camera. But we can look deeper into this later because these toolkit types aren't available for visionOS right now anyway.
![Screenshot 2024-11-14 at 9 57 57 AM](https://github.com/user-attachments/assets/c742d576-ea51-4ea9-a049-14afaca6134c)
