### PR TITLE
Add `.spi.yml`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://developers.arcgis.com/swift/toolkit-api-reference/documentation/arcgistoolkit/"


### PR DESCRIPTION
Thanks to @yo1995 for the suggestion

Adds a link to our documentation on our Swift Package Index [listing](https://swiftpackageindex.com/Esri/arcgis-maps-sdk-swift-toolkit), just like the [SDK entry](https://swiftpackageindex.com/Esri/arcgis-maps-sdk-swift).

<p align="center">
  <img width="50%" src="https://github.com/user-attachments/assets/2bd12be8-801b-4327-91df-af376ec6cbb0">
</p>
