### PR TITLE
`Carousel` - Fix horizontal manual scroll on Catalyst

### DIFF
--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -27,6 +27,9 @@ struct Carousel<Content: View>: View {
     /// The content shown in the Carousel.
     let content: (_: CGSize, _: (() -> Void)?) -> Content
     
+    /// The amount to offset the scroll indicator.
+    let scrollIndicatorOffset = 10.0
+    
     /// This number is used to compute the final width that allows for a partially visible cell.
     var cellBaseWidth = 120.0
     
@@ -55,7 +58,6 @@ struct Carousel<Content: View>: View {
             ScrollViewReader { scrollViewProxy in
                 ScrollView(.horizontal) {
                     makeCommonScrollViewContent(scrollViewProxy)
-                        .padding(.bottom, 10)
                 }
             }
             .onAppear {
@@ -74,7 +76,6 @@ struct Carousel<Content: View>: View {
         ScrollViewReader { scrollViewProxy in
             ScrollView(.horizontal) {
                 makeCommonScrollViewContent(scrollViewProxy)
-                    .padding(.bottom, 10)
             }
         }
         .onScrollGeometryChange(for: CGFloat.self) { geometry in
@@ -94,6 +95,9 @@ struct Carousel<Content: View>: View {
             .id(contentIdentifier)
             .frame(width: cellSize.width, height: cellSize.height)
             .clipped()
+            // Pad the content such that the scroll indicator appears beneath it
+            // so that the content is not covered. 
+            .padding(.bottom, scrollIndicatorOffset)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -68,7 +68,7 @@ struct Carousel<Content: View>: View {
             }
         }
         // When a GeometryReader is within a List, height must be specified.
-        .frame(height: cellSize.height)
+        .frame(height: cellSize.height + scrollIndicatorOffset)
     }
     
     @available(iOS 18.0, *)


### PR DESCRIPTION
In #846 we pushed the scrollbar below the Carousel content.

On Mac Catalyst scrolling with a scroll wheel on a mouse (no Trackpad) isn't supported and so the scroll indicator is necessary to support drag based scrolling. This adjusts an internal frame height such that the height increase from the indicator offset is now included in the form's VStack and the scroll indicator is hittable with a mouse.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/a2f4253d-f661-43ff-8ddf-885f8eb69249"> | <img src="https://github.com/user-attachments/assets/5fe2fa00-2de1-4030-8978-77fb85a1a400"> |