### PR TITLE
`UtilityNetworkTrace` - Enhance trace result labels

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -424,7 +424,7 @@ public struct UtilityNetworkTrace: View {
                             }
                         }
                     } label: {
-                        Text(viewModel.selectedTrace?.elementResults.count ?? 0, format: .number)
+                        Text.makeResultsLabel(viewModel.selectedTrace?.elementResults.count ?? 0)
                             .catalystPadding(4)
                     }
                 }
@@ -459,7 +459,7 @@ public struct UtilityNetworkTrace: View {
                             }
                         }
                     } label: {
-                        Text(viewModel.selectedTrace?.utilityFunctionTraceResult?.functionOutputs.count ?? 0, format: .number)
+                        Text.makeResultsLabel(viewModel.selectedTrace?.utilityFunctionTraceResult?.functionOutputs.count ?? 0)
                             .catalystPadding(4)
                     }
                 }
@@ -1027,6 +1027,16 @@ private extension String {
             localized: "Zoom To Result",
             bundle: .toolkitModule,
             comment: "A user option specifying that a map should automatically change to show completed trace results."
+        )
+    }
+}
+
+private extension Text {
+    static func makeResultsLabel(_ results: Int) -> Self {
+        .init(
+            "^[\(results) Results](inflect: true)",
+            bundle: .toolkitModule,
+            comment: "A label indicating the number of results of a utility network trace."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -1,6 +1,9 @@
 /* A label declaring the number of starting points selected for a utility network trace. */
 "%lld selected" = "%lld selected";
 
+/* A label indicating the number of results of a utility network trace. */
+"^[%lld Results](inflect: true)" = "^[%lld Results](inflect: true)";
+
 /* An alert message indicating that a certificate is required to access
 content on a remote host. The variable is the host that prompted the challenge. */
 "A certificate is required to access content on %@." = "A certificate is required to access content on %@.";


### PR DESCRIPTION
Closes #918 

| 0 Results Example | Multiple Results Example |
|---|---|
| <img src="https://github.com/user-attachments/assets/ea60ea00-cc58-4c66-8590-7aa7345fb8c7"> | <img src="https://github.com/user-attachments/assets/88019741-2ce2-4824-bcad-a12a5e3b4bdc"> |
