### PR TITLE
Add `FloorFilter.automaticSingleSiteSelectionDisabled(_:)`

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -121,26 +121,27 @@ public struct FloorFilter: View {
     private var viewpoint: Binding<Viewpoint?>
     
     /// Button to open and close the site and facility selector.
+    @ViewBuilder
     private var sitesAndFacilitiesButton: some View {
-        Button {
-            siteAndFacilitySelectorIsPresented.toggle()
-        } label: {
-            Group {
-                if [.notLoaded, .loading].contains(viewModel.loadStatus) {
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                } else if viewModel.loadStatus == .loaded {
-                    Image(systemName: "building.2")
-                } else {
-                    Image(systemName: "exclamationmark.circle")
-                }
+        if [.notLoaded, .loading].contains(viewModel.loadStatus) {
+            ProgressView()
+                .padding(.toolkitDefault)
+                .progressViewStyle(.circular)
+        } else if viewModel.loadStatus == .loaded {
+            Button {
+                siteAndFacilitySelectorIsPresented.toggle()
+            } label: {
+                Image(systemName: "building.2")
+                    .padding(.toolkitDefault)
+                    .contentShape(Rectangle())
             }
-            .padding(.toolkitDefault)
-            .contentShape(Rectangle())
+            .accessibilityIdentifier("Floor Filter button")
+            .buttonStyle(.plain)
+            .foregroundStyle(.tint)
+        } else {
+            Image(systemName: "exclamationmark.circle")
+                .padding(.toolkitDefault)
         }
-        .accessibilityIdentifier("Floor Filter button")
-        .buttonStyle(.plain)
-        .foregroundStyle(.tint)
     }
     
     /// A view that displays the level selector and the sites and facilities button.

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -102,6 +102,11 @@ public struct FloorFilter: View {
     /// A Boolean value that indicates whether the site and facility selector is presented.
     @State private var siteAndFacilitySelectorIsPresented = false
     
+    /// A Boolean value controlling whether a site is automatically selected upon load completion.
+    ///
+    /// This property is only relevant when the FloorManager contains a single site.
+    private var automaticSingleSiteSelectionDisabled: Bool = false
+    
     /// The selected site, floor, or level.
     private var selection: Binding<FloorFilterSelection?>?
     
@@ -121,11 +126,13 @@ public struct FloorFilter: View {
             siteAndFacilitySelectorIsPresented.toggle()
         } label: {
             Group {
-                if viewModel.isLoading {
+                if [.notLoaded, .loading].contains(viewModel.loadStatus) {
                     ProgressView()
                         .progressViewStyle(.circular)
-                } else {
+                } else if viewModel.loadStatus == .loaded {
                     Image(systemName: "building.2")
+                } else {
+                    Image(systemName: "exclamationmark.circle")
                 }
             }
             .padding(.toolkitDefault)
@@ -210,7 +217,7 @@ public struct FloorFilter: View {
         // Ensure space for filter text field on small screens in landscape
         .frame(minHeight: 100)
         .environmentObject(viewModel)
-        .disabled(viewModel.isLoading)
+        .disabled(viewModel.loadStatus != .loaded)
         .onChange(selection?.wrappedValue) { newValue in
             // Prevent a double-set if the view model triggered the original change.
             guard newValue != viewModel.selection else { return }
@@ -232,12 +239,40 @@ public struct FloorFilter: View {
                 viewModel.onViewpointChanged(newViewpoint)
             }
         }
+        .task {
+            await viewModel.loadFloorManager()
+            if !automaticSingleSiteSelectionDisabled,
+               viewModel.sites.count == 1,
+               let firstSite = viewModel.sites.first {
+                // If we have only one site, select it.
+                viewModel.setSite(firstSite, zoomTo: true)
+            }
+        }
+    }
+}
+
+@available(visionOS, unavailable)
+public extension FloorFilter {
+    /// Adds a condition that controls whether a site in the Floor Manager
+    /// is automatically selected upon loading.
+    ///
+    /// Automatic selection only occurs when the Floor Manager contains a
+    /// single site.
+    /// - Parameter disabled: A Boolean value that determines whether
+    /// automatic single site selection is disabled..
+    /// - Returns: A view that conditionally disables automatic single site
+    /// selection.
+    /// - Since: 200.7
+    func automaticSingleSiteSelectionDisabled(_ disabled: Bool = true) -> Self {
+        var copy = self
+        copy.automaticSingleSiteSelectionDisabled = disabled
+        return copy
     }
     
     /// The width of the level selector.
     /// - Parameter width: The new width for the level selector.
     /// - Returns: The `FloorFilter`.
-    public func levelSelectorWidth(_ width: CGFloat) -> Self {
+    func levelSelectorWidth(_ width: CGFloat) -> Self {
         var copy = self
         copy.levelSelectorWidth = width
         return copy

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -229,6 +229,15 @@ public struct FloorFilter: View {
             case .none: viewModel.clearSelection()
             }
         }
+        .onChange(viewModel.loadStatus) { newLoadStatus in
+            if newLoadStatus == .loaded,
+               !automaticSingleSiteSelectionDisabled,
+               viewModel.sites.count == 1,
+               let firstSite = viewModel.sites.first {
+                // If we have only one site, select it.
+                viewModel.setSite(firstSite, zoomTo: true)
+            }
+        }
         .onChange(viewModel.selection) { newValue in
             // Prevent a double-set if the user triggered the original change.
             guard selection?.wrappedValue != newValue else { return }
@@ -238,15 +247,6 @@ public struct FloorFilter: View {
             guard isNavigating.wrappedValue else { return }
             if let newViewpoint {
                 viewModel.onViewpointChanged(newViewpoint)
-            }
-        }
-        .task {
-            await viewModel.loadFloorManager()
-            if !automaticSingleSiteSelectionDisabled,
-               viewModel.sites.count == 1,
-               let firstSite = viewModel.sites.first {
-                // If we have only one site, select it.
-                viewModel.setSite(firstSite, zoomTo: true)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterViewModel.swift
@@ -39,6 +39,8 @@ final class FloorFilterViewModel: ObservableObject {
                 self.loadStatus = loadStatus
             }
         }
+        
+        loadFloorManager()
     }
     
     deinit {
@@ -95,17 +97,6 @@ final class FloorFilterViewModel: ObservableObject {
     /// Sets the current selection to `nil`.
     func clearSelection() {
         selection = nil
-    }
-    
-    /// Loads the `FloorManager` if needed.
-    func loadFloorManager() async {
-        floorManager.cancelLoad()
-        
-        do {
-            try await floorManager.load()
-        } catch {
-            print("error: \(error)")
-        }
     }
     
     /// Allows model users to alert the model that the viewpoint has changed.
@@ -257,6 +248,21 @@ final class FloorFilterViewModel: ObservableObject {
         if let selectedLevel = selection?.level {
             levels.forEach {
                 $0.isVisible = $0.verticalOrder == selectedLevel.verticalOrder
+            }
+        }
+    }
+    
+    /// Loads the `FloorManager` if needed.
+    private func loadFloorManager() {
+        guard floorManager.loadStatus == .notLoaded,
+              floorManager.loadStatus != .loading else {
+            return
+        }
+        Task {
+            do {
+                try await floorManager.load()
+            } catch {
+                print("error: \(error)")
             }
         }
     }


### PR DESCRIPTION
Closes #936 

Fulfills the user request in the linked issue by offering an option to disable the following functionality from the component design spec:

> If there is only 1 site, select it and don't display the sites browser.

Specifically this adds `FloorFilter.automaticSingleSiteSelectionDisabled(_:)` which when used prevents a single site from being automatically selected. If there is more than one site, this modifier has no effect.