### PR TITLE
`UtilityNetworkTrace` - Fix button capitalization

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -326,6 +326,9 @@ public struct UtilityNetworkTrace: View {
                         } message: {
                             Text(String.deleteAllStartingPointsMessage)
                         }
+                        // Override default uppercase capitalization for list
+                        // section headers on iOS and iPadOS.
+                        .textCase(nil)
                     }
                 }
             }


### PR DESCRIPTION
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/12338c1a-5010-4008-985d-b9d40b50539b"> | <img src="https://github.com/user-attachments/assets/a7fdb1b3-526b-4daa-b4b2-5c3b093a9031"> |

This change has no effect on Mac Catalyst.