### PR TITLE
add sensory feedback, haptics, to compass

### DIFF
--- a/Examples/Examples/CompassExampleView.swift
+++ b/Examples/Examples/CompassExampleView.swift
@@ -30,8 +30,23 @@ struct CompassExampleView: View {
                 .onViewpointChanged(kind: .centerAndScale) { viewpoint = $0 }
                 .overlay(alignment: .topTrailing) {
                     Compass(rotation: viewpoint?.rotation, mapViewProxy: proxy)
+                        .snapToZeroSensoryFeedbackIfAvailable()
                         .padding()
                 }
+        }
+    }
+}
+
+private extension Compass {
+    /// Enables the sensory feedback when the compass snaps to `zero`
+    /// when sensory feedback is available.
+    @ViewBuilder
+    func snapToZeroSensoryFeedbackIfAvailable() -> some View {
+        if #available(iOS 17, *) {
+            snapToZeroSensoryFeedback()
+        } else {
+            // Fallback on earlier versions
+            self
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -55,7 +55,6 @@ public struct Compass: View {
     /// when the heading snaps to zero.
     private var snapToZeroSensoryFeedbackEnabled: Bool = false
     
-    
     /// Creates a compass with a heading based on compass directions (0° indicates a direction
     /// toward true North, 90° indicates a direction toward true East, etc.).
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -122,6 +122,7 @@ public struct Compass: View {
 private extension View {
     /// Enables the snap to zero sensory feedback
     /// when it is available.
+    @available(visionOS, unavailable)
     @ViewBuilder
     func snapToZeroSensoryFeedback(enabled: Bool, heading: Double) -> some View {
         if #available(iOS 17.0, *) {
@@ -142,7 +143,6 @@ private extension View {
             self
         }
     }
-
 }
 
 @available(visionOS, unavailable)

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -35,9 +35,8 @@ public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
-    /// A Boolean value indicating whether sensory feedback is enabled
-    /// when the heading snaps to zero.
-    private var snapToZeroSensoryFeedbackEnabled: Bool = false
+    /// An action to perform when the compass is tapped.
+    private var action: (() -> Void)?
     
     /// A Boolean value indicating whether the compass should automatically
     /// hide/show itself when the heading is `0`.
@@ -52,8 +51,10 @@ public struct Compass: View {
     /// The width and height of the compass.
     private var size: CGFloat = 44
     
-    /// An action to perform when the compass is tapped.
-    private var action: (() -> Void)?
+    /// A Boolean value indicating whether sensory feedback is enabled
+    /// when the heading snaps to zero.
+    private var snapToZeroSensoryFeedbackEnabled: Bool = false
+    
     
     /// Creates a compass with a heading based on compass directions (0° indicates a direction
     /// toward true North, 90° indicates a direction toward true East, etc.).

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -35,7 +35,11 @@ public struct Compass: View {
     /// The opacity of the compass.
     @State private var opacity: Double = .zero
     
-    /// A Boolean value indicating whether  the compass should automatically
+    /// A Boolean value indicating whether sensory feedback is enabled
+    /// when the heading snaps to zero.
+    private var snapToZeroSensoryFeedbackEnabled: Bool = false
+    
+    /// A Boolean value indicating whether the compass should automatically
     /// hide/show itself when the heading is `0`.
     private var autoHide: Bool = true
     
@@ -110,8 +114,35 @@ public struct Compass: View {
                                  """
                     )
                 )
+                .snapToZeroSensoryFeedback(enabled: snapToZeroSensoryFeedbackEnabled, heading: heading)
         }
     }
+}
+
+private extension View {
+    /// Enables the snap to zero sensory feedback
+    /// when it is available.
+    @ViewBuilder
+    func snapToZeroSensoryFeedback(enabled: Bool, heading: Double) -> some View {
+        if #available(iOS 17.0, *) {
+            if enabled {
+                sensoryFeedback(.selection, trigger: heading) { oldValue, newValue in
+                    if (!oldValue.isZero && newValue.isZero) ||
+                        (oldValue.isZero && !newValue.isZero) {
+                        return true
+                    } else {
+                        return false
+                    }
+                }
+            } else {
+                self
+            }
+        } else {
+            // Fallback on earlier versions
+            self
+        }
+    }
+
 }
 
 @available(visionOS, unavailable)
@@ -165,6 +196,14 @@ public extension Compass {
     func autoHideDisabled(_ disable: Bool = true) -> Self {
         var copy = self
         copy.autoHide = !disable
+        return copy
+    }
+    
+    /// Enables sensory feedback when the heading snaps to `zero`.
+    @available(iOS 17, *)
+    func snapToZeroSensoryFeedback() -> Self {
+        var copy = self
+        copy.snapToZeroSensoryFeedbackEnabled = true
         return copy
     }
 }


### PR DESCRIPTION
Closes #990

As part of an app I am building I have added sensory feedback when the MapView rotation/heading snaps to zero. This has been a nice feature. I think it could be useful to build this feature into the Compass component.

@dg0yal thoughts on this? 