### PR TITLE
Refactor `SearchView` selection

### DIFF
--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -392,18 +392,9 @@ struct SearchResultList: View {
     var body: some View {
         if searchResults.count != 1 {
             if searchResults.count > 1 {
-                List {
-                    // Only show the list if we have more than one result.
-                    ForEach(searchResults) { result in
-                        HStack {
-                            ResultRow(searchResult: result)
-                                .onTapGesture {
-                                    selectedResult = result
-                                }
-                            Spacer()
-                        }
-                        .selected(result == selectedResult)
-                    }
+                List(searchResults, selection: $selectedResult) { result in
+                    ResultRow(searchResult: result)
+                        .tag(result)
                 }
             } else if searchResults.isEmpty {
                 NoResultsView(message: noResultsMessage)
@@ -424,13 +415,9 @@ struct SearchSuggestionList: View {
     
     var body: some View {
         if !suggestionResults.isEmpty {
-            List {
-                ForEach(suggestionResults) { suggestion in
-                    ResultRow(searchSuggestion: suggestion)
-                        .onTapGesture() {
-                            currentSuggestion = suggestion
-                        }
-                }
+            List(suggestionResults, selection: $currentSuggestion) { suggestion in
+                ResultRow(searchSuggestion: suggestion)
+                    .tag(suggestion)
             }
         } else {
             NoResultsView(message: noResultsMessage)
@@ -469,7 +456,7 @@ struct ResultRow: View {
                 if !subtitle.isEmpty {
                     Text(subtitle)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -180,7 +180,7 @@ public enum SearchOutcome: Sendable {
     /// that result is automatically assigned to this property. If there are multiple results, the view sets
     /// this property upon user selection. This property is observable. The view should observe this
     /// property and update the associated GeoView's viewpoint, if configured.
-    var selectedResult: SearchResult? {
+    @Published var selectedResult: SearchResult? {
         willSet {
             (selectedResult?.geoElement as? Graphic)?.isSelected = false
         }
@@ -227,7 +227,7 @@ public enum SearchOutcome: Sendable {
     }
     
     /// The suggestion currently selected by the user.
-    var currentSuggestion: SearchSuggestion? {
+    @Published var currentSuggestion: SearchSuggestion? {
         didSet {
             if let currentSuggestion = currentSuggestion {
                 acceptSuggestion(currentSuggestion)

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -38,26 +38,6 @@ struct KeyboardStateChangedModifier: ViewModifier {
     }
 }
 
-/// A modifier which displays a background and shadow for a view. Used to represent a selected view.
-struct SelectedModifier: ViewModifier {
-    /// A Boolean value that indicates whether view should display as selected.
-    var isSelected: Bool
-    
-    func body(content: Content) -> some View {
-        if isSelected {
-            content
-                .background(Color.secondary.opacity(0.8))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .shadow(
-                    color: .secondary.opacity(0.8),
-                    radius: 2
-                )
-        } else {
-            content
-        }
-    }
-}
-
 extension View {
     /// Sets a closure to perform when the keyboard state has changed.
     /// - Parameter action: The closure to perform when the keyboard state has changed.
@@ -90,15 +70,6 @@ extension View {
     func catalystPadding(_ length: CGFloat? = nil) -> some View {
         return self
             .padding(isMacCatalyst ? [.horizontal] : [], length)
-    }
-    
-    /// View modifier used to denote the view is selected.
-    /// - Parameter isSelected: `true` if the view is selected, `false` otherwise.
-    /// - Returns: The modified view.
-    func selected(
-        _ isSelected: Bool = false
-    ) -> some View {
-        modifier(SelectedModifier(isSelected: isSelected))
     }
     
     /// Performs the provided action when the view appears after a slight delay.


### PR DESCRIPTION
Use built-in selection mechanism. This ensures that rows have the proper highlight and selection colors and that they have a hover effect on visionOS.

  | Before | After
--- | ------ | -----
iOS | ![Screen Recording 2025-01-10 at 9 49 13 PM](https://github.com/user-attachments/assets/a9b0486d-4eae-4a3a-98fc-2a09d3ef91c9) | ![Screen Recording 2025-01-10 at 9 43 09 PM](https://github.com/user-attachments/assets/029078dc-de9e-454c-8da2-7480bf8a01df)
Mac Catalyst | ![Screen Recording 2025-01-10 at 9 50 34 PM](https://github.com/user-attachments/assets/df1351b3-8bc4-4fb8-a13b-3e2860a37ded) | ![Screen Recording 2025-01-10 at 9 38 34 PM](https://github.com/user-attachments/assets/4e7188a1-cd34-421a-bee4-476a72f3e127)
visionOS | ![Screen Recording 2025-01-10 at 10 00 33 PM](https://github.com/user-attachments/assets/60a1c9b2-65b8-4c6f-b4a2-973d331e41cd) | ![Screen Recording 2025-01-10 at 9 37 26 PM](https://github.com/user-attachments/assets/53d33527-ea6c-4842-b6c8-0d054dd72777)


