### PR TITLE
Remove use of `View.foregroundColor(_:)`

### DIFF
--- a/AuthenticationExample/AuthenticationExample/LoadableImageView.swift
+++ b/AuthenticationExample/AuthenticationExample/LoadableImageView.swift
@@ -33,7 +33,7 @@ struct LoadableImageView: View {
             case .failure:
                 Image(systemName: "exclamationmark.circle")
                     .aspectRatio(contentMode: .fit)
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
             case .success(let image):
                 Image(uiImage: image)
                     .resizable()

--- a/AuthenticationExample/AuthenticationExample/MapItemView.swift
+++ b/AuthenticationExample/AuthenticationExample/MapItemView.swift
@@ -34,7 +34,7 @@ struct MapItemView: View {
             case .failure(let error):
                 Text(error.localizedDescription)
                     .font(.footnote)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .task {

--- a/AuthenticationExample/AuthenticationExample/SignInView.swift
+++ b/AuthenticationExample/AuthenticationExample/SignInView.swift
@@ -48,14 +48,14 @@ struct SignInView: View {
 #else
                     .font(.footnote)
 #endif
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 signInButton
             }
             Spacer()
             if let error = error, !error.isChallengeCancellationError {
                 Text(error.localizedDescription)
                     .font(.footnote)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .task {

--- a/AuthenticationExample/AuthenticationExample/UserView.swift
+++ b/AuthenticationExample/AuthenticationExample/UserView.swift
@@ -30,7 +30,7 @@ struct UserView: View {
                 } else {
                     Image(systemName: "person.circle")
                         .resizable()
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
             .frame(width: 100, height: 100, alignment: .center)
@@ -92,7 +92,7 @@ struct UserAttributeView: View {
         VStack(alignment: .leading, spacing: 2) {
             Text(title)
                 .lineLimit(1)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .font(.footnote)
             Text(detail)
                 .font(.caption)
@@ -113,7 +113,7 @@ struct UserAttributeListView: View {
         VStack(alignment: .leading, spacing: 2) {
             Text(title)
                 .lineLimit(1)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .font(.footnote)
             Text(details.map(\.description).joined(separator: "\r"))
                 .font(.caption)

--- a/AuthenticationExample/AuthenticationExample/WebMapsView.swift
+++ b/AuthenticationExample/AuthenticationExample/WebMapsView.swift
@@ -80,7 +80,7 @@ struct PortalItemView: View {
                     .font(.caption)
                 Text(item.snippet)
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
         }

--- a/Examples/Examples/FloorFilterExampleView.swift
+++ b/Examples/Examples/FloorFilterExampleView.swift
@@ -83,7 +83,7 @@ struct FloorFilterExampleView: View {
                         "Map load error!",
                         systemImage: "exclamationmark.triangle"
                     )
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
                     .frame(
                         maxWidth: .infinity,
                         maxHeight: .infinity,

--- a/JobManagerExample/JobManagerExample/JobManagerExampleView.swift
+++ b/JobManagerExample/JobManagerExample/JobManagerExampleView.swift
@@ -176,13 +176,13 @@ private struct JobView: View {
             if let error {
                 Text(error.localizedDescription)
                     .font(.footnote)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             } else {
                 if let message {
                     Text(message.text)
                         .font(.footnote)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
                 if isShowingProgress {

--- a/Sources/ArcGISToolkit/Common/AttachmentList.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentList.swift
@@ -45,7 +45,7 @@ struct AttachmentRow: View  {
                         .lineLimit(1)
                         .truncationMode(.middle)
                     Text(attachmentModel.attachment.measuredSize, format: .byteCount(style: .file))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -85,7 +85,7 @@ struct AttachmentLoadButton: View  {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
 #if !os(visionOS)
-                        .foregroundColor(.accentColor)
+                        .foregroundStyle(Color.accentColor)
 #endif
                 case .loading:
                     ProgressView()
@@ -95,7 +95,7 @@ struct AttachmentLoadButton: View  {
                     Image(systemName: "exclamationmark.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                         .background(Color.clear)
                 }
             }

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -215,7 +215,7 @@ struct AttachmentPreview: View {
                         Image(systemName: "square.and.arrow.down")
                         Spacer()
                     }
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 }
             }
             .font(.caption)
@@ -261,7 +261,7 @@ struct ThumbnailViewFooter: View {
             HStack {
                 if !attachmentModel.name.isEmpty {
                     Text(attachmentModel.name)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .font(.caption)
                         .lineLimit(1)
                 }

--- a/Sources/ArcGISToolkit/Common/ThumbnailView.swift
+++ b/Sources/ArcGISToolkit/Common/ThumbnailView.swift
@@ -43,7 +43,7 @@ struct ThumbnailView: View  {
         .frame(width: size.width, height: size.height, alignment: .center)
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .contentShape(RoundedRectangle(cornerRadius: 4))
-        .foregroundColor(foregroundColor(for: attachmentModel))
+        .foregroundStyle(foregroundColor(for: attachmentModel))
     }
     
     /// The foreground color of the thumbnail image.

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -257,7 +257,7 @@ private extension View {
                              """
                 )
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.bottom)
                 HStack {
@@ -348,7 +348,7 @@ private extension View {
                     )
                 )
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.bottom)
                 HStack {

--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -48,7 +48,7 @@ struct TrustHostViewModifier: ViewModifier {
         )
         .multilineTextAlignment(.center)
         .font(.subheadline)
-        .foregroundColor(.secondary)
+        .foregroundStyle(.secondary)
     }
     
     func body(content: Content) -> some View {

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryCell.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryCell.swift
@@ -56,7 +56,7 @@ struct BasemapGalleryCell: View {
                 Text(item.name ?? "")
                     .font(Font.custom("AvenirNext-Regular", fixedSize: 12))
                     .multilineTextAlignment(.center)
-                    .foregroundColor(item.hasError ? .secondary : .primary)
+                    .foregroundStyle(item.hasError ? .secondary : .primary)
             }
 #if os(visionOS)
             .contentShape(.hoverEffect, .rect(cornerRadius: 12))
@@ -78,10 +78,10 @@ struct BasemapGalleryCell: View {
                         ZStack {
                             // For a white background behind the exclamation mark.
                             Circle()
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                                 .frame(width: 16, height: 16)
                             Image(systemName: "exclamationmark.circle.fill")
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                                 .frame(width: 32, height: 32)
                         }
                         Spacer()
@@ -91,7 +91,7 @@ struct BasemapGalleryCell: View {
             } else {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(lineWidth: isSelected ? 2 : 0)
-                    .foregroundColor(Color.accentColor)
+                    .foregroundStyle(Color.accentColor)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -228,7 +228,7 @@ extension Bookmarks {
         } icon: {
             Image(systemName: "bookmark.slash")
         }
-        .foregroundColor(.primary)
+        .foregroundStyle(.primary)
         .padding()
     }
 }

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
@@ -41,7 +41,7 @@ struct BookmarksHeader: View {
                     comment: "A label prompting the user to make a selection from the available bookmarks."
                 )
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             }
             .frame(
                 maxWidth: .infinity,

--- a/Sources/ArcGISToolkit/Components/Compass/CompassBody.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/CompassBody.swift
@@ -22,8 +22,11 @@ struct CompassBody: View {
             Circle()
                 .inset(by: borderWidth / 2.0)
                 .stroke(lineWidth: borderWidth)
-                .foregroundColor(.outline)
-                .background(Circle().foregroundColor(.fill))
+                .foregroundStyle(Color.outline)
+                .background {
+                    Circle()
+                        .foregroundStyle(Color.fill)
+                }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Compass/Needle.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Needle.swift
@@ -88,7 +88,7 @@ struct NeedleCenter: View {
     var body: some View {
         Circle()
             .scale(0.25)
-            .foregroundColor(.bronze)
+            .foregroundStyle(Color.bronze)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/GroupView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/GroupView.swift
@@ -89,7 +89,7 @@ extension GroupView {
                         .accessibilityIdentifier("\(element.label)")
                         .multilineTextAlignment(.leading)
                         .font(.title2)
-                        .foregroundColor(.primary)
+                        .foregroundStyle(.primary)
                 }
                 
                 if !element.description.isEmpty {
@@ -97,7 +97,7 @@ extension GroupView {
                         .accessibilityIdentifier("\(element.label) Description")
                         .multilineTextAlignment(.leading)
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
 #if targetEnvironment(macCatalyst)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
@@ -83,7 +83,7 @@ struct ComboBoxInput: View {
             Text(displayedValue)
                 .accessibilityIdentifier("\(element.label) Combo Box Value")
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundColor(!selectedValue.isNoValue ? .primary : .secondary)
+                .foregroundStyle(!selectedValue.isNoValue ? .primary : .secondary)
             if let _ = selectedValue.codedValue, !isRequired {
                 // Only show clear button if we have a value
                 // and we're not required. (i.e., Don't show clear if
@@ -98,7 +98,7 @@ struct ComboBoxInput: View {
                 // Otherwise, always show chevron.
                 Image(systemName: "chevron.right")
                     .accessibilityIdentifier("\(element.label) Options Button")
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .formInputStyle()
@@ -161,7 +161,7 @@ extension ComboBoxInput {
         NavigationStack {
             VStack {
                 Text(element.description)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .font(.subheadline)
                     .padding(.horizontal)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -205,7 +205,7 @@ extension ComboBoxInput {
                         } label: {
                             Text.done
                                 .fontWeight(.semibold)
-                                .foregroundColor(.accentColor)
+                                .foregroundStyle(Color.accentColor)
                         }
                         .buttonStyle(.plain)
                     }
@@ -220,7 +220,7 @@ extension ComboBoxInput {
             Spacer()
             if selected {
                 Image(systemName: "checkmark")
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(Color.accentColor)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
@@ -92,7 +92,7 @@ struct DateTimeInput: View {
         HStack {
             Text(!formattedValue.isEmpty ? formattedValue : .noValue)
                 .accessibilityIdentifier("\(element.label) Value")
-                .foregroundColor(displayColor)
+                .foregroundStyle(displayColor)
             
             Spacer()
             
@@ -103,7 +103,7 @@ struct DateTimeInput: View {
                     Image(systemName: "calendar")
                         .font(.title2)
                         .accessibilityIdentifier("\(element.label) Calendar Image")
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 } else if !isRequired {
                     XButton(.clear) {
                         model.focusedElement = element

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
@@ -63,7 +63,7 @@ struct InputFooter: View {
             }
         }
         .font(.footnote)
-        .foregroundColor(isShowingError ? .red : .secondary)
+        .foregroundStyle(isShowingError ? .red : .secondary)
         .id(id)
         .padding(.vertical, elementPadding / 2)
         .task {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputHeader.swift
@@ -32,7 +32,7 @@ struct InputHeader: View {
         HStack {
             Text(verbatim: "\(element.label + (isEditable && isRequired ? " *" : ""))")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             Spacer()
         }
         .padding(.top, elementPadding)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
@@ -147,7 +147,7 @@ extension RadioButtonsInput {
                 if selected {
                     Image(systemName: "checkmark")
                         .accessibilityIdentifier("\(element.label) \(label) Checkmark")
-                        .foregroundColor(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                 }
             }
             .padding(10)
@@ -155,7 +155,7 @@ extension RadioButtonsInput {
         }
         .accessibilityIdentifier("\(element.label) \(label) Radio Button")
         .buttonStyle(.plain)
-        .foregroundColor(.primary)
+        .foregroundStyle(.primary)
         if addDivider {
             Divider()
                 .padding(.leading, 10)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -230,7 +230,7 @@ private extension TextInput {
                     dismiss()
                 }
                 .buttonStyle(.plain)
-                .foregroundColor(.accentColor)
+                .foregroundStyle(Color.accentColor)
             }
             RepresentedUITextView(initialText: text) { text in
                 element.convertAndUpdateValue(text)

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -209,7 +209,7 @@ private struct Handle: View {
     
     var body: some View {
         RoundedRectangle(cornerRadius: 4.0)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .frame(width: 100, height: 8.0)
             .hoverEffect()
     }

--- a/Sources/ArcGISToolkit/Components/FloorFilter/LevelSelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/LevelSelector.swift
@@ -101,7 +101,7 @@ extension LevelSelector {
         } label: {
             let roundedRectangle = RoundedRectangle(cornerRadius: 5)
             Text(level.shortName)
-                .foregroundColor(textColor(for: level))
+                .foregroundStyle(textColor(for: level))
                 .frame(maxWidth: .infinity)
                 .padding([.vertical], 4)
                 .background {

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -129,7 +129,7 @@ struct SiteAndFacilitySelector: View {
         HStack {
             HStack {
                 Image(systemName: "magnifyingglass")
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 TextField(facilityListIsVisible ? String.filterFacilities : String.filterSites, text: $query)
                     .disableAutocorrection(true)
                     .focused($textFieldIsFocused)

--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -57,7 +57,7 @@ struct FieldsPopupElementView: View {
             VStack(alignment: .leading) {
                 Text(field.label)
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 FormattedValueText(formattedValue: field.formattedValue)
                     .padding([.bottom], -1)
             }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupElementHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupElementHeader.swift
@@ -28,14 +28,14 @@ struct PopupElementHeader: View {
                 Text(title)
                     .multilineTextAlignment(.leading)
                     .font(.title2)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
             }
             
             if !description.isEmpty {
                 Text(description)
                     .multilineTextAlignment(.leading)
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
 #if targetEnvironment(macCatalyst) || os(visionOS)

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
@@ -40,7 +40,7 @@ struct MediaDetailView : View {
                         .font(.title2)
                     Text(popupMedia.caption)
                         .font(.title3)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 Spacer()
             }
@@ -69,7 +69,7 @@ struct MediaDetailView : View {
                                          """
                             )
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                             Spacer()
                         }
                     }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/PopupMediaFooter.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/PopupMediaFooter.swift
@@ -34,14 +34,14 @@ struct PopupMediaFooter: View {
                 VStack(alignment: .leading) {
                     if !popupMedia.title.isEmpty {
                         Text(popupMedia.title)
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .font(.body)
                     }
                     
                     if !popupMedia.caption.isEmpty {
                         Text(popupMedia.caption)
                             .font(.subheadline)
-                            .foregroundColor(.init(white: 0.75))
+                            .foregroundStyle(Color(white: 0.75))
                     }
                 }
                 .lineLimit(1)

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarModifiers.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarModifiers.swift
@@ -22,7 +22,7 @@ struct ScalebarTextModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .font(Scalebar.font.font)
-            .foregroundColor(settings.textColor)
+            .foregroundStyle(settings.textColor)
             .shadow(
                 color: settings.textShadowColor,
                 radius: settings.shadowRadius

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -485,7 +485,7 @@ extension ResultRow {
                         )!
                     )
                 )
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             )
         )
     }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -348,7 +348,7 @@ public struct UtilityNetworkTrace: View {
                                 viewModel.pendingTrace.userDidSpecifyName = true
                             }
                             .multilineTextAlignment(.trailing)
-                            .foregroundColor(.blue)
+                            .foregroundStyle(.blue)
                     }
                     ColorPicker(String.colorLabel, selection: $viewModel.pendingTrace.color)
                     Toggle(String.zoomToResult, isOn: $shouldZoomOnTraceCompletion)
@@ -441,7 +441,7 @@ public struct UtilityNetworkTrace: View {
                                     Spacer()
                                     Text(selectedTrace.elements(inAssetGroupNamed: assetGroupName).count, format: .number)
                                 }
-                                .foregroundColor(.blue)
+                                .foregroundStyle(.blue)
                                 .contentShape(Rectangle())
                                 .onTapGesture {
                                     currentActivity = .viewingTraces(.viewingElementGroup(named: assetGroupName))
@@ -469,7 +469,7 @@ public struct UtilityNetworkTrace: View {
                                     VStack(alignment: .trailing) {
                                         Text(item.function.functionType.title)
                                             .font(.caption)
-                                            .foregroundColor(.secondary)
+                                            .foregroundStyle(.secondary)
                                         if let result = item.result as? Double {
                                             Text(result, format: .number)
                                         } else {
@@ -590,7 +590,7 @@ public struct UtilityNetworkTrace: View {
                             Text($0.name)
                         }
                     }
-                    .foregroundColor(.blue)
+                    .foregroundStyle(.blue)
                 }
             }
             Section(String.attributesSectionTitle) {

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FloorFilter/FloorFilterStep5.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FloorFilter/FloorFilterStep5.swift
@@ -54,7 +54,7 @@ struct FloorFilterExampleView: View {
                         "Map load error!",
                         systemImage: "exclamationmark.triangle"
                     )
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
                     .frame(
                         maxWidth: .infinity,
                         maxHeight: .infinity,

--- a/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
+++ b/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
@@ -88,7 +88,7 @@ public struct AsyncImageView: View {
                 HStack(alignment: .center) {
                     Image(systemName: "exclamationmark.circle")
                         .aspectRatio(contentMode: .fit)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
                 .padding([.top, .bottom])
             }

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -218,7 +218,7 @@ struct CredentialInputSheetView: View {
                         .multilineTextAlignment(.center)
                     Text(message)
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                 }
                 .padding(.vertical)

--- a/Sources/ArcGISToolkit/Utility/EsriBorderViewModifier.swift
+++ b/Sources/ArcGISToolkit/Utility/EsriBorderViewModifier.swift
@@ -31,7 +31,7 @@ struct EsriBorderViewModifier: ViewModifier {
             .overlay(
                 roundedRect
                     .stroke(lineWidth: 2)
-                    .foregroundColor(Color(uiColor: .separator))
+                    .foregroundStyle(Color(uiColor: .separator))
             )
             .shadow(
                 color: .gray.opacity(0.4),

--- a/Sources/ArcGISToolkit/Utility/SearchField.swift
+++ b/Sources/ArcGISToolkit/Utility/SearchField.swift
@@ -58,7 +58,7 @@ public struct SearchField: View {
         HStack {
             // Search icon
             Image(systemName: "magnifyingglass.circle.fill")
-                .foregroundColor(Color.secondary)
+                .foregroundStyle(Color.secondary)
             
             // Search text field
             TextField(
@@ -90,7 +90,7 @@ public struct SearchField: View {
                         "chevron.down" :
                             "chevron.up"
                     )
-                    .foregroundColor(Color.secondary)
+                    .foregroundStyle(Color.secondary)
                 }
                 .buttonStyle(.plain)
             }


### PR DESCRIPTION
Related to #842. The replacement is `foregroundStyle(_:)`. While working on visionOS support, we have already done this in many places. This just does it across the board.

Note that there is one more use of what appears to be this modifier here:

https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/453250b297bddd6e587b3f6536ee4b684dd26a00/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift#L119

But it is actually a different modifier, `Text.foregroundStyle(_:)`, which was deprecated in iOS 17. I chose to leave it as-is.