### PR TITLE
Use implicit member expressions for `[Shape]Style`

### DIFF
--- a/AuthenticationExample/AuthenticationExample/UserView.swift
+++ b/AuthenticationExample/AuthenticationExample/UserView.swift
@@ -26,7 +26,7 @@ struct UserView: View {
                 if let thumbnail = user.thumbnail {
                     LoadableImageView(loadableImage: thumbnail)
                         .frame(width: 100, height: 100, alignment: .center)
-                        .clipShape(Circle())
+                        .clipShape(.circle)
                 } else {
                     Image(systemName: "person.circle")
                         .resizable()

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -106,7 +106,7 @@ struct FeatureFormExampleView: View {
                         }
                         .padding()
                         .background(.thinMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .clipShape(.rect(cornerRadius: 10))
                     default:
                         EmptyView()
                     }

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -221,7 +221,7 @@ struct AttachmentPreview: View {
             .font(.caption)
             .frame(width: cellSize.width, height: cellSize.height)
             .background(Color.gray.opacity(0.2))
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .clipShape(.rect(cornerRadius: 8))
             .onTapGesture {
                 if attachmentModel.attachment.loadStatus == .loaded {
                     // Set the url to trigger `.quickLookPreview`.
@@ -254,9 +254,7 @@ struct ThumbnailViewFooter: View {
         ZStack {
             let gradient = Gradient(colors: [.black, .black.opacity(0.15)])
             Rectangle()
-                .fill(
-                    LinearGradient(gradient: gradient, startPoint: .bottom, endPoint: .top)
-                )
+                .fill(.linearGradient(gradient, startPoint: .bottom, endPoint: .top))
                 .frame(height: size.height * 0.25)
             HStack {
                 if !attachmentModel.name.isEmpty {

--- a/Sources/ArcGISToolkit/Common/FlashlightButton.swift
+++ b/Sources/ArcGISToolkit/Common/FlashlightButton.swift
@@ -56,7 +56,7 @@ struct FlashlightButton: View {
                     .foregroundStyle(torchIsOn ? .white : .black)
                     .contentTransition(.interpolate)
                     .background(.tint)
-                    .clipShape(Circle())
+                    .clipShape(.circle)
             }
             .buttonStyle(.plain)
             .disabled(!hasTorch)

--- a/Sources/ArcGISToolkit/Common/ThumbnailView.swift
+++ b/Sources/ArcGISToolkit/Common/ThumbnailView.swift
@@ -41,8 +41,8 @@ struct ThumbnailView: View  {
         }
         .accessibilityIdentifier("\(attachmentModel.name) Thumbnail")
         .frame(width: size.width, height: size.height, alignment: .center)
-        .clipShape(RoundedRectangle(cornerRadius: 4))
-        .contentShape(RoundedRectangle(cornerRadius: 4))
+        .clipShape(.rect(cornerRadius: 4))
+        .contentShape(.rect(cornerRadius: 4))
         .foregroundStyle(foregroundColor(for: attachmentModel))
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
@@ -109,7 +109,7 @@ extension WorldScaleSceneView {
             }
             .padding()
             .background(.regularMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 15))
+            .clipShape(.rect(cornerRadius: 15))
             .frame(maxWidth: 430)
             .padding()
         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -144,7 +144,7 @@ public struct WorldScaleSceneView: View {
                         .padding()
                 }
                 .background(.regularMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .clipShape(.rect(cornerRadius: 10))
                 .disabled(!initialCameraIsSet)
                 .padding()
                 .padding(.vertical)

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryCell.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryCell.swift
@@ -26,10 +26,9 @@ struct BasemapGalleryCell: View {
     let onSelection: () -> Void
     
     var body: some View {
-        let roundedRect = RoundedRectangle(cornerRadius: 8)
-        Button(action: {
+        Button {
             onSelection()
-        }, label: {
+        } label: {
             VStack {
                 ZStack(alignment: .center) {
                     // Display the thumbnail, if available.
@@ -38,7 +37,7 @@ struct BasemapGalleryCell: View {
                             Image(uiImage: thumbnailImage)
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
-                                .clipShape(roundedRect)
+                                .clipShape(.rect(cornerRadius: 8))
                                 .overlay(
                                     makeOverlay()
                                 )
@@ -62,7 +61,7 @@ struct BasemapGalleryCell: View {
             .contentShape(.hoverEffect, .rect(cornerRadius: 12))
             .hoverEffect()
 #endif
-        })
+        }
         .buttonStyle(.plain)
         .disabled(item.isBasemapLoading)
     }
@@ -108,7 +107,7 @@ struct BasemapGalleryCell: View {
                 trailing: 12)
             )
             .background(Color(uiColor: .systemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .clipShape(.rect(cornerRadius: 8))
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -188,7 +188,7 @@ extension Bookmarks {
                     Text(bookmark.name)
                         // Make the entire row tappable.
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
+                        .contentShape(.rect)
                 }
 #if !os(visionOS)
                 .buttonStyle(.plain)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
@@ -151,7 +151,7 @@ extension RadioButtonsInput {
                 }
             }
             .padding(10)
-            .contentShape(Rectangle())
+            .contentShape(.rect)
         }
         .accessibilityIdentifier("\(element.label) \(label) Radio Button")
         .buttonStyle(.plain)

--- a/Sources/ArcGISToolkit/Components/FloorFilter/LevelSelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/LevelSelector.swift
@@ -83,7 +83,7 @@ extension LevelSelector {
         } label: {
             Image(systemName: iconForCollapsedState)
                 .padding(.toolkitDefault)
-                .contentShape(Rectangle())
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .disabled(levels.count == 1)

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -95,7 +95,7 @@ struct SiteAndFacilitySelector: View {
                         }
                     }
                 }
-                .contentShape(Rectangle())
+                .contentShape(.rect)
                 .listRowBackground(facility.id == viewModel.selection?.facility?.id ? Color.secondary.opacity(0.5) : nil)
             }
 #if !os(visionOS)
@@ -165,7 +165,7 @@ struct SiteAndFacilitySelector: View {
             } label: {
                 Image(systemName: "chevron.left")
                     .padding(.toolkitDefault)
-                    .contentShape(Rectangle())
+                    .contentShape(.rect)
             }
             .buttonStyle(.plain)
             .opacity(backButtonIsVisible ? 1 : 0)

--- a/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/MediaPopupElementView.swift
@@ -78,7 +78,7 @@ struct MediaPopupElementView: View {
                             }
                         }
                         .frame(width: mediaSize.width, height: mediaSize.height)
-                        .contentShape(RoundedRectangle(cornerRadius: 8))
+                        .contentShape(.rect(cornerRadius: 8))
                     }
                 }
             }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartMediaView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartMediaView.swift
@@ -57,7 +57,7 @@ struct ChartMediaView: View {
                 .frame(width: mediaSize.width, height: mediaSize.height)
         }
         .frame(width: mediaSize.width, height: mediaSize.height)
-        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .clipShape(.rect(cornerRadius: cornerRadius))
         .onTapGesture {
             isShowingDetailView = true
         }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/ImageMediaView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/ImageMediaView.swift
@@ -50,7 +50,7 @@ struct ImageMediaView: View {
                     .frame(width: mediaSize.width, height: mediaSize.height)
             }
             .frame(width: mediaSize.width, height: mediaSize.height)
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .clipShape(.rect(cornerRadius: cornerRadius))
             .onTapGesture {
                 isShowingDetailView = true
             }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/PopupMediaFooter.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/PopupMediaFooter.swift
@@ -26,9 +26,7 @@ struct PopupMediaFooter: View {
         ZStack {
             let gradient = Gradient(colors: [.black, .black.opacity(0.15)])
             Rectangle()
-                .fill(
-                    LinearGradient(gradient: gradient, startPoint: .bottom, endPoint: .top)
-                )
+                .fill(.linearGradient(gradient, startPoint: .bottom, endPoint: .top))
                 .frame(height: mediaSize.height * 0.25)
             HStack {
                 VStack(alignment: .leading) {

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -460,7 +460,7 @@ struct ResultRow: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+            .contentShape(.rect)
         }
         .padding(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 0))
     }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -442,7 +442,7 @@ public struct UtilityNetworkTrace: View {
                                     Text(selectedTrace.elements(inAssetGroupNamed: assetGroupName).count, format: .number)
                                 }
                                 .foregroundStyle(.blue)
-                                .contentShape(Rectangle())
+                                .contentShape(.rect)
                                 .onTapGesture {
                                     currentActivity = .viewingTraces(.viewingElementGroup(named: assetGroupName))
                                 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -87,7 +87,7 @@ struct FeatureFormExampleView: View {
                             }
                             .padding()
                             .background(.thinMaterial)
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .clipShape(.rect(cornerRadius: 10))
                         default:
                             EmptyView()
                         }


### PR DESCRIPTION
While working on visionOS support, we've encountered code like this and updated it. This just does it all in one go.