### PR TITLE
Offline: Add download button to metadata view

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedListItemView.swift
@@ -62,9 +62,7 @@ struct PreplannedListItemView: View {
         }
         .contentShape(.rect)
         .onTapGesture {
-            if model.status.isDownloaded {
-                metadataViewIsPresented = true
-            }
+            metadataViewIsPresented = true
         }
         .sheet(isPresented: $metadataViewIsPresented) {
             NavigationStack {

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
@@ -59,7 +59,6 @@ struct PreplannedMetadataView: View {
                 }
                 if model.status.isDownloaded {
                     VStack(alignment: .leading) {
-                        
                         Text("Size")
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -68,33 +67,32 @@ struct PreplannedMetadataView: View {
                     }
                 }
             }
-            if !isSelected {
-                if model.status.isDownloaded {
-                    Section {
-                        HStack {
-                            Image(systemName: "trash.circle.fill")
-                                .symbolRenderingMode(.palette)
-                                .foregroundStyle(.red, .gray.opacity(0.1))
-                                .font(.title)
-                            Button("Remove Download", role: .destructive) {
-                                dismiss()
-                                model.removeDownloadedPreplannedMapArea()
-                            }
+            if model.status.isDownloaded && !isSelected {
+                Section {
+                    HStack {
+                        Image(systemName: "trash.circle.fill")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.red, .gray.opacity(0.1))
+                            .font(.title)
+                        Button("Remove Download", role: .destructive) {
+                            dismiss()
+                            model.removeDownloadedPreplannedMapArea()
                         }
                     }
-                } else {
-                    Button {
-                        dismiss()
-                        Task { await model.downloadPreplannedMapArea() }
-                    } label: {
-                        HStack {
-                            Image(systemName: "arrow.down.circle")
-                            Text("Download")
-                        }
-                    }
-                    .foregroundStyle(Color.accentColor)
-                    .disabled(!model.status.allowsDownload)
                 }
+            }
+            if !model.status.isDownloaded {
+                Button {
+                    dismiss()
+                    Task { await model.downloadPreplannedMapArea() }
+                } label: {
+                    HStack {
+                        Image(systemName: "arrow.down.circle")
+                        Text("Download")
+                    }
+                }
+                .foregroundStyle(Color.accentColor)
+                .disabled(!model.status.allowsDownload)
             }
         }
         .navigationTitle(model.preplannedMapArea.title)

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
@@ -57,26 +57,43 @@ struct PreplannedMetadataView: View {
                             .font(.subheadline)
                     }
                 }
-                VStack(alignment: .leading) {
-                    Text("Size")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(Int64(model.directorySize), format: .byteCount(style: .file, allowedUnits: [.kb, .mb]))
-                        .font(.subheadline)
+                if model.status.isDownloaded {
+                    VStack(alignment: .leading) {
+                        
+                        Text("Size")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(Int64(model.directorySize), format: .byteCount(style: .file, allowedUnits: [.kb, .mb]))
+                            .font(.subheadline)
+                    }
                 }
             }
             if !isSelected {
-                Section {
-                    HStack {
-                        Image(systemName: "trash.circle.fill")
-                            .symbolRenderingMode(.palette)
-                            .foregroundStyle(.red, .gray.opacity(0.1))
-                            .font(.title)
-                        Button("Remove Download", role: .destructive) {
-                            dismiss()
-                            model.removeDownloadedPreplannedMapArea()
+                if model.status.isDownloaded {
+                    Section {
+                        HStack {
+                            Image(systemName: "trash.circle.fill")
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(.red, .gray.opacity(0.1))
+                                .font(.title)
+                            Button("Remove Download", role: .destructive) {
+                                dismiss()
+                                model.removeDownloadedPreplannedMapArea()
+                            }
                         }
                     }
+                } else {
+                    Button {
+                        dismiss()
+                        Task { await model.downloadPreplannedMapArea() }
+                    } label: {
+                        HStack {
+                            Image(systemName: "arrow.down.circle")
+                            Text("Download")
+                        }
+                    }
+                    .foregroundStyle(Color.accentColor)
+                    .disabled(!model.status.allowsDownload)
                 }
             }
         }

--- a/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/PreplannedMetadataView.swift
@@ -82,14 +82,9 @@ struct PreplannedMetadataView: View {
                 }
             }
             if !model.status.isDownloaded {
-                Button {
+                Button("Download", systemImage: "arrow.down.circle") {
                     dismiss()
                     Task { await model.downloadPreplannedMapArea() }
-                } label: {
-                    HStack {
-                        Image(systemName: "arrow.down.circle")
-                        Text("Download")
-                    }
                 }
                 .foregroundStyle(Color.accentColor)
                 .disabled(!model.status.allowsDownload)


### PR DESCRIPTION
Closes https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/1004.

Adds tap gesture to shows metadata view for all map areas.

- When map area is not downloaded:
  - Shows "Download" button
- When map area is downloading:
  - "Download" button is disabled
- When map area is downloaded:
  - Shows file size
  - Shows "Remove Download" button

Screenshots:
<img src="https://github.com/user-attachments/assets/05d08e21-5713-4214-8e22-631165bc16f1" width="250"> <img src="https://github.com/user-attachments/assets/ff2ae4e2-e95a-4a1e-904e-33c64225bf65" width="250">  <img src="https://github.com/user-attachments/assets/599eb637-8ab3-46c3-892a-f52990d16b8e" width="250">
