### PR TITLE
Change `FormViewModel.init(featureForm:)` to internal

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormViewModel.swift
@@ -42,7 +42,7 @@ import SwiftUI
     
     /// Initializes a form view model.
     /// - Parameter featureForm: The feature form defining the editing experience.
-    public init(featureForm: FeatureForm) {
+    init(featureForm: FeatureForm) {
         self.featureForm = featureForm
     }
     


### PR DESCRIPTION
No need for this initializer to be public.