### PR TITLE
`UtilityNetworkAssociationsFormElementView` - Add `LeadingEdgeDisclosureGroupStyle`

### DIFF
--- a/Sources/ArcGISToolkit/Common/LeadingEdgeDisclosureGroupStyle.swift
+++ b/Sources/ArcGISToolkit/Common/LeadingEdgeDisclosureGroupStyle.swift
@@ -18,6 +18,14 @@ import SwiftUI
 ///
 /// Use ``DisclosureGroupStyle/leadingEdge`` to construct this style.
 struct LeadingEdgeDisclosureGroupStyle: DisclosureGroupStyle {
+    let arrowColor: Color
+    
+    /// Creates a leading edge disclosure group style.
+    /// - Parameter arrowColor: The color of the disclosure group arrow.
+    init(arrowColor: Color = .accentColor) {
+        self.arrowColor = arrowColor
+    }
+    
     func makeBody(configuration: Configuration) -> some View {
         Button {
             withAnimation {
@@ -26,7 +34,7 @@ struct LeadingEdgeDisclosureGroupStyle: DisclosureGroupStyle {
         } label: {
             HStack(alignment: .firstTextBaseline) {
                 Image(systemName: "chevron.right")
-                    .foregroundColor(.accentColor)
+                    .foregroundColor(arrowColor)
                     .rotationEffect(.degrees(configuration.isExpanded ? 90 : 0))
                     .animation(
                         .easeInOut(duration: 0.3),
@@ -66,6 +74,12 @@ struct LeadingEdgeDisclosureGroupStyle: DisclosureGroupStyle {
                 makeDemoContent()
             }
             .disclosureGroupStyle(.leadingEdge)
+        }
+        Section {
+            DisclosureGroup("\(LeadingEdgeDisclosureGroupStyle.self)") {
+                makeDemoContent()
+            }
+            .disclosureGroupStyle(.leadingEdge(arrowColor: .secondary))
         }
     }
 }

--- a/Sources/ArcGISToolkit/Common/LeadingEdgeDisclosureGroupStyle.swift
+++ b/Sources/ArcGISToolkit/Common/LeadingEdgeDisclosureGroupStyle.swift
@@ -1,0 +1,71 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+/// A disclosure group style that places the disclosure arrow at the leading edge.
+///
+/// Use ``DisclosureGroupStyle/leadingEdge`` to construct this style.
+struct LeadingEdgeDisclosureGroupStyle: DisclosureGroupStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button {
+            withAnimation {
+                configuration.isExpanded.toggle()
+            }
+        } label: {
+            HStack(alignment: .firstTextBaseline) {
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.accentColor)
+                    .rotationEffect(.degrees(configuration.isExpanded ? 90 : 0))
+                    .animation(
+                        .easeInOut(duration: 0.3),
+                        value: configuration.isExpanded
+                    )
+                configuration.label
+                Spacer()
+            }
+            .contentShape(Rectangle())
+            .alignmentGuide(.listRowSeparatorLeading) { dimensions in
+                dimensions[.leading]
+            }
+        }
+        .buttonStyle(.plain)
+        if configuration.isExpanded {
+            configuration.content
+                .listRowInsets((.init(top: 0, leading: 50, bottom: 0, trailing: 0)))
+        }
+    }
+}
+
+#Preview {
+    func makeDemoContent() -> some View {
+        ForEach(1..<3) {
+            Text($0.formatted())
+        }
+    }
+    return List {
+        Section {
+            DisclosureGroup("\(AutomaticDisclosureGroupStyle.self)") {
+                makeDemoContent()
+            }
+            .disclosureGroupStyle(.automatic)
+        }
+        Section {
+            DisclosureGroup("\(LeadingEdgeDisclosureGroupStyle.self)") {
+                makeDemoContent()
+            }
+            .disclosureGroupStyle(.leadingEdge)
+        }
+    }
+}

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/DisclosureGroupStyle.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/DisclosureGroupStyle.swift
@@ -1,0 +1,22 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension DisclosureGroupStyle where Self == LeadingEdgeDisclosureGroupStyle {
+    /// A disclosure group style that places disclosure arrow at the leading edge.
+    static var leadingEdge: LeadingEdgeDisclosureGroupStyle {
+        LeadingEdgeDisclosureGroupStyle()
+    }
+}

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/DisclosureGroupStyle.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/DisclosureGroupStyle.swift
@@ -19,4 +19,13 @@ extension DisclosureGroupStyle where Self == LeadingEdgeDisclosureGroupStyle {
     static var leadingEdge: LeadingEdgeDisclosureGroupStyle {
         LeadingEdgeDisclosureGroupStyle()
     }
+    
+    /// A disclosure group style that places disclosure arrow at the leading edge.
+    static func leadingEdge(arrowColor: Color? = nil) -> LeadingEdgeDisclosureGroupStyle {
+        if let arrowColor {
+            LeadingEdgeDisclosureGroupStyle(arrowColor: arrowColor)
+        } else {
+            leadingEdge
+        }
+    }
 }


### PR DESCRIPTION
Related to Apollo 1088

Adds a new custom `DisclosureGroupStyle` with the disclosure arrow placed at the leading edge to support the UtilityNetworkAssociationsFormElement navigation design spec.

<p align="center">
  <img width="50%" src="https://github.com/user-attachments/assets/0bdc7a08-d0de-4ba7-b701-b4e1741cd42b">
</p>
