### PR TITLE
Make top level `Model` class private

### DIFF
--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -161,7 +161,7 @@ private extension URL {
 
 /// The model class for the form example view
 @MainActor
-class Model: ObservableObject {
+private class Model: ObservableObject {
     /// Feature form workflow states.
     enum State {
         /// Edits are being applied to the remote service.


### PR DESCRIPTION
This class is specific to a particular example, but, by being at the top level as non-private, it was exposed to all examples. This fixes that.

Note: The one declaration that uses the type is already private.