### PR TITLE
Adjust background on floating panel for visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -73,7 +73,7 @@ struct FloatingPanel<Content>: View where Content: View {
             // Set frame width to infinity to prevent horizontal shrink on dismissal.
             .frame(maxWidth: .infinity)
 #if os(visionOS)
-            .background(.regularMaterial)
+            .glassBackgroundEffect()
             .compositingGroup()
 #else
             .background(backgroundColor)

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanel.swift
@@ -74,16 +74,15 @@ struct FloatingPanel<Content>: View where Content: View {
             .frame(maxWidth: .infinity)
 #if os(visionOS)
             .glassBackgroundEffect()
-            .compositingGroup()
 #else
             .background(backgroundColor)
-#endif
             .clipShape(
                 RoundedCorners(
                     corners: isPortraitOrientation ? [.topLeft, .topRight] : .allCorners,
                     radius: .cornerRadius
                 )
             )
+#endif
             .shadow(radius: 10)
             .frame(
                 maxWidth: .infinity,


### PR DESCRIPTION
Closes #1021

The problem here was the background on the floating panel was somehow overriding some default styling on the Utility Network component. If you put the Utility Network component in a sheet you would see it looks as expected but it would look incorrect in a floating panel. This fixes that. This doesn't make a visual difference to the Popup Component example.

Utility Network Before:
![Before](https://github.com/user-attachments/assets/27d55b6c-a5e8-44e3-816f-a3da95e08efe)

Utility Network After:
![After](https://github.com/user-attachments/assets/7cdc27e6-e1c2-418e-8731-ffc4100501cc)
