### PR TITLE
Add visionOS support to Feature Forms

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -98,7 +98,6 @@
 				E4C389D426B8A12C002BC255 /* BasemapGalleryExampleView.swift */,
 				75C37C9127BEDBD800FC9DCE /* BookmarksExampleView.swift */,
 				75657E4727ABAC8400EE865B /* CompassExampleView.swift */,
-				79222E132D5006E0005C2ABA /* Extensions */,
 				75B615012AD76158009D19B6 /* FeatureFormExampleView.swift */,
 				E4AA9315276BF5ED000E6289 /* FloatingPanelExampleView.swift */,
 				E4624A24278CE815000D2A38 /* FloorFilterExampleView.swift */,
@@ -160,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				E40F58042656E509006F5CB9 /* Examples */,
+				79222E132D5006E0005C2ABA /* Extensions */,
 			);
 			path = Examples;
 			sourceTree = "<group>";

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -11,11 +11,12 @@
 		1CC376D42ABA0B3700A83300 /* TableTopExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC376D32ABA0B3700A83300 /* TableTopExampleView.swift */; platformFilter = ios; };
 		4CD62FAA2D49773000338749 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD62FA92D49773000338749 /* Category.swift */; };
 		4D19FCB52881C8F3002601E8 /* PopupExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D19FCB42881C8F3002601E8 /* PopupExampleView.swift */; };
-		4D995CD72B5B01DB00AD45FE /* FeatureFormExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B615012AD76158009D19B6 /* FeatureFormExampleView.swift */; platformFilters = (ios, maccatalyst, ); };
+		4D995CD72B5B01DB00AD45FE /* FeatureFormExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B615012AD76158009D19B6 /* FeatureFormExampleView.swift */; };
 		75230DAE28614369009AF501 /* UtilityNetworkTraceExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75230DAD28614369009AF501 /* UtilityNetworkTraceExampleView.swift */; };
 		75657E4827ABAC8400EE865B /* CompassExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75657E4727ABAC8400EE865B /* CompassExampleView.swift */; };
 		75C37C9227BEDBD800FC9DCE /* BookmarksExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C37C9127BEDBD800FC9DCE /* BookmarksExampleView.swift */; };
 		75D41B2B27C6F21400624D7C /* ScalebarExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D41B2A27C6F21400624D7C /* ScalebarExampleView.swift */; };
+		79222E152D5008BB005C2ABA /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79222E142D5006EF005C2ABA /* View.swift */; };
 		882899FD2AB5099300A0BDC1 /* FlyoverExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882899FC2AB5099300A0BDC1 /* FlyoverExampleView.swift */; platformFilter = ios; };
 		E42BFBE92672BF9500159107 /* SearchExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42BFBE82672BF9500159107 /* SearchExampleView.swift */; };
 		E4624A25278CE815000D2A38 /* FloorFilterExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4624A24278CE815000D2A38 /* FloorFilterExampleView.swift */; };
@@ -53,6 +54,7 @@
 		75B615012AD76158009D19B6 /* FeatureFormExampleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureFormExampleView.swift; sourceTree = "<group>"; };
 		75C37C9127BEDBD800FC9DCE /* BookmarksExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksExampleView.swift; sourceTree = "<group>"; };
 		75D41B2A27C6F21400624D7C /* ScalebarExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalebarExampleView.swift; sourceTree = "<group>"; };
+		79222E142D5006EF005C2ABA /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		882899FC2AB5099300A0BDC1 /* FlyoverExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyoverExampleView.swift; sourceTree = "<group>"; };
 		E42BFBE82672BF9500159107 /* SearchExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchExampleView.swift; sourceTree = "<group>"; };
 		E4624A24278CE815000D2A38 /* FloorFilterExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorFilterExampleView.swift; sourceTree = "<group>"; };
@@ -82,12 +84,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		79222E132D5006E0005C2ABA /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				79222E142D5006EF005C2ABA /* View.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		E40F58042656E509006F5CB9 /* Examples */ = {
 			isa = PBXGroup;
 			children = (
 				E4C389D426B8A12C002BC255 /* BasemapGalleryExampleView.swift */,
 				75C37C9127BEDBD800FC9DCE /* BookmarksExampleView.swift */,
 				75657E4727ABAC8400EE865B /* CompassExampleView.swift */,
+				79222E132D5006E0005C2ABA /* Extensions */,
 				75B615012AD76158009D19B6 /* FeatureFormExampleView.swift */,
 				E4AA9315276BF5ED000E6289 /* FloatingPanelExampleView.swift */,
 				E4624A24278CE815000D2A38 /* FloorFilterExampleView.swift */,
@@ -263,6 +274,7 @@
 				75657E4827ABAC8400EE865B /* CompassExampleView.swift in Sources */,
 				E48A73452658227100F5C118 /* Examples.swift in Sources */,
 				75C37C9227BEDBD800FC9DCE /* BookmarksExampleView.swift in Sources */,
+				79222E152D5008BB005C2ABA /* View.swift in Sources */,
 				75230DAE28614369009AF501 /* UtilityNetworkTraceExampleView.swift in Sources */,
 				E48A73432658227100F5C118 /* Example.swift in Sources */,
 				E47ABE442652FE0900FD2FE3 /* ExamplesApp.swift in Sources */,

--- a/Examples/Examples/Extensions/View.swift
+++ b/Examples/Examples/Extensions/View.swift
@@ -1,0 +1,42 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension View {
+    /// Performs an action when a specified value changes.
+    /// - Note: This is temporary until our minumum platform versions are increased.
+    /// Without this a warning will show saying we are using a deprecated `onChange(of:perform:)` method.
+    /// - Parameters:
+    ///   - value: The value to check when determining whether to run the
+    ///     closure.
+    ///   - action: A closure to run when the value changes. The closure
+    ///     takes a `newValue` parameter that indicates the updated
+    ///     value.
+    /// - Returns: A view that runs an action when the specified value changes.
+    func onChange<V>(
+        _ value: V,
+        perform action: @escaping (_ newValue: V) -> Void
+    ) -> some View where V: Equatable {
+        if #available(iOS 17.0, macCatalyst 17.0, visionOS 1.0, *) {
+            return onChange(of: value) { _, newValue in
+                action(newValue)
+            }
+        } else {
+            return onChange(of: value) { newValue in
+                action(newValue)
+            }
+        }
+    }
+}

--- a/Examples/Examples/Extensions/View.swift
+++ b/Examples/Examples/Extensions/View.swift
@@ -16,20 +16,20 @@ import SwiftUI
 
 extension View {
     /// Performs an action when a specified value changes.
-    /// - Note: This is temporary until our minumum platform versions are increased.
-    /// Without this a warning will show saying we are using a deprecated `onChange(of:perform:)` method.
+    /// - Note: This is temporary until our minimum platform versions are
+    /// increased. Without this, a warning will show saying we are using a
+    /// deprecated `onChange(of:perform:)` method.
     /// - Parameters:
     ///   - value: The value to check when determining whether to run the
-    ///     closure.
-    ///   - action: A closure to run when the value changes. The closure
-    ///     takes a `newValue` parameter that indicates the updated
-    ///     value.
+    ///   closure.
+    ///   - action: A closure to run when the value changes. The closure takes a
+    ///   `newValue` parameter that indicates the updated value.
     /// - Returns: A view that runs an action when the specified value changes.
     func onChange<V>(
         _ value: V,
         perform action: @escaping (_ newValue: V) -> Void
     ) -> some View where V: Equatable {
-        if #available(iOS 17.0, macCatalyst 17.0, visionOS 1.0, *) {
+        if #available(iOS 17.0, visionOS 1.0, *) {
             return onChange(of: value) { _, newValue in
                 action(newValue)
             }

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -57,7 +57,6 @@ struct FeatureFormExampleView: View {
                     }
                 }
                 .ignoresSafeArea(.keyboard)
-#if os(visionOS)
                 .floatingPanel(
                     attributionBarHeight: attributionBarHeight,
                     selectedDetent: $detent,
@@ -71,23 +70,6 @@ struct FeatureFormExampleView: View {
                             .padding(.top, 16)
                     }
                 }
-            
-#else
-                .floatingPanel(
-                    attributionBarHeight: attributionBarHeight,
-                    backgroundColor: Color(uiColor: .systemGroupedBackground),
-                    selectedDetent: $detent,
-                    horizontalAlignment: .leading,
-                    isPresented: model.formIsPresented
-                ) {
-                    if let featureForm = model.featureForm {
-                        FeatureFormView(featureForm: featureForm)
-                            .validationErrors(validationErrorVisibility)
-                            .padding(.horizontal)
-                            .padding(.top, 16)
-                    }
-                }
-#endif
                 .onChange(model.formIsPresented.wrappedValue) { formIsPresented in
                     if !formIsPresented { validationErrorVisibility = .automatic }
                 }

--- a/Examples/Examples/FeatureFormExampleView.swift
+++ b/Examples/Examples/FeatureFormExampleView.swift
@@ -57,6 +57,7 @@ struct FeatureFormExampleView: View {
                     }
                 }
                 .ignoresSafeArea(.keyboard)
+#if os(visionOS)
                 .floatingPanel(
                     attributionBarHeight: attributionBarHeight,
                     selectedDetent: $detent,
@@ -70,7 +71,24 @@ struct FeatureFormExampleView: View {
                             .padding(.top, 16)
                     }
                 }
-                .onChange(of: model.formIsPresented.wrappedValue) { formIsPresented in
+            
+#else
+                .floatingPanel(
+                    attributionBarHeight: attributionBarHeight,
+                    backgroundColor: Color(uiColor: .systemGroupedBackground),
+                    selectedDetent: $detent,
+                    horizontalAlignment: .leading,
+                    isPresented: model.formIsPresented
+                ) {
+                    if let featureForm = model.featureForm {
+                        FeatureFormView(featureForm: featureForm)
+                            .validationErrors(validationErrorVisibility)
+                            .padding(.horizontal)
+                            .padding(.top, 16)
+                    }
+                }
+#endif
+                .onChange(model.formIsPresented.wrappedValue) { formIsPresented in
                     if !formIsPresented { validationErrorVisibility = .automatic }
                 }
                 .alert("Discard edits", isPresented: model.cancelConfirmationIsPresented) {
@@ -356,6 +374,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Examples/ExamplesApp/Examples.swift
+++ b/Examples/ExamplesApp/Examples.swift
@@ -84,27 +84,20 @@ extension Category {
 #endif
     
     static var geoview: Self {
-        var examples: [Example] = [
-            Example("Basemap Gallery", content: BasemapGalleryExampleView()),
-            Example("Bookmarks", content: BookmarksExampleView()),
-            Example("Compass", content: CompassExampleView()),
-            Example("Floor Filter", content: FloorFilterExampleView()),
-            Example("Overview Map", content: OverviewMapExampleView()),
-            Example("Popup", content: PopupExampleView()),
-            Example("Scalebar", content: ScalebarExampleView()),
-            Example("Search", content: SearchExampleView()),
-            Example("Utility Network Trace", content: UtilityNetworkTraceExampleView())
-        ]
-#if !os(visionOS)
-        examples.append(
-            contentsOf: [
-                Example("Feature Form", content: FeatureFormExampleView())
-            ]
-        )
-#endif
-        return .init(
+        .init(
             name: "GeoView",
-            examples: examples.sorted(by: { $0.name < $1.name })
+            examples: [
+                Example("Basemap Gallery", content: BasemapGalleryExampleView()),
+                Example("Bookmarks", content: BookmarksExampleView()),
+                Example("Compass", content: CompassExampleView()),
+                Example("Feature Form", content: FeatureFormExampleView()),
+                Example("Floor Filter", content: FloorFilterExampleView()),
+                Example("Overview Map", content: OverviewMapExampleView()),
+                Example("Popup", content: PopupExampleView()),
+                Example("Scalebar", content: ScalebarExampleView()),
+                Example("Search", content: SearchExampleView()),
+                Example("Utility Network Trace", content: UtilityNetworkTraceExampleView())
+            ].sorted(by: { $0.name < $1.name })
         )
     }
     

--- a/Examples/ExamplesApp/Examples.swift
+++ b/Examples/ExamplesApp/Examples.swift
@@ -97,7 +97,7 @@ extension Category {
                 Example("Scalebar", content: ScalebarExampleView()),
                 Example("Search", content: SearchExampleView()),
                 Example("Utility Network Trace", content: UtilityNetworkTraceExampleView())
-            ].sorted(by: { $0.name < $1.name })
+            ]
         )
     }
     

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -235,7 +235,8 @@ struct AttachmentPreview: View {
                     attachmentModel.load()
                 }
             }
-            // On visionOS, quick look preview will close the sheet by accident.
+            // On visionOS, quick look preview will close (sometimes it comes back) a sheet presenting
+            // the feature form.
             // See thread here: https://developer.apple.com/forums/thread/773599
             .quickLookPreview($url)
             .alert(String.emptyAttachmentDownloadErrorMessage, isPresented: $emptyDownloadAlertIsPresented) { }

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -235,9 +235,12 @@ struct AttachmentPreview: View {
                     attachmentModel.load()
                 }
             }
+            // On visionOS, quick look preview will close the sheet by accident.
+            // See thread here: https://developer.apple.com/forums/thread/773599
             .quickLookPreview($url)
             .alert(String.emptyAttachmentDownloadErrorMessage, isPresented: $emptyDownloadAlertIsPresented) { }
             .alert(maximumSizeDownloadExceededErrorMessage, isPresented: $maximumSizeDownloadExceededAlertIsPresented) { }
+            .hoverEffect()
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+FormHeader.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+FormHeader.swift
@@ -14,7 +14,6 @@
 
 import SwiftUI
 
-@available(visionOS, unavailable)
 public extension FeatureFormView {
     /// Specifies the visibility of the form header.
     /// - Parameter visibility: The preferred visibility of the form header.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
@@ -14,7 +14,6 @@
 
 import SwiftUI
 
-@available(visionOS, unavailable)
 public extension FeatureFormView {
     /// The validation error visibility configuration of a form.
     enum ValidationErrorVisibility: Sendable {
@@ -33,7 +32,6 @@ public extension FeatureFormView {
     }
 }
 
-@available(visionOS, unavailable)
 extension EnvironmentValues {
     /// The validation error visibility configuration of a form.
     var validationErrorVisibility: FeatureFormView.ValidationErrorVisibility {
@@ -43,7 +41,6 @@ extension EnvironmentValues {
 }
 
 /// The validation error visibility configuration of a form.
-@available(visionOS, unavailable)
 struct FormViewValidationErrorVisibility: EnvironmentKey {
     static let defaultValue: FeatureFormView.ValidationErrorVisibility = .automatic
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -65,7 +65,6 @@ import SwiftUI
 /// `Info.plist` file.
 ///
 /// - Since: 200.4
-@available(visionOS, unavailable)
 public struct FeatureFormView: View {
     /// The view model for the form.
     @StateObject private var model: FormViewModel
@@ -134,7 +133,6 @@ public struct FeatureFormView: View {
     }
 }
 
-@available(visionOS, unavailable)
 extension FeatureFormView {
     /// Makes UI for a form element.
     /// - Parameter element: The element to generate UI for.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
@@ -20,15 +20,16 @@ struct FormInputStyle: ViewModifier {
     let isTappable: Bool
     
     func body(content: Content) -> some View {
+        let cornerRadius: CGFloat = 10
         let content = content
             .frame(minHeight: 30)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .background(Color(uiColor: .tertiarySystemFill))
-            .cornerRadius(10)
+            .cornerRadius(cornerRadius)
         if isTappable {
             content
-                .contentShape(.hoverEffect, .rect(cornerRadius: 10))
+                .contentShape(.hoverEffect, .rect(cornerRadius: cornerRadius))
                 .hoverEffect()
         } else {
             content

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
@@ -17,20 +17,29 @@ import SwiftUI
 /// Provides a frame minimum height constraint, padding, background color and rounded corners for a
 /// form input.
 struct FormInputStyle: ViewModifier {
+    let isTappable: Bool
+    
     func body(content: Content) -> some View {
-        content
+        let content = content
             .frame(minHeight: 30)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .background(Color(uiColor: .tertiarySystemFill))
             .cornerRadius(10)
+        if isTappable {
+            content
+                .contentShape(.hoverEffect, .rect(cornerRadius: 10))
+                .hoverEffect()
+        } else {
+            content
+        }
     }
 }
 
 extension View {
     /// Provides a frame minimum height constraint, padding, background color and rounded corners
     /// for a form input.
-    func formInputStyle() -> some View {
-        modifier(FormInputStyle())
+    func formInputStyle(isTappable: Bool) -> some View {
+        modifier(FormInputStyle(isTappable: isTappable))
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FormInputStyle.swift
@@ -40,6 +40,7 @@ struct FormInputStyle: ViewModifier {
 extension View {
     /// Provides a frame minimum height constraint, padding, background color and rounded corners
     /// for a form input.
+    /// - Parameter isTappable: A Boolean value that indicates if this form input is tappable or not.
     func formInputStyle(isTappable: Bool) -> some View {
         modifier(FormInputStyle(isTappable: isTappable))
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
@@ -101,7 +101,7 @@ struct ComboBoxInput: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .formInputStyle()
+        .formInputStyle(isTappable: true)
         .onIsRequiredChange(of: element) { newIsRequired in
             isRequired = newIsRequired
         }
@@ -194,7 +194,9 @@ extension ComboBoxInput {
                         .accessibilityIdentifier("\(element.label) Unsupported Value Section")
                     }
                 }
+#if !os(visionOS)
                 .listStyle(.plain)
+#endif
                 .searchable(text: $filterPhrase, placement: .navigationBarDrawer, prompt: .filter)
                 .navigationTitle(element.label)
                 .navigationBarTitleDisplayMode(.inline)
@@ -205,9 +207,13 @@ extension ComboBoxInput {
                         } label: {
                             Text.done
                                 .fontWeight(.semibold)
+#if !os(visionOS)
                                 .foregroundStyle(Color.accentColor)
+#endif
                         }
+#if !os(visionOS)
                         .buttonStyle(.plain)
+#endif
                     }
                 }
             }
@@ -220,7 +226,9 @@ extension ComboBoxInput {
             Spacer()
             if selected {
                 Image(systemName: "checkmark")
+#if !os(visionOS)
                     .foregroundStyle(Color.accentColor)
+#endif
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
@@ -114,7 +114,7 @@ struct DateTimeInput: View {
                 }
             }
         }
-        .formInputStyle()
+        .formInputStyle(isTappable: true)
         .frame(maxWidth: .infinity)
         .onTapGesture {
             withAnimation {
@@ -163,7 +163,11 @@ struct DateTimeInput: View {
         if date == nil {
             return .secondary
         } else if isEditing {
+#if os(visionOS)
+            return .primary
+#else
             return .accentColor
+#endif
         } else {
             return .primary
         }
@@ -184,8 +188,10 @@ struct DateTimeInput: View {
             input.includesTime ? Text.now : .today
         }
         .accessibilityIdentifier("\(element.label) \(input.includesTime ? "Now" : "Today") Button")
+#if !os(visionOS)
         .buttonStyle(.plain)
         .foregroundStyle(.tint)
+#endif
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import SwiftUI
 
 /// A view shown at the bottom of a field element in a form.
-@available(visionOS, unavailable)
 struct InputFooter: View {
     @Environment(\.formElementPadding) var elementPadding
     
@@ -74,7 +73,6 @@ struct InputFooter: View {
     }
 }
 
-@available(visionOS, unavailable)
 extension InputFooter {
     /// Localized error text to be shown to a user depending on the type of error information available.
     var errorMessage: Text? {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputWrapper.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputWrapper.swift
@@ -19,7 +19,6 @@ import SwiftUI
 ///
 /// This view injects a header and footer. It also monitors whether a field form element is editable and
 /// chooses the correct input view based on the input type.
-@available(visionOS, unavailable)
 struct InputWrapper: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
@@ -147,11 +147,14 @@ extension RadioButtonsInput {
                 if selected {
                     Image(systemName: "checkmark")
                         .accessibilityIdentifier("\(element.label) \(label) Checkmark")
+#if !os(visionOS)
                         .foregroundStyle(Color.accentColor)
+#endif
                 }
             }
             .padding(10)
-            .contentShape(.rect)
+            .contentShape(.rect(cornerRadius: 10))
+            .hoverEffect()
         }
         .accessibilityIdentifier("\(element.label) \(label) Radio Button")
         .buttonStyle(.plain)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/SwitchInput.swift
@@ -60,15 +60,11 @@ struct SwitchInput: View {
                 noValueOption: .show
             )
         } else {
-            HStack {
+            Toggle(isOn: $isOn) {
                 Text(isOn ? input.onValue.name : input.offValue.name)
-                    .accessibilityIdentifier("\(element.label) Switch Label")
-                Spacer()
-                Toggle(isOn: $isOn) {}
-                    .accessibilityIdentifier("\(element.label) Switch")
-                    .toggleStyle(.switch)
             }
-            .formInputStyle()
+            .accessibilityIdentifier("\(element.label) Switch")
+            .formInputStyle(isTappable: false)
             .onAppear {
                 if element.formattedValue.isEmpty {
                     fallbackToComboBox = true
@@ -77,9 +73,6 @@ struct SwitchInput: View {
             .onChange(isOn) { isOn in
                 element.updateValue(isOn ? input.onValue.code : input.offValue.code)
                 model.evaluateExpressions()
-            }
-            .onTapGesture {
-                isOn.toggle()
                 model.focusedElement = element
             }
             .onValueChange(of: element) { newValue, newFormattedValue in

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -16,7 +16,6 @@ import ArcGIS
 import SwiftUI
 
 /// A view for text input.
-@available(visionOS, unavailable)
 struct TextInput: View {
     /// The view model for the form.
     @EnvironmentObject var model: FormViewModel
@@ -83,16 +82,17 @@ struct TextInput: View {
                     model.focusedElement = element
                 }
             }
+#if !os(visionOS)
             .sheet(isPresented: $scannerIsPresented) {
                 CodeScanner(code: $text, isPresented: $scannerIsPresented)
             }
+#endif
             .onValueChange(of: element, when: !element.isMultiline || !fullScreenTextInputIsPresented) { _, newFormattedValue in
                 text = newFormattedValue
             }
     }
 }
 
-@available(visionOS, unavailable)
 private extension TextInput {
     /// The body of the text input when the element is editable.
     var textWriter: some View {
@@ -121,6 +121,11 @@ private extension TextInput {
                     )
                     .accessibilityIdentifier("\(element.label) Text Input")
                     .keyboardType(keyboardType)
+#if os(visionOS)
+                    // No need for hover effect since it will be applied
+                    // properly at 'formInputStyle'.
+                    .hoverEffectDisabled()
+#endif
                 }
             }
             .focused($isFocused)
@@ -150,6 +155,7 @@ private extension TextInput {
                 }
                 .accessibilityIdentifier("\(element.label) Clear Button")
             }
+#if !os(visionOS)
             if isBarcodeScanner {
                 Button {
                     model.focusedElement = element
@@ -163,8 +169,9 @@ private extension TextInput {
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("\(element.label) Scan Button")
             }
+#endif
         }
-        .formInputStyle()
+        .formInputStyle(isTappable: true)
     }
     
     /// The keyboard type to use depending on where the input is numeric and decimal.
@@ -201,7 +208,6 @@ private extension TextInput {
     }
 }
 
-@available(visionOS, unavailable)
 private extension TextInput {
     /// A view for displaying a multiline text input outside the body of the feature form view.
     ///
@@ -229,8 +235,10 @@ private extension TextInput {
                 Button("Done") {
                     dismiss()
                 }
+#if !os(visionOS)
                 .buttonStyle(.plain)
                 .foregroundStyle(Color.accentColor)
+#endif
             }
             RepresentedUITextView(initialText: text) { text in
                 element.convertAndUpdateValue(text)
@@ -248,7 +256,6 @@ private extension TextInput {
     }
 }
 
-@available(visionOS, unavailable)
 private extension TextInput {
     private var isBarcodeScanner: Bool {
         element.input is BarcodeScannerFormInput

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep10.swift
@@ -193,6 +193,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep11.swift
@@ -214,6 +214,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep12.swift
@@ -225,6 +225,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep13.swift
@@ -239,6 +239,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep14.swift
@@ -246,6 +246,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep15.swift
@@ -269,6 +269,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep16.swift
@@ -278,6 +278,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep17.swift
@@ -286,6 +286,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep18.swift
@@ -301,6 +301,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/FeatureFormView/FeatureFormViewStep9.swift
@@ -159,6 +159,6 @@ private extension FeatureForm {
 private extension Array where Element == FeatureEditResult {
     ///  Any errors from the edit results and their inner attachment results.
     var errors: [Error] {
-        compactMap { $0.error } + flatMap { $0.attachmentResults.compactMap { $0.error } }
+        compactMap(\.error) + flatMap { $0.attachmentResults.compactMap(\.error) }
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/AttachmentHelpers/AttachmentsFormElement.swift
@@ -14,7 +14,6 @@
 
 import ArcGIS
 
-@available(visionOS, unavailable)
 extension AttachmentsFormElement: AttachmentsFeatureElement {
     /// Indicates how to display the attachments.
     ///

--- a/Sources/ArcGISToolkit/Utility/MarkdownView.swift
+++ b/Sources/ArcGISToolkit/Utility/MarkdownView.swift
@@ -241,9 +241,8 @@ struct Visitor: MarkupVisitor {
     }
     
     mutating func visitText(_ text: Markdown.Text) -> Result {
-        if let link = text.linkAncestor {
-            let wrappedLink = "[\(text.plainText)](\(link.destination ?? ""))"
-            return .text(SwiftUI.Text(.init(wrappedLink)))
+        if let link = text.linkAncestor, let destination = link.destination {
+            return .other(AnyView(Link(text.plainText, destination: URL(string: destination)!)))
         } else {
             return .text(SwiftUI.Text(text.plainText))
         }

--- a/Sources/ArcGISToolkit/Utility/MarkdownView.swift
+++ b/Sources/ArcGISToolkit/Utility/MarkdownView.swift
@@ -241,10 +241,10 @@ struct Visitor: MarkupVisitor {
     }
     
     mutating func visitText(_ text: Markdown.Text) -> Result {
-        if let link = text.linkAncestor, let destination = link.destination {
-            return .other(AnyView(Link(text.plainText, destination: URL(string: destination)!)))
+        return if let destination = text.linkAncestor?.destination {
+            .other(AnyView(Link(text.plainText, destination: URL(string: destination)!)))
         } else {
-            return .text(SwiftUI.Text(text.plainText))
+            .text(SwiftUI.Text(text.plainText))
         }
     }
     

--- a/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
+++ b/Sources/ArcGISToolkit/Utility/RepresentedUITextView.swift
@@ -34,6 +34,10 @@ struct RepresentedUITextView: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextView {
         let uiTextView = UITextView()
         uiTextView.delegate = context.coordinator
+#if os(visionOS)
+        // The cursor should be white in visionOS not the accent color.
+        uiTextView.tintColor = .white
+#endif
         return uiTextView
     }
     

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1197,7 +1197,6 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["switch integer"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
         let formViewTestsButton = app.buttons["Feature Form Tests"]
-        let switchLabel = app.staticTexts["switch integer Switch Label"]
         let switchView = app.switches["switch integer Switch"]
         
         app.launch()
@@ -1215,14 +1214,14 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            switchLabel.label,
+            switchView.label,
             "2"
         )
         
         switchView.tap()
         
         XCTAssertEqual(
-            switchLabel.label,
+            switchView.label,
             "1"
         )
     }
@@ -1233,7 +1232,6 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["switch string"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
         let formViewTestsButton = app.buttons["Feature Form Tests"]
-        let switchLabel = app.staticTexts["switch string Switch Label"]
         let switchView = app.switches["switch string Switch"]
         
         app.launch()
@@ -1251,7 +1249,7 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            switchLabel.label,
+            switchView.label,
             "1"
         )
         
@@ -1263,7 +1261,7 @@ final class FeatureFormViewTests: XCTestCase {
         switchView.tap()
         
         XCTAssertEqual(
-            switchLabel.label,
+            switchView.label,
             "2"
         )
     }

--- a/Tests/ArcGISToolkitTests/AttachmentsFeatureElementDisplayTypeTests.swift
+++ b/Tests/ArcGISToolkitTests/AttachmentsFeatureElementDisplayTypeTests.swift
@@ -16,7 +16,6 @@ import ArcGIS
 @testable import ArcGISToolkit
 import XCTest
 
-#if !os(visionOS)
 final class AttachmentsFeatureElementDisplayTypeTests: XCTestCase {
     func testInitWithAttachmentsPopupElementDisplayType() {
         XCTAssertEqual(AttachmentsFeatureElementDisplayType(kind: .list), .list)
@@ -24,4 +23,3 @@ final class AttachmentsFeatureElementDisplayTypeTests: XCTestCase {
         XCTAssertEqual(AttachmentsFeatureElementDisplayType(kind: .auto), .auto)
     }
 }
-#endif

--- a/Tests/ArcGISToolkitTests/FeatureAttachmentKindTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureAttachmentKindTests.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !os(visionOS)
 import ArcGIS
 @testable import ArcGISToolkit
 import XCTest
@@ -33,4 +32,3 @@ final class FeatureAttachmentKindTests: XCTestCase {
         XCTAssertEqual(FeatureAttachmentKind(kind: PopupAttachment.Kind.other), .other)
     }
 }
-#endif


### PR DESCRIPTION
Swift #6156

The only two issues I see are these:
- DatePicker is cut off only when FeatureForm is in a floating panel
    - This does look as expected when put into a sheet.
- Hover effect on a disclosure group doesn't look the best
    - I wouldn't consider this a show stopper but it is noticeable if you are familiar with visionOS

The [alternate solution ](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1034) that would have fixed those was explored but was decided not to move forward for a few reasons.

![Screenshot 2025-02-02 at 12 18 15 PM](https://github.com/user-attachments/assets/40163093-b00e-434b-bfb0-cbdf35a0e06f)
![Screenshot 2025-02-02 at 12 22 07 PM](https://github.com/user-attachments/assets/679a755b-6071-40a4-8a6d-6b3b207ee215)
