### PR TITLE
Offline: Ignore keyboard safe area

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -131,6 +131,7 @@ struct OnDemandConfigurationView: View {
             .safeAreaInset(edge: .bottom) {
                 bottomPane(mapView: mapViewProxy)
             }
+            .ignoresSafeArea(.keyboard, edges: .bottom)
         }
     }
     


### PR DESCRIPTION
Fixes a bug where the keyboard presentation causes the map view visible area to change.