### PR TITLE
Offline: Update preplanned map model tests

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
@@ -162,6 +162,9 @@ class PreplannedMapModel: ObservableObject, Identifiable {
         status = .downloading
         do {
             let parameters = try await preplannedMapArea.makeParameters(using: offlineMapTask)
+            
+            parameters.continuesOnErrors = false
+            
             try FileManager.default.createDirectory(at: mmpkDirectoryURL, withIntermediateDirectories: true)
             
             // Create the download preplanned offline map job.

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -32,6 +32,14 @@ private extension PreplannedMapAreaProtocol {
 }
 
 class PreplannedMapModelTests: XCTestCase {
+    override func setUp() async throws {
+        ArcGISEnvironment.apiKey = .default
+    }
+    
+    override func tearDown() {
+        ArcGISEnvironment.apiKey = nil
+    }
+    
     @MainActor
     func testInit() {
         struct MockPreplannedMapArea: PreplannedMapAreaProtocol {}
@@ -208,6 +216,8 @@ class PreplannedMapModelTests: XCTestCase {
     
     @MainActor
     func testDownloadStatuses() async throws {
+        ArcGISEnvironment.backgroundURLSession = .init(configurationProvider: { .default })
+        
         let portalItem = PortalItem(portal: Portal.arcGISOnline(connection: .anonymous), id: .init("acc027394bc84c2fb04d1ed317aac674")!)
         let portalItemID = try XCTUnwrap(portalItem.id)
         let task = OfflineMapTask(portalItem: portalItem)
@@ -274,6 +284,8 @@ class PreplannedMapModelTests: XCTestCase {
     
     @MainActor
     func testLoadMobileMapPackage() async throws {
+        ArcGISEnvironment.backgroundURLSession = .init(configurationProvider: { .default })
+        
         let portalItem = PortalItem(portal: Portal.arcGISOnline(connection: .anonymous), id: .init("acc027394bc84c2fb04d1ed317aac674")!)
         let portalItemID = try XCTUnwrap(portalItem.id)
         let task = OfflineMapTask(portalItem: portalItem)
@@ -329,6 +341,8 @@ class PreplannedMapModelTests: XCTestCase {
     
     @MainActor
     func testRemoveDownloadedPreplannedMapArea() async throws {
+        ArcGISEnvironment.backgroundURLSession = .init(configurationProvider: { .default })
+        
         let portalItem = PortalItem(
             portal: .arcGISOnline(connection: .anonymous),
             id: .init("acc027394bc84c2fb04d1ed317aac674")!


### PR DESCRIPTION
- Fail preplanned job on errors in `PreplannedMapModel`
- Set API key and use non-background URL session in `PreplannedMapModelTests`
    - Test suite runs in under ~20 seconds