### PR TITLE
Add `NavigationLayer`

### DIFF
--- a/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer+DestinationHeader.swift
+++ b/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer+DestinationHeader.swift
@@ -43,6 +43,7 @@ extension NavigationLayer {
                         if let subtitle = model.presented?.subtitle {
                             Text(subtitle)
                                 .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .onGeometryChange(for: CGFloat.self) { proxy in

--- a/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer+DestinationHeader.swift
+++ b/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer+DestinationHeader.swift
@@ -1,0 +1,57 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension NavigationLayer {
+    struct DestinationHeader: View {
+        @EnvironmentObject private var model: NavigationLayerModel
+        
+        @State private var size: CGFloat = .zero
+        
+        var body: some View {
+            HStack {
+                Button {
+                    model.pop()
+                } label: {
+                    let label = Label("Back", systemImage: "chevron.left")
+                    if model.presented?.title == nil {
+                        label
+                            .labelStyle(.titleAndIcon)
+                    } else {
+                        label
+                            .labelStyle(.iconOnly)
+                    }
+                }
+                if let title = model.presented?.title {
+                    Divider()
+                        .frame(height: size)
+                    VStack(alignment: .leading) {
+                        Text(title)
+                            .bold()
+                        if let subtitle = model.presented?.subtitle {
+                            Text(subtitle)
+                                .font(.caption)
+                        }
+                    }
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.height
+                    } action: { newValue in
+                        size = newValue
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer.swift
+++ b/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer.swift
@@ -69,7 +69,7 @@ struct NavigationLayer<Content: View>: View {
         
         var body: some View {
             List {
-                Button("Present a simple view") {
+                Button("Present a view") {
                     model.push { Text("View") }
                 }
                 Button("Present a view with a title") {

--- a/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer.swift
+++ b/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer.swift
@@ -1,0 +1,99 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+/// Navigation designed to work for components hosted in Floating Panels.
+///
+/// As of iOS 18, nested Navigation Stacks aren't supported. Because we don't know how a developer has
+/// presented a Toolkit component, NavigationLayer provides a simple navigation implementation that can be
+/// used in a component presented either modally (e.g. a Sheet) or non-modally (a Floating Panel).
+struct NavigationLayer<Content: View>: View {
+    let root: () -> Content
+    
+    @State private var width: CGFloat = .zero
+    
+    @StateObject private var model: NavigationLayerModel
+    
+    init(_ root: @escaping () -> Content) {
+        self.root = root
+        _model = StateObject(wrappedValue: NavigationLayerModel())
+    }
+    
+    var body: some View {
+        Group {
+            if model.views.isEmpty {
+                root()
+                    .transition(model.transition)
+            } else if let presented = model.presented?.view {
+                VStack {
+                    DestinationHeader()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    Spacer()
+                    AnyView(presented())
+                    Spacer()
+                }
+                // Re-trigger the transition animation when view count changes.
+                .id(model.views.count)
+                .transition(model.transition)
+            }
+        }
+        .environmentObject(model)
+        // Apply container width so the animated transitions work correctly.
+        .frame(width: width)
+        .frame(maxWidth: .infinity)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { newValue in
+            width = newValue
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    struct SampleList: View {
+        @EnvironmentObject private var model: NavigationLayerModel
+        
+        var body: some View {
+            List {
+                Button("Present a simple view") {
+                    model.push { Text("View") }
+                }
+                Button("Present a view with a title") {
+                    model.push(title: "Title") { Text("View") }
+                }
+                Button("Present a view with a title & subtitle") {
+                    model.push(title: "Title", subtitle: "Subtitle") { Text("View") }
+                }
+            }
+        }
+    }
+    
+    @Previewable @State var isPresented = true
+    
+    return LinearGradient(
+        colors: [.red, .orange, .yellow],
+        startPoint: .topLeading, endPoint: .bottomTrailing
+    )
+    .ignoresSafeArea(edges: .all)
+    .sheet(isPresented: $isPresented) {
+        NavigationLayer {
+            SampleList()
+        }
+        .interactiveDismissDisabled()
+        .presentationDetents([.medium])
+    }
+}

--- a/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer.swift
+++ b/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayer.swift
@@ -89,7 +89,7 @@ struct NavigationLayer<Content: View>: View {
         startPoint: .topLeading, endPoint: .bottomTrailing
     )
     .ignoresSafeArea(edges: .all)
-    .sheet(isPresented: $isPresented) {
+    .floatingPanel(isPresented: $isPresented) {
         NavigationLayer {
             SampleList()
         }

--- a/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayerModel.swift
+++ b/Sources/ArcGISToolkit/Common/NavigationLayer/NavigationLayerModel.swift
@@ -1,0 +1,71 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+class NavigationLayerModel: ObservableObject {
+    struct Item {
+        let title: String?
+        
+        let subtitle: String?
+        
+        let view: () -> any View
+    }
+    
+    @Published private(set) var transition: AnyTransition = .push
+    
+    @Published private(set) var views: [Item] = []
+    
+    var presented: Item? {
+        views.last
+    }
+    
+    func pop() {
+        guard !views.isEmpty else { return }
+        transition = .pop
+        withAnimation {
+            _ = views.removeLast()
+        }
+    }
+    
+    /// Push a view.
+    /// - Parameter view: The view to push.
+    func push(_ view: @escaping () -> any View) {
+        push(.init(title: nil, subtitle: nil, view: view))
+    }
+    
+    /// Push a view with a title.
+    /// - Parameters:
+    ///   - title: The title for the view.
+    ///   - view: The view to push.
+    func push(title: String, _ view: @escaping () -> any View) {
+        push(.init(title: title, subtitle: nil, view: view))
+    }
+    
+    /// Push a view with a title and subtitle.
+    /// - Parameters:
+    ///   - title: The title for the view.
+    ///   - subtitle: The subtitle for the view.
+    ///   - view: The view to push.
+    func push(title: String, subtitle: String, _ view: @escaping () -> any View) {
+        push(.init(title: title, subtitle: subtitle, view: view))
+    }
+    
+    private func push(_ view: Item) {
+        transition = .push
+        withAnimation {
+            views.append(view)
+        }
+    }
+}

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/AnyTransition.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/AnyTransition.swift
@@ -1,0 +1,31 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension AnyTransition {
+    static var push: Self {
+        .asymmetric(
+            insertion: .move(edge: .trailing),
+            removal: .move(edge: .leading)
+        )
+    }
+    
+    static var pop: Self {
+        .asymmetric(
+            insertion: .move(edge: .leading),
+            removal: .move(edge: .trailing)
+        )
+    }
+}


### PR DESCRIPTION
Proposes `NavigationLayer`, an internal `NavigationStack` alternative to work around the [nested `NavigationStack` limitation](https://developer.apple.com/forums/thread/772650).

<p align="center">
  <img width="50%" src="https://github.com/user-attachments/assets/439cba6f-1e72-4b87-95d5-0674874a8b25">
</p>
