### PR TITLE
AR: Set atmosphere effect for Flyover

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -136,6 +136,7 @@ public struct FlyoverSceneView: View {
         SceneViewReader { sceneViewProxy in
             sceneViewBuilder(sceneViewProxy)
                 .cameraController(cameraController)
+                .atmosphereEffect(.realistic)
 #if os(iOS)
                 .onAppear {
                     let configuration = ARPositionalTrackingConfiguration()


### PR DESCRIPTION
Sets the atmosphere effect to `.realistic` in `FlyoverSceneView` to fix a bug where the default atmosphere effect of `horizonOnly` caused the top of the view to show the space effect black background with stars. 

Before and after setting atmosphere effect to `.realistic`:
<img src="https://github.com/user-attachments/assets/57d87a09-0507-404f-8581-a06c179ec4f4" width="300">    <img src="https://github.com/user-attachments/assets/63ec0d99-9b07-4048-b6ed-219e362a2c12" width="300">

Note: This bug fix should be mentioned in the Toolkit release notes