### PR TITLE
fix scalebar freeze

### DIFF
--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -55,9 +55,6 @@ public struct Scalebar: View {
     /// A timer to allow for the scheduling of the auto-hide animation.
     @State private var autoHideTimer: Timer?
     
-    /// The vertical amount of space used by the scalebar.
-    @State private var height: Double?
-    
     /// Controls the current opacity of the scalebar.
     @State private var opacity: Double
     
@@ -197,14 +194,8 @@ public struct Scalebar: View {
                 }
             }
         }
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.frame(in: .global).height
-        } action: { newValue in
-            height = newValue
-        }
         .frame(
-            width: $viewModel.displayLength.wrappedValue,
-            height: height ?? .zero
+            width: $viewModel.displayLength.wrappedValue
         )
         .environment(\.scalebarSettings, settings)
     }

--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -194,9 +194,7 @@ public struct Scalebar: View {
                 }
             }
         }
-        .frame(
-            width: $viewModel.displayLength.wrappedValue
-        )
+        .frame(width: $viewModel.displayLength.wrappedValue)
         .environment(\.scalebarSettings, settings)
     }
 }


### PR DESCRIPTION
fixes https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/1092

This seems to fix the freeze. And it seems that the code was reading the height and then setting the height to what was read.