### PR TITLE
Charts: honor popup color from `PopupMediaValue`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/BarChart.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/BarChart.swift
@@ -48,12 +48,14 @@ struct BarChart: View {
                     x: .value(String.field, $0.label),
                     y: .value(String.value, $0.value)
                 )
+                .foregroundStyle(Color($0.color))
             } else {
                 // Horizontal bars.
                 BarMark(
                     x: .value(String.value, $0.value),
                     y: .value(String.field, $0.label)
                 )
+                .foregroundStyle(Color($0.color))
             }
         }
         .chartXAxis {

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartData.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartData.swift
@@ -21,13 +21,15 @@ struct ChartData: Identifiable {
     let label: String
     /// The value of the data.
     let value: Double
+    /// A chart color to be used for the data.
+    let color: UIColor
     let id = UUID()
     
     /// Creates a `ChartData`.
     /// - Parameters:
     ///   - label: The label for the data.
     ///   - value: The value of the data.
-    init(label: String, value: Any) {
+    init(label: String, value: Any, color: UIColor) {
         self.label = label
         if let int = value as? Int {
             self.value = Double(int)
@@ -38,6 +40,7 @@ struct ChartData: Identifiable {
         } else {
             self.value = 0
         }
+        self.color = color
     }
     
     /// Gets the chart data for a `PopupMedia`.
@@ -45,13 +48,63 @@ struct ChartData: Identifiable {
     /// - Returns: The array of chart data for the popup media.
     static func getChartData(from popupMedia: PopupMedia) -> [ChartData] {
         guard let labels = popupMedia.value?.labels,
-              let data = popupMedia.value?.data else { return [] }
+              let data = popupMedia.value?.data,
+              let colors = popupMedia.value?.chartColors else { return [] }
         
+        let chartData: [ChartData]
         let chartRawData = zip(labels, data).map { ($0, $1) }
-        let chartData = chartRawData.map {
-            ChartData(label: $0.0, value: $0.1)
+        if popupMedia.kind == .lineChart, let color = colors.first {
+            // When the popup media type is line chart, the first color
+            // will be the line color and other colors are ignored.
+            chartData = chartRawData.map {
+                ChartData(label: $0.0, value: $0.1, color: color)
+            }
+        } else {
+            var paddedColors = colors
+            if paddedColors.count > labels.count {
+                // Ignores the additional colors when the color array is
+                // longer than field labels.
+                paddedColors.removeLast(colors.count - labels.count)
+            } else if colors.count < labels.count {
+                // Uses a fallback color ramp when the color array is
+                // shorter than field labels.
+                for i in 0 ..< labels.count - colors.count {
+                    paddedColors += [color(for: i)]
+                }
+            }
+            chartData = zip(chartRawData, paddedColors).map {
+                ChartData(label: $0.0, value: $0.1, color: $1)
+            }
         }
-        
         return chartData
+    }
+    
+    /// The pre-defined colors for a color ramp.
+    private static let rampColors: [UIColor] = [
+        .systemMint,
+        .systemTeal,
+        .systemGreen,
+        .systemCyan,
+        .systemYellow,
+        .systemBlue,
+        .systemOrange,
+        .systemIndigo,
+        .systemRed,
+        .systemPurple,
+        .systemPink,
+        .systemBrown
+    ]
+    
+    /// Calculates a color for the given index.
+    /// - Parameter index: The index of an element in color ramp array.
+    /// - Returns: The color for the element at `index`.
+    private static func color(for index: Int) -> UIColor {
+        // We don't want to just wrap color indices because we don't want
+        // two adjacent slices to have the same color. "extra" will skip the
+        // the 1st color for the second time through the list, skip the 2nd
+        // color the third time through the list, etc., ensuring that we
+        // don't get adjacent colors.
+        let extra = index / rampColors.count
+        return rampColors[(index + extra) % rampColors.count]
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/LineChart.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/LineChart.swift
@@ -40,10 +40,12 @@ struct LineChart: View {
                 x: .value(String.field, $0.label),
                 y: .value(String.value, $0.value)
             )
+            .foregroundStyle(Color($0.color))
             PointMark(
                 x: .value(String.field, $0.label),
                 y: .value(String.value, $0.value)
             )
+            .foregroundStyle(Color($0.color))
         }
         .chartXAxis {
             AxisMarks { _ in

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/PieChartModel.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/PieChartModel.swift
@@ -24,47 +24,18 @@ final class PieChartModel: ObservableObject {
     /// - Parameter chartData: The data used for the pie chart.
     init(chartData: [ChartData]) {
         var slices = [PieSlice]()
-        var dataTotal: Double = 0
-        _ = chartData.map { dataTotal += $0.value }
+        let dataTotal = chartData.reduce(0) { $0 + $1.value }
         for i in 0..<chartData.count {
+            let data = chartData[i]
             slices.append(
                 PieSlice(
-                    fraction: chartData[i].value / dataTotal,
-                    color: PieChartModel.color(for: i),
-                    name: chartData[i].label
+                    fraction: data.value / dataTotal,
+                    color: Color(data.color),
+                    name: data.label
                 )
             )
         }
         pieSlices = slices
-    }
-    
-    /// The pre-defined colors for the pie slices.
-    static let sliceColors: [Color] = [
-        .mint,
-        .teal,
-        .green,
-        .cyan,
-        .yellow,
-        .blue,
-        .orange,
-        .indigo,
-        .red,
-        .purple,
-        .pink,
-        .brown
-    ]
-    
-    /// Calculates a slice color for the given slice index.
-    /// - Parameter index: The index of the slice.
-    /// - Returns: The color for the slice at `index`.
-    static func color(for index: Int) -> Color {
-        // We don't want to just wrap color indices because we don't want
-        // two adjacent slices to have the same color. "extra" will skip the
-        // the 1st color for the second time through the list, skip the 2nd
-        // color the third time through the list, etc., ensuring that we
-        // don't get adjacent colors.
-        let extra = index / sliceColors.count
-        return sliceColors[(index + extra) % sliceColors.count].opacity(0.75)
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds #995 , for bar chart, line chart, and pie chart.

Please use the runtimecoretest web map (PopupElement Test Case 1.2) to see specified chart colors (pink, green), or use the current popup example to see the default color ramp (mint, teal, …).

<details><summary>code for authentication</summary>

```swift
                .onAppear {
                    ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler = ChallengeHandler()
                }
                .onDisappear {
                    ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler = nil
                }

private struct ChallengeHandler: ArcGISAuthenticationChallengeHandler {
    func handleArcGISAuthenticationChallenge(
        _ challenge: ArcGISAuthenticationChallenge
    ) async throws -> ArcGISAuthenticationChallenge.Disposition {
        // NOTE: Never hardcode login information in a production application.
        // This is done solely for the sake of the sample.
        return .continueWithCredential(
            try await TokenCredential.credential(for: challenge, username: "XXX", password: "XXX")
        )
    }
}

```

</details>