### PR TITLE
remove arbitrary sleep workaround

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -154,6 +154,7 @@ struct OnDemandConfigurationView: View {
             .attributionBarHidden(true)
             .interactionModes([.pan, .zoom])
             .onDrawStatusChanged { drawStatus in
+                guard !mapIsReady else { return }
                 if drawStatus == .completed && map.loadStatus == .loaded {
                     mapIsReady = true
                 }

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -153,11 +153,8 @@ struct OnDemandConfigurationView: View {
         #endif
             .attributionBarHidden(true)
             .interactionModes([.pan, .zoom])
-            .onLayerViewStateChanged { _, _ in
-                Task { @MainActor in
-                    // Sleep for a moment to give the map a chance to become fully ready
-                    // to convert coordinates from screen to location.
-                    try? await Task.sleep(for: .milliseconds(250))
+            .onDrawStatusChanged { drawStatus in
+                if drawStatus == .completed && map.loadStatus == .loaded {
                     mapIsReady = true
                 }
             }


### PR DESCRIPTION
This changes the UX so that controls are disabled until the map is completely done with initial drawing. This allows us to remove the arbitrary workaround.