### PR TITLE
Offline: Done button visibility

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
@@ -183,13 +183,13 @@ struct OpenOfflineMapAreaButton: View {
     /// The action to dismiss the view.
     /// Note: if this is not passed in to this view, and we use
     /// the environment here, it doesn't work.
-    let dismiss: DismissAction
+    let dismiss: DismissAction?
     
     var body: some View {
         Button {
             if let map {
                 selectedMap = map
-                dismiss()
+                dismiss?()
             }
         } label: {
             Text(

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
@@ -181,7 +181,7 @@ struct OpenOfflineMapAreaButton: View {
     let isSelected: Bool
     
     /// The action to dismiss the view.
-    /// Note: if this is not passed in to this view, and we use
+    /// - Note: If this is not passed in to this view, and we use
     /// the environment here, it doesn't work.
     let dismiss: DismissAction?
     

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -27,6 +27,12 @@ public struct OfflineMapAreasView: View {
     @Binding private var selectedMap: Map?
     /// A Boolean value indicating whether an on-demand map area is being added.
     @State private var isAddingOnDemandArea = false
+    /// The visibility of the done button.
+    private var doneVisibility: Visibility = .automatic
+    /// A Boolean value indicating whether the view should dismiss.
+    private var shouldDismiss: Bool {
+        doneVisibility == .automatic || doneVisibility == .visible
+    }
     
     /// The portal item for the web map to be taken offline.
     private var portalItem: PortalItem {
@@ -64,6 +70,14 @@ public struct OfflineMapAreasView: View {
         _mapViewModel = StateObject(wrappedValue: OfflineManager.shared.model(for: onlineMap))
         self.onlineMap = onlineMap
         _selectedMap = selection
+    }
+    
+    /// Specifies the visibility of the done button.
+    /// - Parameter visibility: The preferred visibility of the done button.
+    public func doneButton(_ visibility: Visibility) -> Self {
+        var copy = self
+        copy.doneVisibility = visibility
+        return copy
     }
     
     public var body: some View {
@@ -107,9 +121,11 @@ public struct OfflineMapAreasView: View {
                 }
             }
             .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button.done {
-                        dismiss()
+                if shouldDismiss {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button.done {
+                            dismiss()
+                        }
                     }
                 }
             }
@@ -131,7 +147,11 @@ public struct OfflineMapAreasView: View {
                 List {
                     Section {
                         ForEach(models) { preplannedMapModel in
-                            PreplannedListItemView(model: preplannedMapModel, selectedMap: $selectedMap)
+                            PreplannedListItemView(
+                                model: preplannedMapModel,
+                                selectedMap: $selectedMap,
+                                shouldDismiss: shouldDismiss
+                            )
                         }
                     } footer: {
                         if mapViewModel.isShowingOnlyOfflineModels {
@@ -165,7 +185,11 @@ public struct OfflineMapAreasView: View {
             if !mapViewModel.onDemandMapModels.isEmpty {
                 List {
                     ForEach(mapViewModel.onDemandMapModels) { onDemandMapModel in
-                        OnDemandListItemView(model: onDemandMapModel, selectedMap: $selectedMap)
+                        OnDemandListItemView(
+                            model: onDemandMapModel,
+                            selectedMap: $selectedMap,
+                            shouldDismiss: shouldDismiss
+                        )
                     }
                     Section {
                         Button {

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -32,6 +32,9 @@ struct OnDemandListItemView: View {
         selectedMap?.item?.title == model.title
     }
     
+    /// A Boolean value indicating whether the view should dismiss.
+    var shouldDismiss = true
+    
     var body: some View {
         OfflineMapAreaListItemView(model: model, isSelected: isSelected) {
             trailingButton
@@ -47,7 +50,7 @@ struct OnDemandListItemView: View {
                 selectedMap: $selectedMap,
                 map: model.map,
                 isSelected: isSelected,
-                dismiss: dismiss
+                dismiss: shouldDismiss ? dismiss : nil
             )
         case .initialized:
             EmptyView()

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -33,7 +33,7 @@ struct OnDemandListItemView: View {
     }
     
     /// A Boolean value indicating whether the view should dismiss.
-    var shouldDismiss = true
+    let shouldDismiss: Bool
     
     var body: some View {
         OfflineMapAreaListItemView(model: model, isSelected: isSelected) {

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -38,7 +38,7 @@ struct PreplannedListItemView: View {
     }
     
     /// A Boolean value indicating whether the view should dismiss.
-    var shouldDismiss = true
+    let shouldDismiss: Bool
     
     var body: some View {
         OfflineMapAreaListItemView(model: model, isSelected: isSelected) {
@@ -89,7 +89,8 @@ struct PreplannedListItemView: View {
             preplannedMapAreaID: .init("preview")!,
             onRemoveDownload: {}
         ),
-        selectedMap: .constant(nil)
+        selectedMap: .constant(nil),
+        shouldDismiss: true
     )
     .padding()
 }

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -37,6 +37,9 @@ struct PreplannedListItemView: View {
         selectedMap?.item?.title == model.preplannedMapArea.title
     }
     
+    /// A Boolean value indicating whether the view should dismiss.
+    var shouldDismiss = true
+    
     var body: some View {
         OfflineMapAreaListItemView(model: model, isSelected: isSelected) {
             trailingButton
@@ -59,7 +62,7 @@ struct PreplannedListItemView: View {
                 selectedMap: $selectedMap,
                 map: model.map,
                 isSelected: isSelected,
-                dismiss: dismiss
+                dismiss: shouldDismiss ? dismiss : nil
             )
         }
     }


### PR DESCRIPTION
Adds support to set the visibility of the "Done" button with the `doneButton(Visibility)` view modifier on the `OfflineMapAreasView`. This allows various types of navigation to be supported.

Closes `swift/6471`.