### PR TITLE
`SearchView` - Resolve crashing condition with `swift-toolkit-daily`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -475,13 +475,7 @@ extension ResultRow {
             image: AnyView(
                 (searchSuggestion.isCollection ?
                  Image(systemName: "magnifyingglass") :
-                    Image(
-                        uiImage: UIImage(
-                            named: "pin",
-                            in: .toolkitModule,
-                            with: nil
-                        )!
-                    )
+                    Image("pin", bundle: .toolkitModule)
                 )
                     .foregroundStyle(.secondary)
             )
@@ -495,7 +489,7 @@ extension ResultRow {
             title: searchResult.displayTitle,
             subtitle: searchResult.displaySubtitle,
             image: AnyView(
-                Image(uiImage: UIImage.mapPin)
+                Image("MapPin", bundle: .toolkitModule)
                     .scaleEffect(0.65)
             )
         )

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -428,9 +428,13 @@ private extension Graphic {
 private extension Symbol {
     /// A search result marker symbol.
     static func searchResult() -> MarkerSymbol {
-        let image = UIImage.mapPin
-        let symbol = PictureMarkerSymbol(image: image)
-        symbol.offsetY = image.size.height / 2.0
+        var symbol: MarkerSymbol
+        if let image = UIImage.mapPin {
+            symbol = PictureMarkerSymbol(image: image)
+            symbol.offsetY = image.size.height / 2.0
+        } else {
+            symbol = SimpleMarkerSymbol()
+        }
         return symbol
     }
 }

--- a/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchViewModel.swift
@@ -436,7 +436,7 @@ private extension Symbol {
 }
 
 extension UIImage {
-    static var mapPin: UIImage {
-        return UIImage(named: "MapPin", in: .toolkitModule, with: nil)!
+    static var mapPin: UIImage? {
+        UIImage(named: "MapPin", in: .toolkitModule, with: nil)
     }
 }


### PR DESCRIPTION
Related #1109 

Between 4489 and 4490 Swift was upgraded from 6.0 to 6.0.3 (see RTC 30409). I suspect the inclusion of these resources was broken by that upgrade.