### PR TITLE
Offline: Fix flakey tests

### DIFF
--- a/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
@@ -253,7 +253,7 @@ class OnDemandMapModelTests: XCTestCase {
         
         // Verify statuses.
         // First give time for final status to come in.
-        try? await Task.yield(timeout: 0.1) { @MainActor in
+        try? await Task.yield(timeout: 0.5) { @MainActor in
             statuses.last == .downloaded
         }
         XCTAssertEqual(

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -327,7 +327,7 @@ class PreplannedMapModelTests: XCTestCase {
         
         // Verify statuses.
         // First give time for final status to come in.
-        try? await Task.yield(timeout: 0.1) { @MainActor in
+        try? await Task.yield(timeout: 0.5) { @MainActor in
             statuses.last == .downloaded
         }
         XCTAssertEqual(

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -353,6 +353,12 @@ class PreplannedMapModelTests: XCTestCase {
         let area = try XCTUnwrap(areas.first)
         let areaID = try XCTUnwrap(area.portalItem.id)
         
+        // Create mmpk directory and verify it exists before creating model.
+        let directory = URL.preplannedDirectory(forPortalItemID: portalItemID, preplannedMapAreaID: areaID)
+        let mmpkDirectory = directory.appending(component: "mmpk")
+        try FileManager.default.createDirectory(at: mmpkDirectory, withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mmpkDirectory.path()))
+        
         let model = PreplannedMapModel(
             offlineMapTask: task,
             mapArea: area,
@@ -371,34 +377,17 @@ class PreplannedMapModelTests: XCTestCase {
         
         await model.load()
         
-        // Start downloading.
-        await model.downloadPreplannedMapArea()
-        
-        // Wait for job to finish.
-        _ = await model.job?.result
-        
-        // Verify statuses after download.
-        // First give time for final status to come in.
-        try? await Task.yield(timeout: 0.1) { @MainActor in
-            statuses.last == .downloaded
-        }
-        XCTAssertEqual(
-            statuses,
-            [.notLoaded, .loading, .packaged, .downloading, .downloaded]
-        )
+        XCTAssertNotEqual(model.status, .notLoaded)
         
         // Clean up folder.
         model.removeDownloadedArea()
         
         // Verify statuses after remove.
         // First give time for final status to come in.
-        try? await Task.yield(timeout: 0.1) { @MainActor in
+        try? await Task.yield(timeout: 0.5) { @MainActor in
             statuses.last == .packaged
         }
-        XCTAssertEqual(
-            statuses,
-            [.notLoaded, .loading, .packaged, .downloading, .downloaded, .notLoaded, .loading, .packaged]
-        )
+        XCTAssertEqual(statuses.last, .packaged)
     }
     
     @MainActor


### PR DESCRIPTION
Related to `swift/6723`

Fixes the following flakey tests:

Increases the timeout for the download to succeed.
- `PreplannedMapModelTests.testLoadMobileMapPackage()`
- `OnDemandMapModelTests.testLoadMobileMapPackage()`

Removes step to download mmpk, and instead removes an empty file.
- `PreplannedMapModelTests.testRemoveDownloadedPreplannedMapArea()`
