### PR TITLE
Fix intermittent crash accessing credential in Example

### DIFF
--- a/Examples/Examples/UtilityNetworkTraceExampleView.swift
+++ b/Examples/Examples/UtilityNetworkTraceExampleView.swift
@@ -37,6 +37,13 @@ struct UtilityNetworkTraceExampleView: View {
     /// A container for graphical trace results.
     @State private var resultGraphicsOverlay = GraphicsOverlay()
     
+    init() {
+        Task {
+            let publicSample = try? await ArcGISCredential.publicSample
+            ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(publicSample!)
+        }
+    }
+    
     var body: some View {
         GeometryReader { geometryProxy in
             MapViewReader { mapViewProxy in
@@ -49,10 +56,6 @@ struct UtilityNetworkTraceExampleView: View {
                 }
                 .onSingleTapGesture { _, mapPoint in
                     self.mapPoint = mapPoint
-                }
-                .task {
-                    let publicSample = try? await ArcGISCredential.publicSample
-                    ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(publicSample!)
                 }
 #if os(visionOS)
                 mapView


### PR DESCRIPTION
Fixes a crash in the `UtilityNetworkTraceExampleView` where accessing the credential causes a crash when it is `nil`.