### PR TITLE
offline: Remove unused `metadataViewIsPresented`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -22,9 +22,6 @@ struct OnDemandListItemView: View {
     /// The currently selected map.
     @Binding var selectedMap: Map?
     
-    /// A Boolean value indicating whether the metadata view is presented.
-    @State private var metadataViewIsPresented = false
-    
     /// The action to dismiss the view.
     @Environment(\.dismiss) private var dismiss
     

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -23,9 +23,6 @@ struct PreplannedListItemView: View {
     /// The currently selected map.
     @Binding var selectedMap: Map?
     
-    /// A Boolean value indicating whether the metadata view is presented.
-    @State private var metadataViewIsPresented = false
-    
     /// The action to dismiss the view.
     @Environment(\.dismiss) private var dismiss
     


### PR DESCRIPTION
This Boolean value seems to be unused, as the value is moved to [`OfflineMapAreaListItemView`](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/v.next/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift#L42).