### PR TITLE
offline: Update URL+Offline.swift

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/Utilities/URL+Offline.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Utilities/URL+Offline.swift
@@ -24,14 +24,14 @@ extension URL {
     }
     
     /// The path to the web map directory for a specific portal item.
-    /// `Documents/OfflineMapAreas/<Portal Item ID>/`
+    /// `Documents/com.esri.ArcGISToolkit.offlineManager/<Portal Item ID>/`
     /// - Parameter portalItemID: The ID of the web map portal item.
     static func portalItemDirectory(forPortalItemID portalItemID: Item.ID) -> URL {
         return offlineManagerDirectory().appending(path: portalItemID.rawValue)
     }
     
     /// The path to the directory for a specific map area from the preplanned map areas directory for a specific portal item.
-    /// `Documents/OfflineMapAreas/<Portal Item ID>/Preplanned/<Preplanned Area ID>/`
+    /// `Documents/com.esri.ArcGISToolkit.offlineManager/<Portal Item ID>/Preplanned/<Preplanned Area ID>/`
     /// - Parameters:
     ///   - portalItemID: The ID of the web map portal item.
     ///   - preplannedMapAreaID: The ID of the preplanned map area portal item.
@@ -50,6 +50,7 @@ extension URL {
     
     /// The path to the directory for a specific on-demand map area. Or if `nil` is passed for the
     /// map area ID, then the on-demand directory.
+    /// `Documents/com.esri.ArcGISToolkit.offlineManager/<Portal Item ID>/OnDemand/`
     /// - Parameters:
     ///   - portalItemID: The ID of the web map portal item.
     ///   - onDemandMapAreaID: The unique ID of the on-demand map area.


### PR DESCRIPTION
Fix docs for example file paths. The base path for map area storage has become `Documents/com.esri.ArcGISToolkit.offlineManager/` so fix that in the docs.