### PR TITLE
Field popup element button

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -81,7 +81,11 @@ struct FieldsPopupElementView: View {
                         comment: "E.g. Open a hyperlink."
                     )
                 }
-                .buttonStyle(.bordered)
+#if os(visionOS)
+                    .buttonStyle(.bordered)
+#else
+                    .buttonStyle(.borderless)
+#endif
             } else {
                 Text(formattedValue)
             }


### PR DESCRIPTION
With the visionOS updates, the "View" button in the `FieldsPopupElementView` changed from borderless to bordered. This just changes it back for non-visionOS builds.