### PR TITLE
Basemap gallery test fix

### DIFF
--- a/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
@@ -312,7 +312,7 @@ class BasemapGalleryViewModelTests: XCTestCase {
         let items = try await viewModel.$items.dropFirst().first
         let basemapGalleryItems = try XCTUnwrap(items)
         XCTAssertFalse(basemapGalleryItems.isEmpty)
-        XCTAssertEqual(basemapGalleryItems.count, 39)
+        XCTAssertEqual(basemapGalleryItems.count, 43)
         
         try await withThrowingTaskGroup(of: Void.self) { group in
             for index in basemapGalleryItems.indices {


### PR DESCRIPTION
Fixes `BasemapGalleryViewModelTests.testCase_2_5()`. The count of base maps is 43, not 39.