### PR TITLE
offline: Reorder the rotate gesture priorities on config view

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -164,7 +164,6 @@ struct OnDemandConfigurationView: View {
                 }
             }
             .highPriorityGesture(DragGesture())
-            .highPriorityGesture(RotateGesture())
             .interactiveDismissDisabled()
     }
     

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -163,6 +163,7 @@ struct OnDemandConfigurationView: View {
                     mapIsReady = true
                 }
             }
+            .highPriorityGesture(RotateGesture())
             .highPriorityGesture(DragGesture())
             .interactiveDismissDisabled()
     }


### PR DESCRIPTION
- On iOS 17 simulator, with the `RotateGesture`, it would cause the sheet to move when panning the map view. Reordering the priority gestures fixes the problem.
- On iOS 18 simulator, with or without the change, the sheet doesn't move.

This was introduced in #1067. ~~However, I couldn't figure out what the pinching problem was referring to. Let me know if there are other considerations.~~

test map: 3da658f2492f4cfd8494970ef489d2c5

https://github.com/user-attachments/assets/cf94e8e9-b491-4004-a2d9-1f7979127844

