### PR TITLE
hotfix: 200.7.1 Release

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -32,14 +32,8 @@ struct OnDemandConfigurationView: View {
     /// The max scale of the map to take offline.
     @State private var maxScale: CacheScale = .street
     
-    /// The visible area of the map.
-    @State private var visibleArea: Envelope?
-    
     /// The selected map area.
     @State private var selectedRect: CGRect = .zero
-    
-    /// The extent of the selected map area.
-    @State private var selectedExtent: Envelope?
     
     /// A Boolean value indicating that the map is ready.
     @State private var mapIsReady = false
@@ -48,7 +42,7 @@ struct OnDemandConfigurationView: View {
     @Environment(\.dismiss) private var dismiss
     
     /// A Boolean value indicating if the download button is disabled.
-    private var downloadIsDisabled: Bool { selectedExtent == nil || hasNoInternetConnection }
+    private var downloadIsDisabled: Bool { selectedRect == .zero || hasNoInternetConnection }
     
     /// The result of trying to load the map.
     @State private var loadResult: Result<Void, Error>?
@@ -121,9 +115,6 @@ struct OnDemandConfigurationView: View {
                             // Don't add the selector view until the map is ready.
                             OnDemandMapAreaSelectorView(selectedRect: $selectedRect)
                         }
-                    }
-                    .onChange(selectedRect) { _ in
-                        selectedExtent = mapViewProxy.envelope(fromViewRect: selectedRect)
                     }
             }
             .safeAreaInset(edge: .bottom) {
@@ -209,7 +200,7 @@ struct OnDemandConfigurationView: View {
                 
                 HStack {
                     Button {
-                        guard let selectedExtent else { return }
+                        guard let selectedExtent = mapView.envelope(fromViewRect: selectedRect) else { return }
                         Task {
                             let image = try? await mapView.exportImage()
                             let thumbnail = image?.crop(to: selectedRect)


### PR DESCRIPTION
# Description

#1149 fixes a bug that stops the on-demand workflow from downloading an area without moving the extent selector. Please test with an API key and the breweries web map 3da658f2492f4cfd8494970ef489d2c5 .

After these cherry-picked changes are reviewed, I'll figure out what version numbers need to be updated.
- edit: no example app version needs to be bumped as there aren't changes in them. They will pick up the latest toolkit once this patch is tagged.