### PR TITLE
Fix: Refactor localized strings

### DIFF
--- a/Sources/ArcGISToolkit/Common/CameraRequester.swift
+++ b/Sources/ArcGISToolkit/Common/CameraRequester.swift
@@ -52,7 +52,7 @@ private struct CameraRequesterModifier: ViewModifier {
                     Task { await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!) }
                 }
 #endif
-                Button(String.cancel, role: .cancel) {
+                Button.cancel {
                     requester.onAccessDenied?()
                 }
             } message: {

--- a/Sources/ArcGISToolkit/Common/CodeScanner.swift
+++ b/Sources/ArcGISToolkit/Common/CodeScanner.swift
@@ -31,7 +31,7 @@ struct CodeScanner: View {
             CodeScannerRepresentable(scannerIsPresented: $isPresented, scanOutput: $code)
                 .ignoresSafeArea()
                 .overlay(alignment:.topTrailing) {
-                    Button(String.cancel, role: .cancel) {
+                    Button.cancel {
                         isPresented = false
                     }
                     .buttonStyle(.borderedProminent)

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -201,13 +201,13 @@ struct CertificatePickerViewModifier: ViewModifier {
                     comment: "A label indicating that a password is required to proceed with an operation."
                 ),
                 cancelAction: .init(
-                    title: String.cancel,
+                    title: .cancel,
                     handler: { _, _ in
                         viewModel.cancel()
                     }
                 ),
                 continueAction: .init(
-                    title: String.ok,
+                    title: .ok,
                     handler: { _, password in
                         viewModel.proceedToUseCertificate(withPassword: password)
                     }
@@ -262,7 +262,7 @@ private extension View {
                         isPresented.wrappedValue = false
                         viewModel.cancel()
                     } label: {
-                        Text(String.cancel)
+                        Text.cancel
                             .padding(.horizontal)
                     }
                     .buttonStyle(.bordered)
@@ -353,7 +353,7 @@ private extension View {
                         isPresented.wrappedValue = false
                         viewModel.cancel()
                     } label: {
-                        Text(String.cancel)
+                        Text.cancel
                             .padding(.horizontal)
                     }
                     .buttonStyle(.bordered)

--- a/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/LoginViewModifier.swift
@@ -54,15 +54,15 @@ struct LoginViewModifier: ViewModifier {
                     comment: "A label indicating authentication is required to proceed."
                 ),
                 cancelAction: .init(
-                    title: String.cancel,
+                    title: .cancel,
                     handler: { _, _ in
                         onCancel()
                     }
                 ),
                 continueAction: .init(
-                    title: String(
-                        localized: "Continue",
-                        bundle: .toolkitModule,
+                    title: .init(
+                        "Continue",
+                        bundle: .toolkit,
                         comment: "A label for a button used to continue the authentication operation."
                     ),
                     handler: { username, password in

--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -72,7 +72,7 @@ struct TrustHostViewModifier: ViewModifier {
                             isPresented = false
                             challenge.resume(with: .cancel)
                         } label: {
-                            Text(String.cancel)
+                            Text.cancel
                                 .padding(.horizontal)
                         }
                         .buttonStyle(.bordered)

--- a/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/BookmarksHeader.swift
@@ -48,11 +48,8 @@ struct BookmarksHeader: View {
                 alignment: .leading
             )
             Spacer()
-            Button {
+            Button.done {
                 isPresented = false
-            } label: {
-                Text.done
-                    .fontWeight(.semibold)
             }
 #if !os(visionOS)
             .buttonStyle(.plain)

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -143,7 +143,7 @@ struct SiteAndFacilitySelector: View {
             .background(.quinary)
             .clipShape(.rect(cornerRadius: 10))
             if textFieldIsFocused {
-                Button(String.cancel) {
+                Button.cancel {
                     query.removeAll()
                     textFieldIsFocused = false
                 }

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -307,7 +307,7 @@ private struct RenameButton: View {
         .fontWeight(.semibold)
         .alert(enterName, isPresented: $alertIsShowing) {
             TextField(text: $proposedNewTitle, prompt: areaName) {}
-            Button(String.ok, action: submitNewTitle)
+            Button.ok(action: submitNewTitle)
                 .disabled(!proposedTitleIsValid)
                 .keyboardShortcut(.defaultAction)
             Button.cancel {}

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
@@ -26,11 +26,8 @@ struct MediaDetailView : View {
         VStack {
             HStack {
                 Spacer()
-                Button {
+                Button.done {
                     isShowingDetailView.wrappedValue = false
-                } label: {
-                    Text.done
-                        .fontWeight(.semibold)
                 }
                 .padding([.bottom], 4)
             }

--- a/Sources/ArcGISToolkit/Extensions/Swift/LocalizedStringResource.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/LocalizedStringResource.swift
@@ -19,8 +19,15 @@ extension LocalizedStringResource.BundleDescription {
     static let toolkit: Self = .atURL(Bundle.toolkitModule.bundleURL)
 }
 
-
 extension LocalizedStringResource {
+    static var cancel: Self {
+        .init(
+            "Cancel",
+            bundle: .toolkit,
+            comment: "A label for a button to cancel an operation."
+        )
+    }
+    
     static var downloaded: Self {
         .init(
             "Downloaded",
@@ -66,6 +73,15 @@ extension LocalizedStringResource {
             "No Internet Connection",
             bundle: .toolkit,
             comment: "An error message explaining that there is no internet connection."
+        )
+    }
+    
+    /// A localized string for the word "OK".
+    static var ok: Self {
+        .init(
+            "OK",
+            bundle: .toolkit,
+            comment: "A label for button to proceed with an operation."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/Swift/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/String.swift
@@ -15,15 +15,6 @@
 import Foundation
 
 extension String {
-    /// A localized string for the word "Cancel".
-    static var cancel: Self {
-        .init(
-            localized: "Cancel",
-            bundle: .toolkitModule,
-            comment: "A label for a button to cancel an operation."
-        )
-    }
-    
     /// A localized string for the word "Clear".
     static var clear: Self {
         .init(
@@ -66,15 +57,6 @@ extension String {
             localized: "No Value",
             bundle: .toolkitModule,
             comment: "A string indicating that no value has been set for a form field."
-        )
-    }
-    
-    /// A localized string for the word "OK".
-    static var ok: Self {
-        .init(
-            localized: "OK",
-            bundle: .toolkitModule,
-            comment: "A label for button to proceed with an operation."
         )
     }
     

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
@@ -36,6 +36,7 @@ extension Button<Text> {
     static nonisolated func done(action: @escaping @MainActor () -> Void) -> Self {
         Button(action: action) {
             Text.done
+                .fontWeight(.semibold)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
@@ -21,11 +21,7 @@ extension Button<Text> {
     /// - Returns: A button.
     static nonisolated func cancel(action: @escaping @MainActor () -> Void) -> Self {
         Button(role: .cancel, action: action) {
-            Text(
-                "Cancel",
-                bundle: .toolkitModule,
-                comment: "Title for a button that cancels an action."
-            )
+            Text(LocalizedStringResource.cancel)
         }
     }
     
@@ -37,6 +33,16 @@ extension Button<Text> {
         Button(action: action) {
             Text.done
                 .fontWeight(.semibold)
+        }
+    }
+    
+    /// Returns a button with the title "ok" and the given action.
+    /// - Parameter action: The action to perform when the user triggers the
+    /// button.
+    /// - Returns: A button.
+    static nonisolated func ok(action: @escaping @MainActor () -> Void) -> Self {
+        Button(action: action) {
+            Text(LocalizedStringResource.ok)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
@@ -15,6 +15,11 @@
 import SwiftUI
 
 extension Text {
+    /// Localized text for the word "Cancel".
+    static var cancel: Self {
+        .init(LocalizedStringResource.cancel)
+    }
+    
     /// Localized text for the word "Done".
     static var done: Self {
         .init(

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -75,8 +75,7 @@ for the AR experience. */
 /* A title for an alert that camera access is disabled. */
 "Camera access is disabled" = "Camera access is disabled";
 
-/* A label for a button to cancel an operation.
-Title for a button that cancels an action. */
+/* A label for a button to cancel an operation. */
 "Cancel" = "Cancel";
 
 /* A label for a button to cancel the starting point selection operation. */

--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -291,7 +291,7 @@ extension CredentialInputSheetView {
     /// A configuration for an alert action.
     struct Action {
         /// The title of the action.
-        let title: String
+        let title: LocalizedStringResource
         
         /// The block to execute when the action is triggered.
         /// The parameters are the username and the password.


### PR DESCRIPTION
Related to `swift/6790`

- Change some localized strings from type String to type LocalizedStringResource
- Use localized Button.cancel, Button.cancel, Button.ok where applicable
- Remove redundant localized string for "Cancel"