### PR TITLE
`FeatureFormView` - Rename `FormViewModel` to `InternalFeatureFormViewModel`

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -29,7 +29,7 @@ struct AttachmentsFeatureElementView: View {
     ///
     /// - Note: This property is only present when
     /// `featureElement` is an `AttachmentsFormElement`.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
@@ -166,7 +166,7 @@ struct AttachmentsFeatureElementView: View {
         newModel.load()
         models.insert(newModel, at: 0)
         withAnimation { attachmentModelsState = .initialized(models) }
-        formViewModel.evaluateExpressions()
+        internalFeatureFormViewModel.evaluateExpressions()
         scrollToNewAttachmentAction?()
     }
     
@@ -178,7 +178,7 @@ struct AttachmentsFeatureElementView: View {
         if let attachment = attachmentModel.attachment as? FormAttachment {
             attachment.name = newAttachmentName
             withAnimation { attachmentModel.sync() }
-            formViewModel.evaluateExpressions()
+            internalFeatureFormViewModel.evaluateExpressions()
         }
     }
     
@@ -192,7 +192,7 @@ struct AttachmentsFeatureElementView: View {
             guard case .initialized(var models) = attachmentModelsState else { return }
             models.removeAll { $0 === attachmentModel }
             withAnimation { attachmentModelsState = .initialized(models) }
-            formViewModel.evaluateExpressions()
+            internalFeatureFormViewModel.evaluateExpressions()
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.Model.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.Model.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import ArcGIS
-import SwiftUI
+import Observation
 
 @Observable
-class FormViewModel {
+class InternalFeatureFormViewModel {
     /// The current focused element, if one exists.
     var focusedElement: FormElement? {
         didSet {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.swift
@@ -25,23 +25,23 @@ struct InternalFeatureFormView: View {
     @Environment(NavigationLayerModel.self) private var navigationLayerModel
     
     /// The view model for the form.
-    @State private var model: FormViewModel
+    @State private var internalFeatureFormViewModel: InternalFeatureFormViewModel
     
     /// Initializes a form view.
     /// - Parameters:
     ///   - featureForm: The feature form defining the editing experience.
     init(featureForm: FeatureForm) {
-        model = FormViewModel(featureForm: featureForm)
+        internalFeatureFormViewModel = InternalFeatureFormViewModel(featureForm: featureForm)
     }
     
     var body: some View {
         ScrollViewReader { scrollViewProxy in
             ScrollView {
                 VStack(alignment: .leading) {
-                    ForEach(model.visibleElements, id: \.self) { element in
+                    ForEach(internalFeatureFormViewModel.visibleElements, id: \.self) { element in
                         makeElement(element)
                     }
-                    if let attachmentsElement = model.featureForm.defaultAttachmentsElement {
+                    if let attachmentsElement = internalFeatureFormViewModel.featureForm.defaultAttachmentsElement {
                         // The Toolkit currently only supports AttachmentsFormElements via the
                         // default attachments element. Once AttachmentsFormElements can be authored
                         // this can call makeElement(_:) instead and makeElement(_:) should have a
@@ -50,26 +50,26 @@ struct InternalFeatureFormView: View {
                     }
                 }
             }
-            .onChange(of: model.focusedElement) {
-                if let focusedElement = model.focusedElement {
+            .onChange(of: internalFeatureFormViewModel.focusedElement) {
+                if let focusedElement = internalFeatureFormViewModel.focusedElement {
                     withAnimation { scrollViewProxy.scrollTo(focusedElement, anchor: .top) }
                 }
             }
-            .onTitleChange(of: model.featureForm) { newTitle in
-                model.title = newTitle
+            .onTitleChange(of: internalFeatureFormViewModel.featureForm) { newTitle in
+                internalFeatureFormViewModel.title = newTitle
             }
-            .navigationLayerTitle(model.title)
+            .navigationLayerTitle(internalFeatureFormViewModel.title)
         }
 #if os(iOS)
         .scrollDismissesKeyboard(.immediately)
 #endif
-        .environment(model)
+        .environment(internalFeatureFormViewModel)
         .padding([.horizontal])
         .task {
-            await model.initialEvaluation()
+            await internalFeatureFormViewModel.initialEvaluation()
         }
         .onAppear {
-            formChangedAction?(model.featureForm)
+            formChangedAction?(internalFeatureFormViewModel.featureForm)
         }
     }
 }
@@ -135,7 +135,7 @@ extension InternalFeatureFormView {
         .padding(.top, formElementPadding)
         
         UtilityAssociationsFormElementView(element: element)
-            .environment(model)
+            .environment(internalFeatureFormViewModel)
         
         if !element.description.isEmpty {
             Text(element.description)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// This is the preferable input type for long lists of coded value domains.
 struct ComboBoxInput: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// The phrase to use when filtering by coded value name.
     @State private var filterPhrase = ""
@@ -89,8 +89,8 @@ struct ComboBoxInput: View {
                 // and we're not required. (i.e., Don't show clear if
                 // the field is required.)
                 XButton(.clear) {
-                    formViewModel.focusedElement = element
-                    defer { formViewModel.focusedElement = nil }
+                    internalFeatureFormViewModel.focusedElement = element
+                    defer { internalFeatureFormViewModel.focusedElement = nil }
                     updateValue(nil)
                 }
                 .accessibilityIdentifier("\(element.label) Clear Button")
@@ -117,7 +117,7 @@ struct ComboBoxInput: View {
             }
         }
         .onTapGesture {
-            formViewModel.focusedElement = element
+            internalFeatureFormViewModel.focusedElement = element
             isPresented = true
         }
         .sheet(isPresented: $isPresented) {
@@ -235,7 +235,7 @@ extension ComboBoxInput {
     
     private func updateValue(_ value: (any Sendable)?) {
         element.updateValue(value)
-        formViewModel.evaluateExpressions()
+        internalFeatureFormViewModel.evaluateExpressions()
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/DateTimeInput.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// A view for date/time input.
 struct DateTimeInput: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// The current date selection.
     @State private var date: Date?
@@ -52,13 +52,13 @@ struct DateTimeInput: View {
     
     var body: some View {
         dateEditor
-            .onChange(of: formViewModel.focusedElement) {
-                isEditing = formViewModel.focusedElement == element
+            .onChange(of: internalFeatureFormViewModel.focusedElement) {
+                isEditing = internalFeatureFormViewModel.focusedElement == element
             }
             .onChange(of: date) {
                 element.updateValue(date)
                 formattedValue = element.formattedValue
-                formViewModel.evaluateExpressions()
+                internalFeatureFormViewModel.evaluateExpressions()
             }
             .onValueChange(of: element) { newValue, newFormattedValue in
                 if newFormattedValue.isEmpty {
@@ -106,8 +106,8 @@ struct DateTimeInput: View {
                         .foregroundStyle(.secondary)
                 } else if !isRequired {
                     XButton(.clear) {
-                        formViewModel.focusedElement = element
-                        defer { formViewModel.focusedElement = nil }
+                        internalFeatureFormViewModel.focusedElement = element
+                        defer { internalFeatureFormViewModel.focusedElement = nil }
                         date = nil
                     }
                     .accessibilityIdentifier("\(element.label) Clear Button")
@@ -128,7 +128,7 @@ struct DateTimeInput: View {
                     }
                 }
                 isEditing.toggle()
-                formViewModel.focusedElement = isEditing ? element : nil
+                internalFeatureFormViewModel.focusedElement = isEditing ? element : nil
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/Other/InputFooter.swift
@@ -23,7 +23,7 @@ struct InputFooter: View {
     @Environment(\._validationErrorVisibility) private var validationErrorVisibility
     
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// An ID regenerated each time the element's value changes.
     ///
@@ -40,7 +40,7 @@ struct InputFooter: View {
                     errorMessage
                 } else if !element.description.isEmpty {
                     Text(element.description)
-                } else if formViewModel.focusedElement == element {
+                } else if internalFeatureFormViewModel.focusedElement == element {
                     if element.fieldType == .text, let lengthRange {
                         if lengthRange.lowerBound == lengthRange.upperBound {
                             makeExactLengthMessage(lengthRange)
@@ -199,7 +199,7 @@ extension InputFooter {
     
     /// A Boolean value which indicates whether or not the character indicator is showing in the footer.
     var isShowingCharacterIndicator: Bool {
-        formViewModel.focusedElement == element
+        internalFeatureFormViewModel.focusedElement == element
         && !(element.fieldType?.isNumeric ?? false)
         && (element.input is TextAreaFormInput || element.input is TextBoxFormInput)
         && (element.description.isEmpty || primaryError != nil)
@@ -209,7 +209,7 @@ extension InputFooter {
     var isShowingError: Bool {
         element.isEditable
         && primaryError != nil
-        && (formViewModel.previouslyFocusedElements.contains(element) || validationErrorVisibility == .visible)
+        && (internalFeatureFormViewModel.previouslyFocusedElements.contains(element) || validationErrorVisibility == .visible)
     }
     
     /// The allowable number of characters in the input.
@@ -246,7 +246,7 @@ extension InputFooter {
             default:
                 return false
             }
-        }), formViewModel.focusedElement != element {
+        }), internalFeatureFormViewModel.focusedElement != element {
             return requiredError
         } else {
             return elementErrors?.first(where: {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// This is the preferable input type for short lists of coded value domains.
 struct RadioButtonsInput: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// A Boolean value indicating whether a ``ComboBoxInput`` should be used instead.
     /// This will be `true` if the current value doesn't exist as an option in the domain
@@ -97,7 +97,7 @@ struct RadioButtonsInput: View {
             }
             .onChange(of: selectedValue) {
                 element.updateValue(selectedValue?.code)
-                formViewModel.evaluateExpressions()
+                internalFeatureFormViewModel.evaluateExpressions()
             }
             .onValueChange(of: element) { newValue, newFormattedValue in
                 value = newValue
@@ -132,7 +132,7 @@ extension RadioButtonsInput {
         _ action: @escaping () -> Void
     ) -> some View {
         Button {
-            formViewModel.focusedElement = element
+            internalFeatureFormViewModel.focusedElement = element
             action()
         } label: {
             HStack {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/SwitchInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/SwitchInput.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// The switch represents two mutually exclusive values, such as: yes/no, on/off, true/false.
 struct SwitchInput: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// A Boolean value indicating whether the initial element value was received.
     @State private var didReceiveInitialValue = false
@@ -82,7 +82,7 @@ struct SwitchInput: View {
             // defined for `isOn`.
             .onChange(of: isOn) {
                 element.updateValue(isOn ? input.onValue.code : input.offValue.code)
-                formViewModel.evaluateExpressions()
+                internalFeatureFormViewModel.evaluateExpressions()
             }
             // onValueChange(of:action:) is a good signal for user interaction
             // because it will reliably run when the view first loads and each
@@ -91,7 +91,7 @@ struct SwitchInput: View {
             .onValueChange(of: element) { newValue, newFormattedValue in
                 isOn = newFormattedValue == input.onValue.name
                 if didReceiveInitialValue {
-                    formViewModel.focusedElement = element
+                    internalFeatureFormViewModel.focusedElement = element
                 } else {
                     didReceiveInitialValue = true
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// A view for text input.
 struct TextInput: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// A Boolean value indicating whether or not the field is focused.
     @FocusState private var isFocused: Bool
@@ -61,7 +61,7 @@ struct TextInput: View {
         textWriter
             .onChange(of: text) {
                 element.convertAndUpdateValue(text)
-                formViewModel.evaluateExpressions()
+                internalFeatureFormViewModel.evaluateExpressions()
             }
             .onTapGesture {
                 if element.isMultiline {
@@ -91,10 +91,10 @@ private extension TextInput {
                         .lineLimit(5)
                         .truncationMode(.tail)
                         .sheet(isPresented: $fullScreenTextInputIsPresented) {
-                            FullScreenTextInput(text: $text, element: element, model: formViewModel)
+                            FullScreenTextInput(text: $text, element: element, internalFeatureFormViewModel: internalFeatureFormViewModel)
                                 .padding()
 #if targetEnvironment(macCatalyst)
-                                .environment(formViewModel)
+                                .environment(internalFeatureFormViewModel)
 #endif
                         }
                         .frame(minHeight: 100, alignment: .top)
@@ -114,11 +114,11 @@ private extension TextInput {
                     .hoverEffectDisabled()
 #endif
                     .onChange(of: isFocused) {
-                        formViewModel.focusedElement = isFocused ? element : nil
+                        internalFeatureFormViewModel.focusedElement = isFocused ? element : nil
                     }
-                    .onChange(of: formViewModel.focusedElement) {
+                    .onChange(of: internalFeatureFormViewModel.focusedElement) {
                         // Another form input took focus.
-                        if formViewModel.focusedElement != element {
+                        if internalFeatureFormViewModel.focusedElement != element {
                             isFocused  = false
                         }
                     }
@@ -144,8 +144,8 @@ private extension TextInput {
                     if !isFocused {
                         // If the user wasn't already editing the field provide
                         // instantaneous focus to enable validation.
-                        formViewModel.focusedElement = element
-                        formViewModel.focusedElement = nil
+                        internalFeatureFormViewModel.focusedElement = element
+                        internalFeatureFormViewModel.focusedElement = nil
                     }
                     text.removeAll()
                 }
@@ -154,7 +154,7 @@ private extension TextInput {
 #if !os(visionOS)
             if isBarcodeScanner {
                 Button {
-                    formViewModel.focusedElement = element
+                    internalFeatureFormViewModel.focusedElement = element
                     scannerIsPresented = true
                 } label: {
                     Image(systemName: "barcode.viewfinder")
@@ -223,7 +223,7 @@ private extension TextInput {
         let element: FieldFormElement
         
         /// The view model for the form.
-        let model: FormViewModel
+        let internalFeatureFormViewModel: InternalFeatureFormViewModel
         
         var body: some View {
             HStack {
@@ -238,7 +238,7 @@ private extension TextInput {
             }
             RepresentedUITextView(initialText: text) { text in
                 element.convertAndUpdateValue(text)
-                model.evaluateExpressions()
+                internalFeatureFormViewModel.evaluateExpressions()
             } onTextViewDidEndEditing: { text in
                 self.text = text
             }
@@ -247,7 +247,7 @@ private extension TextInput {
                 isFocused = true
             }
             .onChange(of: isFocused) {
-                model.focusedElement = isFocused ? element : nil
+                internalFeatureFormViewModel.focusedElement = isFocused ? element : nil
             }
             Spacer()
             InputFooter(element: element)

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/UtilityAssociationsFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/UtilityAssociationsFormElementView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// A view for a utility associations form element.
 struct UtilityAssociationsFormElementView: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// The set of utility associations filter results for the element.
     @State private var associationsFilterResults = [UtilityAssociationsFilterResult]()
@@ -30,7 +30,7 @@ struct UtilityAssociationsFormElementView: View {
         FeatureFormGroupedContentView(content: associationsFilterResults.compactMap {
             if $0.resultCount > 0 {
                 UtilityAssociationsFilterResultListRowView(utilityAssociationsFilterResult: $0)
-                    .environment(formViewModel)
+                    .environment(internalFeatureFormViewModel)
             } else {
                 nil
             }
@@ -50,7 +50,7 @@ private struct UtilityAssociationGroupResultView: View {
     @Environment(\.setAlertContinuation) var setAlertContinuation
     
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// The model for the navigation layer.
     @Environment(NavigationLayerModel.self) private var navigationLayerModel
@@ -69,7 +69,7 @@ private struct UtilityAssociationGroupResultView: View {
                             )
                         }
                     }
-                    if formViewModel.featureForm.hasEdits {
+                    if internalFeatureFormViewModel.featureForm.hasEdits {
                         setAlertContinuation?(true, navigationAction)
                     } else {
                         navigationAction()
@@ -82,7 +82,7 @@ private struct UtilityAssociationGroupResultView: View {
             // This view is considered the tail end of a navigable FeatureForm.
             // When a user is backing out of a navigation path, this view
             // appearing is considered a change to the presented FeatureForm.
-            formChangedAction?(formViewModel.featureForm)
+            formChangedAction?(internalFeatureFormViewModel.featureForm)
         }
     }
 }
@@ -90,7 +90,7 @@ private struct UtilityAssociationGroupResultView: View {
 /// A view referencing a utility associations filter result.
 private struct UtilityAssociationsFilterResultListRowView: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// The model for the navigation layer.
     @Environment(NavigationLayerModel.self) private var navigationLayerModel
@@ -103,8 +103,8 @@ private struct UtilityAssociationsFilterResultListRowView: View {
         Button {
             navigationLayerModel.push {
                 UtilityAssociationsFilterResultView(utilityAssociationsFilterResult: utilityAssociationsFilterResult)
-                    .navigationLayerTitle(listRowTitle, subtitle: formViewModel.title)
-                    .environment(formViewModel)
+                    .navigationLayerTitle(listRowTitle, subtitle: internalFeatureFormViewModel.title)
+                    .environment(internalFeatureFormViewModel)
             }
         } label: {
             HStack {
@@ -137,7 +137,7 @@ private struct UtilityAssociationsFilterResultListRowView: View {
 /// A view for a utility associations filter result.
 private struct UtilityAssociationsFilterResultView: View {
     /// The view model for the form.
-    @Environment(FormViewModel.self) private var formViewModel: FormViewModel
+    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
     
     /// The model for the navigation layer.
     @Environment(NavigationLayerModel.self) private var navigationLayerModel
@@ -154,7 +154,7 @@ private struct UtilityAssociationsFilterResultView: View {
                             utilityAssociationGroupResult.name,
                             subtitle: utilityAssociationsFilterResult.filter.title
                         )
-                        .environment(formViewModel)
+                        .environment(internalFeatureFormViewModel)
                 }
             } label: {
                 HStack {


### PR DESCRIPTION
Related Apollo 1222

In #1161, a new model (`FeatureFormViewModel`) will be added for the top-level public `FeatureFormView` so that form elements deep in the view hierarchy can trigger an overlay presentation over the entire feature form view. I propose this rename to clearly delineate between the two models.