### PR TITLE
Add new usage specific initializers for AttachmentsFeatureElementView

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -29,7 +29,7 @@ struct AttachmentsFeatureElementView: View {
     ///
     /// - Note: This property is only present when
     /// `featureElement` is an `AttachmentsFormElement`.
-    @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
+    private var internalFeatureFormViewModel: InternalFeatureFormViewModel?
     
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
@@ -57,10 +57,19 @@ struct AttachmentsFeatureElementView: View {
     /// The current state of the attachment models.
     @State private var attachmentModelsState: AttachmentModelsState = .notInitialized
     
-    /// Creates a new `AttachmentsFeatureElementView`.
-    /// - Parameter featureElement: The `AttachmentsFeatureElement`.
-    init(featureElement: AttachmentsFeatureElement) {
-        self.featureElement = featureElement
+    /// Creates a new `AttachmentsFeatureElementView` for a Feature Form.
+    /// - Parameter formElement: The `AttachmentsFeatureElement`.
+    /// - Parameter formViewModel: The model for the feature form containing the element.
+    init(formElement: AttachmentsFormElement, formViewModel: InternalFeatureFormViewModel) {
+        self.featureElement = formElement
+        self.internalFeatureFormViewModel = formViewModel
+    }
+    
+    /// Creates a new `AttachmentsFeatureElementView` for a Popup.
+    /// - Parameter popupElement: The `AttachmentsFeatureElement`.
+    init(popupElement: AttachmentsPopupElement) {
+        self.featureElement = popupElement
+        self.internalFeatureFormViewModel = nil
     }
     
     /// A Boolean value denoting whether the Disclosure Group is expanded.
@@ -166,7 +175,7 @@ struct AttachmentsFeatureElementView: View {
         newModel.load()
         models.insert(newModel, at: 0)
         withAnimation { attachmentModelsState = .initialized(models) }
-        internalFeatureFormViewModel.evaluateExpressions()
+        internalFeatureFormViewModel?.evaluateExpressions()
         scrollToNewAttachmentAction?()
     }
     
@@ -178,7 +187,7 @@ struct AttachmentsFeatureElementView: View {
         if let attachment = attachmentModel.attachment as? FormAttachment {
             attachment.name = newAttachmentName
             withAnimation { attachmentModel.sync() }
-            internalFeatureFormViewModel.evaluateExpressions()
+            internalFeatureFormViewModel?.evaluateExpressions()
         }
     }
     
@@ -192,7 +201,7 @@ struct AttachmentsFeatureElementView: View {
             guard case .initialized(var models) = attachmentModelsState else { return }
             models.removeAll { $0 === attachmentModel }
             withAnimation { attachmentModelsState = .initialized(models) }
-            internalFeatureFormViewModel.evaluateExpressions()
+            internalFeatureFormViewModel?.evaluateExpressions()
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.swift
@@ -46,7 +46,10 @@ struct InternalFeatureFormView: View {
                         // default attachments element. Once AttachmentsFormElements can be authored
                         // this can call makeElement(_:) instead and makeElement(_:) should have a
                         // case added for AttachmentsFormElement.
-                        AttachmentsFeatureElementView(featureElement: attachmentsElement)
+                        AttachmentsFeatureElementView(
+                            formElement: attachmentsElement,
+                            formViewModel: internalFeatureFormViewModel
+                        )
                     }
                 }
             }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -175,7 +175,7 @@ extension PopupView {
                 Group {
                     switch popupElement {
                     case let popupElement as AttachmentsPopupElement:
-                        AttachmentsFeatureElementView(featureElement: popupElement)
+                        AttachmentsFeatureElementView(popupElement: popupElement)
                     case let popupElement as FieldsPopupElement:
                         FieldsPopupElementView(popupElement: popupElement)
                     case let popupElement as MediaPopupElement:


### PR DESCRIPTION
This resolves a crash introduced in #1160 by ensuring that an `InternalFeatureFormViewModel` is present when needed.

Unlike with an `ObservableObject`, if an `@Observable` object is not in the environment, such as is the case when using `AttachmentsFeatureElementView` in a popup, a fatal error is encountered:

> SwiftUICore/Environment+Objects.swift:34: Fatal error: No Observable object of type InternalFeatureFormViewModel found. A View.environmentObject(_:) for InternalFeatureFormViewModel may be missing as an ancestor of this view.


Note that `FormViewModel` was renamed to `InternalFeatureFormViewModel` after #1160 in #1162.

Thank you to @CalebRas for catching this new crash.