### PR TITLE
Authenticator: Adds challenge type and Identity-Aware Proxy (IAP) support

### DIFF
--- a/AuthenticationExample/AuthenticationExample/AuthenticationApp.swift
+++ b/AuthenticationExample/AuthenticationExample/AuthenticationApp.swift
@@ -18,10 +18,7 @@ import SwiftUI
 
 @main
 struct AuthenticationApp: App {
-    @StateObject private var authenticator = Authenticator(
-        // If you want to use OAuth, uncomment this code:
-//      oAuthUserConfigurations: [.arcgisDotCom]
-    )
+    @StateObject private var authenticator = Authenticator()
     
     @State private var isSettingUp = true
     
@@ -43,6 +40,10 @@ struct AuthenticationApp: App {
             .authenticator(authenticator)
             .task {
                 isSettingUp = true
+                // If you want to use OAuth, uncomment this code:
+//                authenticator.oAuthUserConfigurations.append(.oAuthUserConfiguration)
+                // If you want to use Identity-Aware Proxy (IAP), uncomment this code:
+//                try? await authenticator.iapConfigurations.append(.iapConfiguration)
                 ArcGISEnvironment.authenticationManager.handleChallenges(using: authenticator)
                 // Here we setup credential stores to be persistent, which means that it will
                 // synchronize with the keychain for storing credentials.
@@ -58,7 +59,7 @@ struct AuthenticationApp: App {
 
 private extension OAuthUserConfiguration {
     // If you want to use OAuth, uncomment this code:
-//    static let arcgisDotCom = OAuthUserConfiguration(
+//    static let oAuthUserConfiguration = OAuthUserConfiguration(
 //        portalURL: .portal,
 //        clientID: "<#Your client ID goes here#>",
 //        // Note: You must have the same redirect URL used here
@@ -66,6 +67,17 @@ private extension OAuthUserConfiguration {
 //        // The scheme of the redirect URL is also specified in the Info.plist file.
 //        redirectURL: URL(string: "authexample://auth")!
 //    )
+}
+
+private extension IAPConfiguration {
+    // If you want to use Identity-Aware Proxy (IAP), uncomment this code:
+//    static var iapConfiguration: IAPConfiguration {
+//        get async throws {
+//            try await .configuration(
+//                from: URL(filePath: "/path/to/IAP configuration/file.json")!
+//            )
+//        }
+//    }
 }
 
 extension URL {

--- a/AuthenticationExample/AuthenticationExample/ProfileView.swift
+++ b/AuthenticationExample/AuthenticationExample/ProfileView.swift
@@ -73,6 +73,7 @@ struct ProfileView: View {
         isSigningOut = true
         Task {
             await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
+            await ArcGISEnvironment.authenticationManager.invalidateIAPCredentials()
             await ArcGISEnvironment.authenticationManager.clearCredentialStores()
             isSigningOut = false
             signOutAction()

--- a/Sources/ArcGISToolkit/Components/Authentication/AuthenticationManager.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/AuthenticationManager.swift
@@ -92,6 +92,7 @@ public extension AuthenticationManager {
     /// Initiates a logout request, invalidating the user's identity within the
     /// web session and removing all associated tokens for all IAP credentials.
     /// - Returns: `true` if all IAP credentials are invalidated, otherwise `false`.
+    /// - Since: 200.8
     @discardableResult
     func invalidateIAPCredentials() async -> Bool {
         let iapCredentials = arcGISCredentialStore.credentials.compactMap {

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -49,6 +49,8 @@ import CryptoTokenKit
 /// To see the `Authenticator` in action, check out the [Authentication Examples](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/AuthenticationExample)
 /// and refer to [AuthenticationApp.swift](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/main/AuthenticationExample/AuthenticationExample/AuthenticationApp.swift).
 /// To learn more about using the `Authenticator`, see the <doc:AuthenticatorTutorial>.
+///
+/// - Since: 200.1
 @MainActor
 public final class Authenticator: ObservableObject {
     /// A value indicating whether we should prompt the user when encountering an untrusted host.

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import Combine
 import CryptoTokenKit
 
 /// The `Authenticator` is a configurable object that handles authentication challenges. It will
@@ -54,17 +53,36 @@ import CryptoTokenKit
 public final class Authenticator: ObservableObject {
     /// A value indicating whether we should prompt the user when encountering an untrusted host.
     let promptForUntrustedHosts: Bool
-    /// The OAuth configurations that this authenticator can work with.
-    public var oAuthUserConfigurations: [OAuthUserConfiguration]
+    /// The OAuth user configurations that this authenticator can work with.
+    /// - Since: 200.8
+    public var oAuthUserConfigurations: [OAuthUserConfiguration] = []
     /// The IAP configurations that this authenticator can work with.
-    public var iapConfigurations: [IAPConfiguration]
+    /// - Since: 200.8
+    public var iapConfigurations: [IAPConfiguration] = []
     
     /// Creates an authenticator.
     /// - Parameters:
     ///   - promptForUntrustedHosts: A value indicating whether we should prompt the user when
     ///   encountering an untrusted host.
     ///   - oAuthUserConfigurations: The OAuth configurations that this authenticator can work with.
-    ///   - iapConfiguration: The IAP configurations that this authenticator can work with.
+    /// - Attention: Deprecated at 200.8.
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Use 'init(promptForUntrustedHosts:oAuthUserConfigurations:iapConfigurations:)' instead")
+    public init(
+        promptForUntrustedHosts: Bool = false,
+        oAuthUserConfigurations: [OAuthUserConfiguration] = []
+    ) {
+        self.promptForUntrustedHosts = promptForUntrustedHosts
+        self.oAuthUserConfigurations = oAuthUserConfigurations
+    }
+    
+    /// Creates an authenticator.
+    /// - Parameters:
+    ///   - promptForUntrustedHosts: A value indicating whether we should prompt the user when
+    ///   encountering an untrusted host.
+    ///   - oAuthUserConfigurations: The OAuth user configurations that this authenticator can work with.
+    ///   - iapConfigurations: The IAP configurations that this authenticator can work with.
+    /// - Since: 200.8
     public init(
         promptForUntrustedHosts: Bool = false,
         oAuthUserConfigurations: [OAuthUserConfiguration] = [],

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/Authenticator/AuthenticatorStep3.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/Authenticator/AuthenticatorStep3.swift
@@ -1,6 +1,6 @@
-import SwiftUI
-import ArcGISToolkit
 import ArcGIS
+import ArcGISToolkit
+import SwiftUI
 
 @main
 struct AuthenticationApp: App {
@@ -11,6 +11,18 @@ struct AuthenticationApp: App {
             HomeView()
                 .authenticator(authenticator)
                 .task {
+                    // If the app requires the use of OAuth or Identity-Aware Proxy (IAP),
+                    // then provide the necessary configurations.
+                    authenticator.oAuthUserConfigurations.append(
+                        OAuthUserConfiguration(
+                            portalURL: URL(string: "Your client portal URL goes here")!,
+                            clientID: "Your client ID goes here",
+                            redirectURL: URL(string: "Your redirect URL goes here")!
+                        )
+                    )
+                    try? await authenticator.iapConfigurations.append(
+                        IAPConfiguration.configuration(from: URL(filePath: "Your IAP configuration JSON file path goes here")!)
+                    )
                     ArcGISEnvironment.authenticationManager.handleChallenges(using: authenticator)
                     try? await ArcGISEnvironment.authenticationManager.setupPersistentCredentialStorage(access: .whenUnlockedThisDeviceOnly)
                 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/Authenticator/AuthenticatorStep4.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/Authenticator/AuthenticatorStep4.swift
@@ -1,6 +1,7 @@
 func signOut() {
     Task {
         await ArcGISEnvironment.authenticationManager.revokeOAuthTokens()
+        await ArcGISEnvironment.authenticationManager.invalidateIAPCredentials()
         await ArcGISEnvironment.authenticationManager.clearCredentialStores()
     }
 }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/AuthenticatorTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/AuthenticatorTutorial.tutorial
@@ -13,8 +13,6 @@
         @Steps {
             @Step {
                 Declare and initialize an `Authenticator` member in your app.
-                
-                For OAuth implementations use `Authenticator(oAuthUserConfigurations:)`.
                 @Code(name: "ExampleApp.swift", file: AuthenticatorStep1.swift)
             }
             
@@ -24,6 +22,7 @@
             }
             
             @Step {
+                Configure the `Authenticator` with OAuth and IAP configurations if required. 
                 Set the `Authenticator` to handle challenges.
                 Set up credential persistence.
                 @Code(name: "ExampleApp.swift", file: AuthenticatorStep3.swift)

--- a/Tests/ArcGISToolkitTests/AuthenticatorTests.swift
+++ b/Tests/ArcGISToolkitTests/AuthenticatorTests.swift
@@ -20,13 +20,33 @@ import Combine
 final class AuthenticatorTests: XCTestCase {
     @MainActor
     func testInit() {
-        let config = OAuthUserConfiguration(
+        let oAuthUserConfiguration = OAuthUserConfiguration(
             portalURL: URL(string:"www.arcgis.com")!,
             clientID: "client id",
-            redirectURL: URL(string:"myapp://oauth")!
+            redirectURL: URL(string:"myapp://auth")!
         )
-        let authenticator = Authenticator(promptForUntrustedHosts: true, oAuthUserConfigurations: [config])
+        let iapConfiguration = try! IAPConfiguration.configuration(
+            authorizeURL: URL(string: "https://login.microsoftonline.com/tenantID/oauth2/v2.0/authorize")!,
+            tokenURL: URL(string: "https://login.microsoftonline.com/tenantID/oauth2/v2.0/token")!,
+            logoutURL: URL(string: "https://login.microsoftonline.com/tenantID/oauth2/v2.0/logout")!,
+            clientID: "clientID",
+            redirectURL: URL(string: "myapp://auth")!,
+            scopes: [
+                "clientID/.default",
+                "offline_access",
+                "openid",
+                "profile"
+            ],
+            hostsBehindProxy: ["*.domain.com"],
+            authorizationPromptType: .login
+        )
+        let authenticator = Authenticator(
+            promptForUntrustedHosts: true,
+            oAuthUserConfigurations: [oAuthUserConfiguration],
+            iapConfigurations: [iapConfiguration]
+        )
         XCTAssertTrue(authenticator.promptForUntrustedHosts)
-        XCTAssertEqual(authenticator.oAuthUserConfigurations, [config])
+        XCTAssertEqual(authenticator.oAuthUserConfigurations, [oAuthUserConfiguration])
+        XCTAssertEqual(authenticator.iapConfigurations, [iapConfiguration])
     }
 }


### PR DESCRIPTION
###  Issues

- Serenity 2056
- Closes https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/988

###  Testing

- Test `ArcGIS.com` portal with and without OAuth user configuration
- Test portal behind IAP using the OAuth and IAP configurations
- Please reach out to me to get the configurations to test changes in this PR

### Changes in this PR:

- Adds support for `ArcGISAuthenticationChallenge.kind`
- Adds support for `Identity-Aware Proxy (IAP)`
   - Deprecates the existing Authenticator initializer
   - Adds a new Authenticator initializer that takes an array of `IAPConfigurations`, along with `promptForUntrustedHosts` and `OAuthUserConfigurations`
   - Adds a read-write `iapConfigurations` property
   - Adds a function to invalidate IAP credentials in the `AuthenticationManager` extension
- Updates documentation and the authenticator tutorial
- Changes the `oAuthUserConfigurations` property to read-write and makes it public
- Changes `AuthenticationExample` to take OAuth and IAP configurations in `task` instead of initializer because the IAP configuration creation is asynchronous

