### PR TITLE
Offline: Remove `Backported`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -302,41 +302,44 @@ public struct OfflineMapAreasView: View {
     }
     
     @ViewBuilder private var noInternetNoAreasView: some View {
-        Backported.ContentUnavailableView(
-            .noInternetConnectionErrorMessage,
-            systemImage: "wifi.exclamationmark",
-            description: noMapAreasErrorMessage
-        ) {
+        ContentUnavailableView {
+            Label(
+                LocalizedStringResource.noInternetConnectionErrorMessage.key,
+                systemImage: "wifi.exclamationmark"
+            )
+        } description: {
+            Text(noMapAreasErrorMessage)
+        } actions: {
             refreshPreplannedButton
         }
     }
     
     @ViewBuilder private var emptyPreplannedOfflineAreasView: some View {
-        Backported.ContentUnavailableView(
-            noMapAreas,
-            systemImage: "arrow.down.circle",
-            description: noOfflineMapAreasMessage
-        ) {
+        ContentUnavailableView {
+            Label(noMapAreas.key, systemImage: "arrow.down.circle")
+        } description: {
+            Text(noOfflineMapAreasMessage)
+        } actions: {
             refreshPreplannedButton
         }
     }
     
     @ViewBuilder private var preplannedErrorView: some View {
-        Backported.ContentUnavailableView(
-            errorFetchingAreas,
-            systemImage: "exclamationmark.triangle",
-            description: errorFetchingAreasMessage
-        ) {
+        ContentUnavailableView {
+            Label(errorFetchingAreas.key, systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(errorFetchingAreasMessage)
+        } actions: {
             refreshPreplannedButton
         }
     }
     
     @ViewBuilder private var emptyOnDemandOfflineAreasView: some View {
-        Backported.ContentUnavailableView(
-            noMapAreas,
-            systemImage: "arrow.down.circle",
-            description: emptyOnDemandMessage
-        ) {
+        ContentUnavailableView {
+            Label(noMapAreas.key, systemImage: "arrow.down.circle")
+        } description: {
+            Text(emptyOnDemandMessage)
+        } actions: {
             Button {
                 isAddingOnDemandArea = true
             } label: {
@@ -354,10 +357,10 @@ public struct OfflineMapAreasView: View {
     }
     
     @ViewBuilder private var offlineDisabledView: some View {
-        Backported.ContentUnavailableView(
-            offlineDisabled,
+        ContentUnavailableView(
+            offlineDisabled.key,
             systemImage: "exclamationmark.triangle",
-            description: offlineDisabledMessage
+            description:  Text(offlineDisabledMessage)
         )
     }
 }
@@ -380,51 +383,6 @@ public struct OfflineMapAreasView: View {
         }
     }
     return OfflineMapAreasViewPreview()
-}
-
-enum Backported {
-    /// A content unavailable view that can be used in older operating systems.
-    struct ContentUnavailableView<Actions: View>: View {
-        let title: LocalizedStringResource
-        let systemImage: String
-        let description: LocalizedStringResource?
-        let actions: () -> Actions
-        
-        init(
-            _ title: LocalizedStringResource,
-            systemImage name: String,
-            description: LocalizedStringResource? = nil,
-            @ViewBuilder actions: @escaping () -> Actions
-        ) {
-            self.title = title
-            self.systemImage = name
-            self.description = description
-            self.actions = actions
-        }
-        
-        init(
-            _ title: LocalizedStringResource,
-            systemImage name: String,
-            description: LocalizedStringResource? = nil
-        ) where Actions == EmptyView {
-            self.title = title
-            self.systemImage = name
-            self.description = description
-            self.actions = { EmptyView() }
-        }
-        
-        var body: some View {
-            SwiftUI.ContentUnavailableView {
-                Label(title.key, systemImage: systemImage)
-            } description: {
-                if let description {
-                    Text(description)
-                }
-            } actions: {
-                actions()
-            }
-        }
-    }
 }
 
 private extension OfflineMapAreasView {

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -360,7 +360,7 @@ public struct OfflineMapAreasView: View {
         ContentUnavailableView(
             offlineDisabled.key,
             systemImage: "exclamationmark.triangle",
-            description:  Text(offlineDisabledMessage)
+            description: Text(offlineDisabledMessage)
         )
     }
 }

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -239,16 +239,16 @@ struct OnDemandConfigurationView: View {
     @ViewBuilder private var failedToLoadView: some View {
         VStack {
             if hasNoInternetConnection {
-                Backported.ContentUnavailableView(
-                    .noInternetConnectionErrorMessage,
+                ContentUnavailableView(
+                    LocalizedStringResource.noInternetConnectionErrorMessage.key,
                     systemImage: "wifi.exclamationmark",
-                    description: cannotDownloadMessage
+                    description: Text(cannotDownloadMessage)
                 )
             } else {
-                Backported.ContentUnavailableView(
-                    failedToLoadMessage,
+                ContentUnavailableView(
+                    failedToLoadMessage.key,
                     systemImage: "exclamationmark.triangle",
-                    description: cannotDownloadMessage
+                    description: Text(cannotDownloadMessage)
                 )
             }
             Button {


### PR DESCRIPTION
Close #1155. Remove the `Backported` enum introduced in #1145 to support `ContentUnavailableView` on iOS 16.