### PR TITLE
Offline: Rename `delete map area` button

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
@@ -162,7 +162,7 @@ private class MockMetadata: OfflineMapAreaListItemInfo {
     var statusSystemImage: String { "exclamationmark.circle" }
     var jobProgress: Progress? { nil }
     var dismissMetadataViewOnDelete: Bool { false }
-    var mapMode: OfflineMapViewModel.Mode { .preplanned }
+    var removeDownloadString: LocalizedStringResource { .removeDownload }
     
     func removeDownloadedArea() {}
     func startDownload() {}

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
@@ -162,7 +162,7 @@ private class MockMetadata: OfflineMapAreaListItemInfo {
     var statusSystemImage: String { "exclamationmark.circle" }
     var jobProgress: Progress? { nil }
     var dismissMetadataViewOnDelete: Bool { false }
-    var removeDownloadString: LocalizedStringResource { .removeDownload }
+    var removeDownloadButtonText: LocalizedStringResource { .removeDownload }
     
     func removeDownloadedArea() {}
     func startDownload() {}

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
@@ -162,6 +162,7 @@ private class MockMetadata: OfflineMapAreaListItemInfo {
     var statusSystemImage: String { "exclamationmark.circle" }
     var jobProgress: Progress? { nil }
     var dismissMetadataViewOnDelete: Bool { false }
+    var mapMode: OfflineMapViewModel.Mode { .preplanned }
     
     func removeDownloadedArea() {}
     func startDownload() {}

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaMetadataView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaMetadataView.swift
@@ -54,20 +54,7 @@ struct OfflineMapAreaMetadataView<Metadata: OfflineMapAreaMetadata>: View {
                         }
                         model.removeDownloadedArea()
                     } label: {
-                        switch model.mapMode {
-                        case .preplanned, .undetermined:
-                            Text(
-                                "Remove Download",
-                                bundle: .toolkitModule,
-                                comment: "A label for a button to remove a map area download."
-                            )
-                        case .onDemand:
-                            Text(
-                                "Delete Download",
-                                bundle: .toolkitModule,
-                                comment: "A label for a button to delete a map area download."
-                            )
-                        }
+                        Text(model.removeDownloadString)
                     }
                 }
             }
@@ -156,8 +143,8 @@ protocol OfflineMapAreaMetadata: ObservableObject {
     var directorySize: Int { get }
     /// A Boolean value indicating whether the metadata view should be dismissed when the map area is deleted.
     var dismissMetadataViewOnDelete: Bool { get }
-    /// The map mode that determines if the map is preplanned or on-demand.
-    var mapMode: OfflineMapViewModel.Mode { get }
+    /// The localized string for the button to remove a download.
+    var removeDownloadString: LocalizedStringResource { get }
     /// Removes the downloaded area.
     func removeDownloadedArea()
     /// Starts downloading the area.
@@ -190,7 +177,7 @@ private class MockMetadata: OfflineMapAreaMetadata {
     var allowsDownload: Bool { true }
     var directorySize: Int { 1_000_000_000 }
     var dismissMetadataViewOnDelete: Bool { false }
-    var mapMode: OfflineMapViewModel.Mode { .preplanned }
+    var removeDownloadString: LocalizedStringResource { .removeDownload }
     
     func removeDownloadedArea() {}
     func startDownload() {}

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaMetadataView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaMetadataView.swift
@@ -54,11 +54,20 @@ struct OfflineMapAreaMetadataView<Metadata: OfflineMapAreaMetadata>: View {
                         }
                         model.removeDownloadedArea()
                     } label: {
-                        Text(
-                            "Delete Map Area",
-                            bundle: .toolkitModule,
-                            comment: "A label for a button to delete a map area."
-                        )
+                        switch model.mapMode {
+                        case .preplanned, .undetermined:
+                            Text(
+                                "Remove Download",
+                                bundle: .toolkitModule,
+                                comment: "A label for a button to remove a map area download."
+                            )
+                        case .onDemand:
+                            Text(
+                                "Delete Download",
+                                bundle: .toolkitModule,
+                                comment: "A label for a button to delete a map area download."
+                            )
+                        }
                     }
                 }
             }
@@ -147,7 +156,8 @@ protocol OfflineMapAreaMetadata: ObservableObject {
     var directorySize: Int { get }
     /// A Boolean value indicating whether the metadata view should be dismissed when the map area is deleted.
     var dismissMetadataViewOnDelete: Bool { get }
-    
+    /// The map mode that determines if the map is preplanned or on-demand.
+    var mapMode: OfflineMapViewModel.Mode { get }
     /// Removes the downloaded area.
     func removeDownloadedArea()
     /// Starts downloading the area.
@@ -180,6 +190,7 @@ private class MockMetadata: OfflineMapAreaMetadata {
     var allowsDownload: Bool { true }
     var directorySize: Int { 1_000_000_000 }
     var dismissMetadataViewOnDelete: Bool { false }
+    var mapMode: OfflineMapViewModel.Mode { .preplanned }
     
     func removeDownloadedArea() {}
     func startDownload() {}

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaMetadataView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaMetadataView.swift
@@ -54,7 +54,7 @@ struct OfflineMapAreaMetadataView<Metadata: OfflineMapAreaMetadata>: View {
                         }
                         model.removeDownloadedArea()
                     } label: {
-                        Text(model.removeDownloadString)
+                        Text(model.removeDownloadButtonText)
                     }
                 }
             }
@@ -143,8 +143,8 @@ protocol OfflineMapAreaMetadata: ObservableObject {
     var directorySize: Int { get }
     /// A Boolean value indicating whether the metadata view should be dismissed when the map area is deleted.
     var dismissMetadataViewOnDelete: Bool { get }
-    /// The localized string for the button to remove a download.
-    var removeDownloadString: LocalizedStringResource { get }
+    /// The localized text for the button to remove a download.
+    var removeDownloadButtonText: LocalizedStringResource { get }
     /// Removes the downloaded area.
     func removeDownloadedArea()
     /// Starts downloading the area.
@@ -177,7 +177,7 @@ private class MockMetadata: OfflineMapAreaMetadata {
     var allowsDownload: Bool { true }
     var directorySize: Int { 1_000_000_000 }
     var dismissMetadataViewOnDelete: Bool { false }
-    var removeDownloadString: LocalizedStringResource { .removeDownload }
+    var removeDownloadButtonText: LocalizedStringResource { .removeDownload }
     
     func removeDownloadedArea() {}
     func startDownload() {}

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -75,6 +75,7 @@ extension OnDemandMapModel: OfflineMapAreaMetadata {
     var allowsDownload: Bool { false }
     var dismissMetadataViewOnDelete: Bool { true }
     var mapMode: OfflineMapViewModel.Mode { .onDemand }
+    var removeDownloadString: LocalizedStringResource { .deleteDownload }
     func startDownload() { fatalError() }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -74,7 +74,7 @@ extension OnDemandMapModel: OfflineMapAreaMetadata {
     var thumbnailImage: UIImage? { thumbnail }
     var allowsDownload: Bool { false }
     var dismissMetadataViewOnDelete: Bool { true }
-    var removeDownloadString: LocalizedStringResource { .deleteDownload }
+    var removeDownloadButtonText: LocalizedStringResource { .deleteDownload }
     func startDownload() { fatalError() }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -74,6 +74,7 @@ extension OnDemandMapModel: OfflineMapAreaMetadata {
     var thumbnailImage: UIImage? { thumbnail }
     var allowsDownload: Bool { false }
     var dismissMetadataViewOnDelete: Bool { true }
+    var mapMode: OfflineMapViewModel.Mode { .onDemand }
     func startDownload() { fatalError() }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -74,7 +74,6 @@ extension OnDemandMapModel: OfflineMapAreaMetadata {
     var thumbnailImage: UIImage? { thumbnail }
     var allowsDownload: Bool { false }
     var dismissMetadataViewOnDelete: Bool { true }
-    var mapMode: OfflineMapViewModel.Mode { .onDemand }
     var removeDownloadString: LocalizedStringResource { .deleteDownload }
     func startDownload() { fatalError() }
 }

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -104,6 +104,7 @@ extension PreplannedMapModel: OfflineMapAreaMetadata {
     var isDownloaded: Bool { status.isDownloaded }
     var allowsDownload: Bool { status.allowsDownload }
     var dismissMetadataViewOnDelete: Bool { false }
+    var mapMode: OfflineMapViewModel.Mode { .preplanned }
     
     func startDownload() {
         Task { await downloadPreplannedMapArea() }

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -104,7 +104,7 @@ extension PreplannedMapModel: OfflineMapAreaMetadata {
     var isDownloaded: Bool { status.isDownloaded }
     var allowsDownload: Bool { status.allowsDownload }
     var dismissMetadataViewOnDelete: Bool { false }
-    var mapMode: OfflineMapViewModel.Mode { .preplanned }
+    var removeDownloadString: LocalizedStringResource { .removeDownload }
     
     func startDownload() {
         Task { await downloadPreplannedMapArea() }

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -104,7 +104,7 @@ extension PreplannedMapModel: OfflineMapAreaMetadata {
     var isDownloaded: Bool { status.isDownloaded }
     var allowsDownload: Bool { status.allowsDownload }
     var dismissMetadataViewOnDelete: Bool { false }
-    var removeDownloadString: LocalizedStringResource { .removeDownload }
+    var removeDownloadButtonText: LocalizedStringResource { .removeDownload }
     
     func startDownload() {
         Task { await downloadPreplannedMapArea() }

--- a/Sources/ArcGISToolkit/Extensions/Swift/LocalizedStringResource.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/LocalizedStringResource.swift
@@ -28,6 +28,14 @@ extension LocalizedStringResource {
         )
     }
     
+    static var deleteDownload: Self {
+        .init(
+            "Delete Download",
+            bundle: .toolkit,
+            comment: "A label for a button to delete a map area download."
+        )
+    }
+    
     static var downloaded: Self {
         .init(
             "Downloaded",
@@ -82,6 +90,14 @@ extension LocalizedStringResource {
             "OK",
             bundle: .toolkit,
             comment: "A label for button to proceed with an operation."
+        )
+    }
+    
+    static var removeDownload: Self {
+        .init(
+            "Remove Download",
+            bundle: .toolkit,
+            comment: "A label for a button to remove a map area download."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -165,8 +165,8 @@ east, etc.). */
 /* The title of the dialogue confirming deletion of all points. */
 "Delete all starting points?" = "Delete all starting points?";
 
-/* A label for a button to delete a map area. */
-"Delete Map Area" = "Delete Map Area";
+/* A label for a button to delete a map area download. */
+"Delete Download" = "Delete Download";
 
 /* A label for the description of the map area. */
 "Description" = "Description";
@@ -443,6 +443,9 @@ variable provides additional data. */
 
 /* A button allowing users to proceed to record a video while acknowledging audio will not be captured. */
 "Record video only" = "Record video only";
+
+/* A label for a button to remove a map area download. */
+"Remove Download" = "Remove Download";
 
 /* A label for a button to refresh map area content. */
 "Refresh" = "Refresh";


### PR DESCRIPTION
Related to https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/1166.

Renames the "Delete Map Area" button to "Remove Download" and "Delete Download" for the preplanned and on-demand use-cases respectively.