### PR TITLE
`FeatureFormView` - Revert `validationErrors(_:)` deprecation

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+Deprecated.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+Deprecated.swift
@@ -23,23 +23,4 @@ public extension FeatureFormView /* Deprecated */ {
     init(featureForm: FeatureForm) {
         self.init(featureForm: .constant(featureForm))
     }
-    
-    /// The validation error visibility configuration of a form.
-    /// - Attention: Deprecated at 200.7.
-    @available(*, deprecated)
-    enum ValidationErrorVisibility: Sendable {
-        /// Errors may be visible or hidden for a given form field depending on its focus state.
-        case automatic
-        /// Errors will always be visible for a given form field.
-        case visible
-    }
-    
-    /// Specifies the visibility of validation errors in the form.
-    /// - Parameter visibility: The preferred visibility of validation errors in the form.
-    /// - Attention: Deprecated at 200.7. ``FeatureFormView`` automatically manages
-    /// validation error visibility.
-    @available(*, deprecated)
-    func validationErrors(_ visibility: ValidationErrorVisibility) -> Self {
-        self
-    }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
@@ -1,0 +1,46 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+public extension FeatureFormView {
+    /// The validation error visibility configuration of a form.
+    enum ValidationErrorVisibility: Sendable {
+        /// Errors may be visible or hidden for a given form field depending on its focus state.
+        case automatic
+        /// Errors will always be visible for a given form field.
+        case visible
+    }
+    
+    /// Specifies the visibility of validation errors in the form.
+    /// - Parameter visibility: The preferred visibility of validation errors in the form.
+    func validationErrors(_ visibility: ValidationErrorVisibility) -> Self {
+        var copy = self
+//        copy.validationErrorVisibility = visibility
+        return copy
+    }
+}
+
+extension EnvironmentValues {
+    /// The validation error visibility configuration of a form.
+    var validationErrorVisibility: FeatureFormView.ValidationErrorVisibility {
+        get { self[FormViewValidationErrorVisibility.self] }
+        set { self[FormViewValidationErrorVisibility.self] = newValue }
+    }
+}
+
+/// The validation error visibility configuration of a form.
+struct FormViewValidationErrorVisibility: EnvironmentKey {
+    static let defaultValue: FeatureFormView.ValidationErrorVisibility = .automatic
+}

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
@@ -27,20 +27,7 @@ public extension FeatureFormView {
     /// - Parameter visibility: The preferred visibility of validation errors in the form.
     func validationErrors(_ visibility: ValidationErrorVisibility) -> Self {
         var copy = self
-//        copy.validationErrorVisibility = visibility
+        copy.validationErrorVisibilityExternal = visibility
         return copy
     }
-}
-
-extension EnvironmentValues {
-    /// The validation error visibility configuration of a form.
-    var validationErrorVisibility: FeatureFormView.ValidationErrorVisibility {
-        get { self[FormViewValidationErrorVisibility.self] }
-        set { self[FormViewValidationErrorVisibility.self] = newValue }
-    }
-}
-
-/// The validation error visibility configuration of a form.
-struct FormViewValidationErrorVisibility: EnvironmentKey {
-    static let defaultValue: FeatureFormView.ValidationErrorVisibility = .automatic
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView+ValidationErrorVisibility.swift
@@ -23,8 +23,18 @@ public extension FeatureFormView {
         case visible
     }
     
-    /// Specifies the visibility of validation errors in the form.
+    /// Sets the visibility of validation errors on the form.
     /// - Parameter visibility: The preferred visibility of validation errors in the form.
+    ///
+    /// `FeatureFormView` will automatically show validation errors on fields once they've received
+    /// user interaction or the user has attempted to save the form with the built-in "Save" buttons.
+    ///
+    /// If it's preferred that validation errors are always shown, override the default behavior with this
+    /// modifier, passing `.visible`.
+    ///
+    /// If the built-in "Save" button in the form footer has been hidden with
+    /// ``FeatureFormView.editingButtons(_:)``,  use this modifier to make any validation
+    /// errors visible when the user attempts to save the form with a custom save button.
     func validationErrors(_ visibility: ValidationErrorVisibility) -> Self {
         var copy = self
         copy.validationErrorVisibilityExternal = visibility

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/InternalFeatureFormView.swift
@@ -50,6 +50,11 @@ struct InternalFeatureFormView: View {
                     }
                 }
             }
+            .onChange(of: internalFeatureFormViewModel.featureForm.hasEdits) { hadEdits, hasEdits in
+                if hadEdits && !hasEdits {
+                    internalFeatureFormViewModel.previouslyFocusedElements.removeAll()
+                }
+            }
             .onChange(of: internalFeatureFormViewModel.focusedElement) {
                 if let focusedElement = internalFeatureFormViewModel.focusedElement {
                     withAnimation { scrollViewProxy.scrollTo(focusedElement, anchor: .top) }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/FormElementWrapper/FormElementFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/FormElementWrapper/FormElementFooter.swift
@@ -46,8 +46,11 @@ extension FormElementFooter {
         /// The view model for the form.
         @Environment(InternalFeatureFormViewModel.self) private var internalFeatureFormViewModel
         
-        /// The validation error visibility configuration of a form.
-        @Environment(\._validationErrorVisibility) private var validationErrorVisibility
+        /// The developer configurable validation error visibility.
+        @Environment(\.validationErrorVisibilityExternal) private var validationErrorVisibilityExternal
+        
+        /// The internally managed validation error visibility.
+        @Environment(\.validationErrorVisibilityInternal) private var validationErrorVisibilityInternal
         
         let element: FieldFormElement
         
@@ -228,7 +231,12 @@ extension FormElementFooter {
         var isShowingError: Bool {
             element.isEditable
             && primaryError != nil
-            && (internalFeatureFormViewModel.previouslyFocusedElements.contains(element) || validationErrorVisibility == .visible)
+            &&
+            (
+                internalFeatureFormViewModel.previouslyFocusedElements.contains(element)
+                || validationErrorVisibilityExternal == .visible
+                || validationErrorVisibilityInternal == .visible
+            )
         }
         
         /// The allowable number of characters in the input.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormFooter.swift
@@ -25,8 +25,8 @@ struct FormFooter: View {
     /// to the ``FeatureFormView``.
     let formHandlingEventAction: ((FeatureFormView.EditingEvent) -> Void)?
     
-    /// The validation error visibility configuration of the form.
-    @Binding var validationErrorVisibility: Visibility
+    /// The internally managed validation error visibility.
+    @Binding var validationErrorVisibilityInternal: FeatureFormView.ValidationErrorVisibility
     
     /// An error thrown from finish editing.
     @Binding var finishEditingError: (any Error)?
@@ -38,7 +38,7 @@ struct FormFooter: View {
             Button {
                 featureForm.discardEdits()
                 formHandlingEventAction?(.discardedEdits(willNavigate: false))
-                validationErrorVisibility = .hidden
+                validationErrorVisibilityInternal = .automatic
             } label: {
                 Text(
                     "Discard",
@@ -60,7 +60,7 @@ struct FormFooter: View {
                             }
                         }
                     } else {
-                        validationErrorVisibility = .visible
+                        validationErrorVisibilityInternal = .visible
                         setAlertContinuation?(false, {})
                     }
             } label: {


### PR DESCRIPTION
Apollo 1284

- Reverts the planned deprecation of `FeatureFormView.validationErrors(_:)`.
- Updates the modifier's doc in light of the added built-in "Save" buttons in 200.8.