### PR TITLE
`PopupView` - Fix daily test failures

### DIFF
--- a/Test Runner/UI Tests/PopupViewTests.swift
+++ b/Test Runner/UI Tests/PopupViewTests.swift
@@ -82,7 +82,9 @@ final class PopupViewTests: XCTestCase {
         let structureFilterResult = app.staticTexts["Structure"]
         
         openPopup(3216, on: .electricDistributionDevice)
-        assertPopupOpened(popupTitle: popupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: popupTitle)
+        }
         
         // Expectation: The default title is "Associations".
         XCTAssertTrue(
@@ -123,7 +125,9 @@ final class PopupViewTests: XCTestCase {
         let structureTitle = app.staticTexts["Junction Structure"]
         
         openPopup(2473, on: "Electric Distribution Junction")
-        assertPopupOpened(popupTitle: popupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: popupTitle)
+        }
         
         // Expectation: The custom popup element title and description are displayed.
         XCTAssertTrue(
@@ -166,7 +170,9 @@ final class PopupViewTests: XCTestCase {
         let popupTitle = app.navigationBars["Electric Distribution Line: Medium Voltage"]
         
         openPopup(513, on: "Electric Distribution Line")
-        assertPopupOpened(popupTitle: popupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: popupTitle)
+        }
         
         // Expectation: There is only one associations element with no filter results.
         XCTAssertEqual(associationsElements.count, 1)
@@ -190,7 +196,9 @@ final class PopupViewTests: XCTestCase {
         let structureFilterResult = app.staticTexts["Structure"]
         
         openPopup(2339, on: .structureJunction)
-        assertPopupOpened(popupTitle: popupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: popupTitle)
+        }
         
         // Expectation: There are 2 associations popup elements.
         XCTAssertEqual(associationsElements.count, 2)
@@ -228,7 +236,9 @@ final class PopupViewTests: XCTestCase {
         let searchField = app.searchFields["Title"]
         
         openPopup(1464, on: .structureJunction)
-        assertPopupOpened(popupTitle: switchgearPopupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: switchgearPopupTitle)
+        }
         
         // Expectation: A filter result opens the group result list.
         XCTAssertTrue(
@@ -333,7 +343,9 @@ final class PopupViewTests: XCTestCase {
         let switchObjectIDText = app.staticTexts["Selected Popup Object ID, 4361"]
         
         openPopup(4361, on: .electricDistributionDevice)
-        assertPopupOpened(popupTitle: switchPopupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: switchPopupTitle)
+        }
         
         // Expectation: The first provided popup's object ID matches the opened popup's.
         XCTAssertTrue(
@@ -394,7 +406,9 @@ final class PopupViewTests: XCTestCase {
         let transformerResult = app.staticTexts["Electric Distribution Device: Transformer"]
         
         openPopup(2672, on: .electricDistributionDevice)
-        assertPopupOpened(popupTitle: popupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: popupTitle)
+        }
         
         // Opens the "Connectivity" filter result.
         XCTAssertTrue(
@@ -452,7 +466,9 @@ final class PopupViewTests: XCTestCase {
         let transformerBankPopupTitle = app.staticTexts["Electric Distribution Assembly: Transformer Bank"]
         
         openPopup(4567, on: .electricDistributionDevice)
-        assertPopupOpened(popupTitle: fusePopupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: fusePopupTitle)
+        }
         
         // Opens the "Connectivity" filter result.
         XCTAssertTrue(
@@ -543,7 +559,9 @@ final class PopupViewTests: XCTestCase {
         let searchField = app.searchFields["Title"]
         
         openPopup(316, on: .electricDistributionAssembly)
-        assertPopupOpened(popupTitle: popupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: popupTitle)
+        }
         
         // Opens the filter result.
         XCTAssertTrue(
@@ -589,7 +607,9 @@ final class PopupViewTests: XCTestCase {
         let searchField = app.searchFields["Title"]
         
         openPopup(475, on: .electricDistributionAssembly)
-        assertPopupOpened(popupTitle: popupTitle)
+        XCTExpectFailure("KNOWN ISSUE -- nautilus/issues/2625") {
+            assertPopupOpened(popupTitle: popupTitle)
+        }
         
         // Opens the filter result.
         XCTAssertTrue(


### PR DESCRIPTION
## Description

This PR resolves `PopupViewTests` daily failures caused by a known issue.

**Note**: These changes now cause the tests to fail on non-on-device platforms, such as simulators and Mac Catalyst. They will also occasionally fail on-device if the map happens to finish drawing under 15 seconds. The alternative would be to skip the tests altogether, but then we wouldn't be notified when the issue is resolved. Let me know if you think that is a better solution.

## Linked Issue(s)

- `nautilus/issues/2625`

## How To Test

- Ensure the tests pass on device.
