### PR TITLE
`PopupView` - Update initializer to match FeatureForm

### DIFF
--- a/Examples/Examples/PopupExampleView.swift
+++ b/Examples/Examples/PopupExampleView.swift
@@ -55,7 +55,7 @@ struct PopupExampleView: View {
                     popup = identifyResult?.popups.first
                 }
                 .sheet(isPresented: $showPopup) { [popup] in
-                    PopupView(popup: popup!, isPresented: $showPopup)
+                    PopupView(root: popup!, isPresented: $showPopup)
                 }
         }
     }

--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -92,6 +92,9 @@ extension EmbeddedPopupView {
     private struct PopupElementList: View {
         let popupElements: [PopupElement]
         
+        /// A Boolean value indicating whether the deprecated Popup View initializer was used.
+        @Environment(\.popupDeprecatedInitializerWasUsed) private var deprecatedInitializerWasUsed
+        
         var body: some View {
             List(popupElements) { popupElement in
                 Group {
@@ -105,7 +108,9 @@ extension EmbeddedPopupView {
                     case let popupElement as TextPopupElement:
                         TextPopupElementView(popupElement: popupElement)
                     case let popupElement as UtilityAssociationsPopupElement:
-                        UtilityAssociationsPopupElementView(popupElement: popupElement)
+                        if !deprecatedInitializerWasUsed {
+                            UtilityAssociationsPopupElementView(popupElement: popupElement)
+                        }
                     default:
                         EmptyView()
                     }

--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
+import OSLog
 import SwiftUI
 
 /// A view that display a `Popup` and its evaluated elements.
@@ -22,6 +23,9 @@ import SwiftUI
 struct EmbeddedPopupView: View {
     /// The `Popup` to display.
     let popup: Popup
+    
+    /// The properties used by the parent PopupView's deprecated members.
+    @Environment(\.deprecatedProperties) private var deprecatedProperties
     
     /// The result of evaluating the popup expressions.
     @State private var evaluationResult: Result<[PopupElement], Error>?
@@ -54,9 +58,7 @@ struct EmbeddedPopupView: View {
             }
         }
         .preference(key: PresentedPopupPreferenceKey.self, value: .init(popup: popup))
-        .navigationTitle(popup.title)
-        .navigationBarTitleDisplayMode(.inline)
-        .popupViewToolbar()
+        .popupViewHeader(title: popup.title)
         .task(id: ObjectIdentifier(popup)) {
             // Initial evaluation for a newly assigned popup.
             guard !Task.isCancelled else { return }
@@ -85,6 +87,16 @@ struct EmbeddedPopupView: View {
             _ = try await popup.evaluateExpressions()
             return popup.evaluatedElements
         }
+        
+        // Logs an error if UtilityAssociationsFormElements are used with the deprecated initializer.
+        // This can be removed when `PopupView.init(popup:isPresented:)` is removed.
+        if deprecatedProperties.initializerWasUsed,
+           case .success(let evaluatedElements) = evaluationResult,
+           evaluatedElements.contains(where: { $0 is UtilityAssociationsPopupElement }) {
+            Logger.popupView.error(
+                "'UtilityAssociationsPopupElement's are not supported with this 'PopupView' initializer. Use 'init(root:isPresented:)' instead."
+            )
+        }
     }
 }
 
@@ -92,8 +104,8 @@ extension EmbeddedPopupView {
     private struct PopupElementList: View {
         let popupElements: [PopupElement]
         
-        /// A Boolean value indicating whether the deprecated Popup View initializer was used.
-        @Environment(\.popupDeprecatedInitializerWasUsed) private var deprecatedInitializerWasUsed
+        /// The properties used by the parent PopupView's deprecated members.
+        @Environment(\.deprecatedProperties) private var deprecatedProperties
         
         var body: some View {
             List(popupElements) { popupElement in
@@ -108,7 +120,7 @@ extension EmbeddedPopupView {
                     case let popupElement as TextPopupElement:
                         TextPopupElementView(popupElement: popupElement)
                     case let popupElement as UtilityAssociationsPopupElement:
-                        if !deprecatedInitializerWasUsed {
+                        if !deprecatedProperties.initializerWasUsed {
                             UtilityAssociationsPopupElementView(popupElement: popupElement)
                         }
                     default:
@@ -127,4 +139,11 @@ extension EmbeddedPopupView {
 extension EnvironmentValues {
     /// The title of the popup associated with the view.
     @Entry var popupTitle = ""
+}
+
+private extension Logger {
+    /// A logger for the popup view.
+    static var popupView: Logger {
+        Logger(subsystem: "com.esri.ArcGISToolkit", category: "PopupView")
+    }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView+Deprecated.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView+Deprecated.swift
@@ -16,12 +16,31 @@ import ArcGIS
 import SwiftUI
 
 public extension PopupView /* Deprecated */ {
+    /// Creates a `PopupView` with the given popup.
+    ///
+    /// - Important: This initializer has been deprecated and replaced with a new version that
+    /// supports UtilityAssociationsPopupElement. UtilityAssociationsPopupElements will not render
+    /// when this initializer is used.
+    ///
+    /// - Parameters:
+    ///   - popup: The popup to display.
+    ///   - isPresented: A Boolean value indicating if the view is presented.
+    /// - Attention: Deprecated at 200.8.
+    @available(*, deprecated, message: "Use 'init(root:isPresented:)' instead.")
+    init(popup: Popup, isPresented: Binding<Bool>? = nil) {
+        self.popup = popup
+        self.isPresented = isPresented
+        deprecatedProperties.initializerWasUsed = true
+    }
+    
     /// Specifies the visibility of the popup header.
     /// - Parameter visibility: The preferred visibility of the popup header.
     /// - Attention: Deprecated at 200.8.
     @available(*, deprecated, message: "Use 'init(root:isPresented:)' to control the close button visibility instead.")
     func header(_ visibility: Visibility) -> Self {
-        return self
+        var copy = self
+        copy.deprecatedProperties.headerVisibility = visibility
+        return copy
     }
     
     /// Specifies whether a "close" button should be shown to the right of the popup title. If the "close"
@@ -33,6 +52,32 @@ public extension PopupView /* Deprecated */ {
     /// - Attention: Deprecated at 200.7.
     @available(*, deprecated, message: "Use 'init(root:isPresented:)' to control the close button visibility instead.")
     func showCloseButton(_ newShowCloseButton: Bool) -> Self {
-        return self
+        var copy = self
+        copy.deprecatedProperties.showCloseButton = newShowCloseButton
+        return copy
     }
+}
+
+// MARK: - DeprecatedProperties
+
+extension PopupView {
+    /// The properties used by the PopupView's deprecated members.
+    struct DeprecatedProperties {
+        /// A Boolean value indicating whether the deprecated PopupView initializer was used.
+        /// - Note: This can be removed when `PopupView.init(popup:isPresented:)` is removed.
+        fileprivate(set) var initializerWasUsed = false
+        
+        /// The visibility of the popup header.
+        /// - Note: This can be removed when `PopupView.header(_:)` is removed.
+        fileprivate(set) var headerVisibility: Visibility = .automatic
+        
+        /// A Boolean value indicating whether a "close" button should be shown.
+        /// - Note: This can be removed when `PopupView.showCloseButton(_:)` is removed.
+        fileprivate(set) var showCloseButton: Bool? = nil
+    }
+}
+
+extension EnvironmentValues {
+    /// The properties used by the PopupView's deprecated members.
+    @Entry var deprecatedProperties = PopupView.DeprecatedProperties()
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView+Deprecated.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView+Deprecated.swift
@@ -19,7 +19,7 @@ public extension PopupView /* Deprecated */ {
     /// Specifies the visibility of the popup header.
     /// - Parameter visibility: The preferred visibility of the popup header.
     /// - Attention: Deprecated at 200.8.
-    @available(*, deprecated, message: "Use 'closeButton(_:)' to specify the close button visibility instead.")
+    @available(*, deprecated, message: "Use 'init(root:isPresented:)' to control the close button visibility instead.")
     func header(_ visibility: Visibility) -> Self {
         return self
     }
@@ -31,10 +31,8 @@ public extension PopupView /* Deprecated */ {
     /// - Parameter newShowCloseButton: The new value.
     /// - Returns: A new `PopupView`.
     /// - Attention: Deprecated at 200.7.
-    @available(*, deprecated, message: "Use 'closeButton(_:)' instead.")
+    @available(*, deprecated, message: "Use 'init(root:isPresented:)' to control the close button visibility instead.")
     func showCloseButton(_ newShowCloseButton: Bool) -> Self {
-        var copy = self
-        copy.closeButtonVisibility = newShowCloseButton ? .visible : .hidden
-        return copy
+        return self
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -87,7 +87,7 @@ public struct PopupView: View {
             EmbeddedPopupView(popup: popup)
         }
         .environment(\.popupCloseButtonVisibility, closeButtonVisibility)
-        .environment(\.popupIsPresented, isPresented)
+        .environment(\.isPresented, isPresented)
         .onPreferenceChange(PresentedPopupPreferenceKey.self) { wrappedPopup in
             guard let wrappedPopup else { return }
             onPopupChanged?(wrappedPopup.popup)
@@ -98,9 +98,6 @@ public struct PopupView: View {
 extension EnvironmentValues {
     /// The visibility of the popup view's close button.
     @Entry var popupCloseButtonVisibility: Visibility = .automatic
-    
-    /// A binding to a Boolean value that determines whether a popup view is presented.
-    @Entry var popupIsPresented: Binding<Bool>?
 }
 
 public extension PopupView {

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -62,13 +62,13 @@ import ArcGIS
 /// in the project. To learn more about using the `PopupView`, see the <doc:PopupViewTutorial>.
 public struct PopupView: View {
     /// The `Popup` to display in the root `EmbeddedPopupView`.
-    private let popup: Popup
+    let popup: Popup
     
     /// A binding to a Boolean value that determines whether the view is presented.
-    private let isPresented: Binding<Bool>?
+    let isPresented: Binding<Bool>?
     
-    /// A Boolean value indicating whether the deprecated Popup View initializer was used.
-    private let deprecatedInitializerWasUsed: Bool
+    /// The properties used by the view's deprecated members.
+    var deprecatedProperties = DeprecatedProperties()
     
     /// The closure to perform when a new popup is shown in the navigation stack.
     var onPopupChanged: ((Popup) -> Void)?
@@ -76,11 +76,11 @@ public struct PopupView: View {
     /// Creates a `PopupView` with the given popup.
     /// - Parameters:
     ///   - root: The popup to display.
-    ///   - isPresented: A Boolean value indicating if the view is presented.
+    ///   - isPresented: A Boolean value indicating whether the view is presented. The close button
+    ///   is displayed when this is non-`nil`.
     public init(root: Popup, isPresented: Binding<Bool>? = nil) {
         self.popup = root
         self.isPresented = isPresented
-        self.deprecatedInitializerWasUsed = false
     }
     
     public var body: some View {
@@ -88,17 +88,12 @@ public struct PopupView: View {
             EmbeddedPopupView(popup: popup)
         }
         .environment(\.isPresented, isPresented)
-        .environment(\.popupDeprecatedInitializerWasUsed, deprecatedInitializerWasUsed)
+        .environment(\.deprecatedProperties, deprecatedProperties)
         .onPreferenceChange(PresentedPopupPreferenceKey.self) { wrappedPopup in
             guard let wrappedPopup else { return }
             onPopupChanged?(wrappedPopup.popup)
         }
     }
-}
-
-extension EnvironmentValues {
-    /// A Boolean value indicating whether the deprecated Popup View initializer was used.
-    @Entry var popupDeprecatedInitializerWasUsed = false
 }
 
 public extension PopupView {
@@ -111,22 +106,6 @@ public extension PopupView {
         var copy = self
         copy.onPopupChanged = action
         return copy
-    }
-    
-    /// Creates a `PopupView` with the given popup.
-    ///
-    /// - Important: This initializer has been deprecated and replaced with a new version that
-    /// supports UtilityAssociationsPopupElement. UtilityAssociationsPopupElements will not render
-    /// when this initializer is used.
-    ///
-    /// - Parameters:
-    ///   - popup: The popup to display.
-    ///   - isPresented: A Boolean value indicating if the view is presented.
-    @available(*, deprecated, message: "Use 'init(root:isPresented:)' instead.")
-    init(popup: Popup, isPresented: Binding<Bool>? = nil) {
-        self.popup = popup
-        self.isPresented = isPresented
-        self.deprecatedInitializerWasUsed = true
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -67,16 +67,20 @@ public struct PopupView: View {
     /// A binding to a Boolean value that determines whether the view is presented.
     private let isPresented: Binding<Bool>?
     
+    /// A Boolean value indicating whether the deprecated Popup View initializer was used.
+    private let deprecatedInitializerWasUsed: Bool
+    
     /// The closure to perform when a new popup is shown in the navigation stack.
     var onPopupChanged: ((Popup) -> Void)?
     
     /// Creates a `PopupView` with the given popup.
     /// - Parameters:
-    ///   - popup: The popup to display.
+    ///   - root: The popup to display.
     ///   - isPresented: A Boolean value indicating if the view is presented.
-    public init(popup: Popup, isPresented: Binding<Bool>? = nil) {
-        self.popup = popup
+    public init(root: Popup, isPresented: Binding<Bool>? = nil) {
+        self.popup = root
         self.isPresented = isPresented
+        self.deprecatedInitializerWasUsed = false
     }
     
     public var body: some View {
@@ -84,11 +88,17 @@ public struct PopupView: View {
             EmbeddedPopupView(popup: popup)
         }
         .environment(\.isPresented, isPresented)
+        .environment(\.popupDeprecatedInitializerWasUsed, deprecatedInitializerWasUsed)
         .onPreferenceChange(PresentedPopupPreferenceKey.self) { wrappedPopup in
             guard let wrappedPopup else { return }
             onPopupChanged?(wrappedPopup.popup)
         }
     }
+}
+
+extension EnvironmentValues {
+    /// A Boolean value indicating whether the deprecated Popup View initializer was used.
+    @Entry var popupDeprecatedInitializerWasUsed = false
 }
 
 public extension PopupView {
@@ -101,6 +111,22 @@ public extension PopupView {
         var copy = self
         copy.onPopupChanged = action
         return copy
+    }
+    
+    /// Creates a `PopupView` with the given popup.
+    ///
+    /// - Important: This initializer has been deprecated and replaced with a new version that
+    /// supports UtilityAssociationsPopupElement. UtilityAssociationsPopupElements will not render
+    /// when this initializer is used.
+    ///
+    /// - Parameters:
+    ///   - popup: The popup to display.
+    ///   - isPresented: A Boolean value indicating if the view is presented.
+    @available(*, deprecated, message: "Use 'init(root:isPresented:)' instead.")
+    init(popup: Popup, isPresented: Binding<Bool>? = nil) {
+        self.popup = popup
+        self.isPresented = isPresented
+        self.deprecatedInitializerWasUsed = true
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -67,9 +67,6 @@ public struct PopupView: View {
     /// A binding to a Boolean value that determines whether the view is presented.
     private let isPresented: Binding<Bool>?
     
-    /// The visibility of the close button.
-    var closeButtonVisibility: Visibility = .automatic
-    
     /// The closure to perform when a new popup is shown in the navigation stack.
     var onPopupChanged: ((Popup) -> Void)?
     
@@ -86,7 +83,6 @@ public struct PopupView: View {
         NavigationStack {
             EmbeddedPopupView(popup: popup)
         }
-        .environment(\.popupCloseButtonVisibility, closeButtonVisibility)
         .environment(\.isPresented, isPresented)
         .onPreferenceChange(PresentedPopupPreferenceKey.self) { wrappedPopup in
             guard let wrappedPopup else { return }
@@ -95,21 +91,7 @@ public struct PopupView: View {
     }
 }
 
-extension EnvironmentValues {
-    /// The visibility of the popup view's close button.
-    @Entry var popupCloseButtonVisibility: Visibility = .automatic
-}
-
 public extension PopupView {
-    /// Sets the visibility of the close button on the popup view.
-    /// - Parameter visibility: The visibility of the close button.
-    /// - Since: 200.8
-    func closeButton(_ visibility: Visibility) -> Self {
-        var copy = self
-        copy.closeButtonVisibility = visibility
-        return copy
-    }
-    
     /// Sets a closure to perform when a new popup is shown in the view.
     ///
     /// This can happen when navigating through the associations in a `UtilityAssociationsPopupElement`.

--- a/Sources/ArcGISToolkit/Components/Popups/PopupViewHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupViewHeader.swift
@@ -1,0 +1,70 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+extension View {
+    /// Adds a PopupView header to the view.
+    /// - Parameter title: The title to display in the header.
+    /// - Note: This can be removed once `PopupView.DeprecatedProperties` is removed.
+    func popupViewHeader(title: String) -> some View {
+        modifier(PopupViewHeaderModifier(title: title))
+    }
+}
+
+/// A view modifier that adds a PopupView header to a view.
+/// - Note: This can be removed once `PopupView.DeprecatedProperties` is removed.
+private struct PopupViewHeaderModifier: ViewModifier {
+    /// The title to display in the header.
+    let title: String
+    
+    /// The properties used by the parent PopupView's deprecated members.
+    @Environment(\.deprecatedProperties) private var deprecatedProperties
+    
+    /// A binding to a Boolean value that determines whether a popup view is presented.
+    @Environment(\.isPresented) private var isPresented
+    
+    func body(content: Content) -> some View {
+        if !deprecatedProperties.initializerWasUsed {
+            content
+                .popupViewToolbar()
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.inline)
+        } else if deprecatedProperties.headerVisibility != .hidden {
+            VStack {
+                HStack {
+                    if !title.isEmpty {
+                        Text(title)
+                            .font(.title)
+                            .fontWeight(.bold)
+                    }
+                    Spacer()
+                    if deprecatedProperties.showCloseButton ?? (isPresented != nil) {
+                        XButton(.dismiss) {
+                            isPresented?.wrappedValue = false
+                        }
+#if !os(visionOS)
+                        .font(.title)
+                        .padding([.top, .bottom, .trailing], 4)
+#endif
+                    }
+                }
+                Divider()
+                content
+            }
+        } else {
+            content
+        }
+    }
+}

--- a/Sources/ArcGISToolkit/Components/Popups/PopupViewToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupViewToolbar.swift
@@ -27,7 +27,7 @@ private struct PopupViewToolbar: ViewModifier {
     @Environment(\.popupCloseButtonVisibility) private var closeButtonVisibility
     
     /// A binding to a Boolean value that determines whether a popup view is presented.
-    @Environment(\.popupIsPresented) private var isPresented
+    @Environment(\.isPresented) private var isPresented
     
     func body(content: Content) -> some View {
         content

--- a/Sources/ArcGISToolkit/Components/Popups/PopupViewToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupViewToolbar.swift
@@ -23,19 +23,16 @@ extension View {
 
 /// A view modifier that populates the content's toolbar with items used by the `PopupView`.
 private struct PopupViewToolbar: ViewModifier {
-    /// The visibility of the popup view's close button.
-    @Environment(\.popupCloseButtonVisibility) private var closeButtonVisibility
-    
     /// A binding to a Boolean value that determines whether a popup view is presented.
     @Environment(\.isPresented) private var isPresented
     
     func body(content: Content) -> some View {
         content
             .toolbar {
-                if closeButtonVisibility != .hidden {
+                if let isPresented {
                     ToolbarItem(placement: .topBarTrailing) {
                         XButton(.dismiss) {
-                            isPresented?.wrappedValue = false
+                            isPresented.wrappedValue = false
                         }
                         .font(.headline)
                     }

--- a/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
+++ b/Sources/ArcGISToolkit/Documentation.docc/Resources/PopupView/PopupViewStep6.swift
@@ -21,8 +21,6 @@ struct PopupExampleView: View {
     
     @State private var showPopup = false
     
-    @State private var floatingPanelDetent: FloatingPanelDetent = .full
-    
     var body: some View {
         MapViewReader { proxy in
             MapView(map: map)
@@ -38,12 +36,8 @@ struct PopupExampleView: View {
                     ).first
                     popup = identifyResult?.popups.first
                 }
-                .floatingPanel(
-                    selectedDetent: $floatingPanelDetent,
-                    horizontalAlignment: .leading,
-                    isPresented: $showPopup
-                ) { [popup] in
-                    PopupView(popup: popup!, isPresented: $showPopup)
+                .sheet(isPresented: $showPopup) { [popup] in
+                    PopupView(root: popup!, isPresented: $showPopup)
                 }
         }
     }

--- a/Test Runner/Test Runner/TestViews/PopupTestView.swift
+++ b/Test Runner/Test Runner/TestViews/PopupTestView.swift
@@ -41,7 +41,7 @@ struct PopupTestView: View {
                 .background(.regularMaterial, ignoresSafeAreaEdges: .horizontal)
             }
             .sheet(isPresented: .init(optionalValue: $popup)) {
-                PopupView(popup: popup!, isPresented: .init(optionalValue: $popup))
+                PopupView(root: popup!, isPresented: .init(optionalValue: $popup))
                     .onPopupChanged { popup in
                         // Clears the current popup selection.
                         if let feature = selectedPopup?.geoElement as? Feature,


### PR DESCRIPTION
## Description

Similar to the `FeatureFormView` updates made in #1201, this PR:

- Deprecates `PopupView.init(popup:isPresented:)` in favor of `PopupView.init(root:isPresented:)`.
- Removes `PopupView.closeButton(_:)` in favor of displaying the close button when the passed `isPresented` parameter is non-`nil`.
- Maintains the current behavior of `init(popup:isPresented:)`, `header(_:)`, and `showCloseButton(_:)` to allow developers to move to the new initializer at their own pace.

See feature form PR for more details.

## Linked Issue(s)

- `apollo/issues/1277`

## How To Test

Ensure the initializers and modifiers work as expected
- See "How to Test" in [#1171](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1171) for data containing `UtilityAssociationsPopupElement`s. 
- This snippet can be used to test the deprecated init in the example:

```swift
.floatingPanel(horizontalAlignment: .leading, isPresented: $showPopup) { [popup] in
    PopupView(popup: popup!, isPresented: $showPopup)
        .header(.visible)
        .showCloseButton(true)
        .padding()
}
```

**Note:** `PopupViewTests` failures are unrelated to the changes in this PR.
