### PR TITLE
`PopupView` - Fix popover background on Mac Catalyst

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -131,7 +131,7 @@ extension EmbeddedPopupView {
                 .listRowInsets(.toolkitDefault)
 #endif
             }
-            .listStyle(.plain)
+            .listStyle(.inset)
         }
     }
 }


### PR DESCRIPTION
### Description

This PR fixes an issue where the `PopupView` background wouldn't display correctly when shown in a `popover` on Mac Catalyst. The appearance of the view using other presentation modes and platforms looks to be unaffected by these changes.

### How To Test

- Replace the `PopupExampleView` sheet with a popover:

```swift
.popover(isPresented: $showPopup, attachmentAnchor: .point(.top)) { [popup] in
    PopupView(root: popup!, isPresented: $showPopup)
        .frame(idealWidth: 320, idealHeight: 500)
}
```

- Run on Mac Catalyst and open a popup.

### Screenshots

|Before|After|
|:-:|:-:|
|    ![Screenshot 2025-07-09 at 4 43 12 PM](https://github.com/user-attachments/assets/db532e19-d883-450b-a762-819cbd9a0b4b)    |    ![Screenshot 2025-07-09 at 4 44 51 PM](https://github.com/user-attachments/assets/a2601dd2-6615-4c1d-adee-2aaed17f6a75)    |

