### PR TITLE
`UtilityAssociationResultLabel` - Raise limit on title to two lines

### DIFF
--- a/Sources/ArcGISToolkit/Common/UtilityAssociationResultLabel.swift
+++ b/Sources/ArcGISToolkit/Common/UtilityAssociationResultLabel.swift
@@ -20,6 +20,12 @@ struct UtilityAssociationResultLabel: View {
     /// The utility association result to display.
     let result: UtilityAssociationResult
     
+    /// A scaled ideal frame height that allows for two lines of title text.
+    ///
+    /// At standard (non-accessible) system sizing, labels with two lines of title text in the body font and
+    /// a single line of detail text in the caption2 font have a height of 55.666.
+    @ScaledMetric(relativeTo: .body) private var frameHeight = 56
+    
     var body: some View {
         HStack {
             result.association.kind.icon
@@ -27,14 +33,17 @@ struct UtilityAssociationResultLabel: View {
             
             VStack(alignment: .leading) {
                 Text(result.title)
+                    .font(.body)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
                 if let details = result.details {
                     details
+                        .accessibilityIdentifier("Association Result Description")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
-                        .accessibilityIdentifier("Association Result Description")
+                        .lineLimit(1)
                 }
             }
-            .lineLimit(1)
             
             Spacer()
             
@@ -44,6 +53,7 @@ struct UtilityAssociationResultLabel: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("Association Result")
+        .frame(idealHeight: frameHeight)
     }
 }
 


### PR DESCRIPTION
In order to better support usability for UNA data where associations have long titles Apollo is requesting that we bump the title line limit to 2 while setting a common height for all rows, independent of whether they need the space for two lines or not.

@CalebRas, if we want to opt PopupView out of this change I can find a way to do that.

<img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 33 37 PM" src="https://github.com/user-attachments/assets/1fe5a74e-1874-4b39-b529-22c55a6e1d75" />
<img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 33 48 PM" src="https://github.com/user-attachments/assets/63c33583-02f2-4307-adb3-af06523a3db7" />
<img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-10 at 14 36 32" src="https://github.com/user-attachments/assets/5e148b9a-abc2-4ecc-a4cf-8045b42076d9" />
<img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-10 at 14 36 57" src="https://github.com/user-attachments/assets/11c3cba3-327d-4cab-9587-5ff848ed06ae" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-10 at 14 10 07" src="https://github.com/user-attachments/assets/5c04f28a-0048-480e-a933-5d3965fadac5" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-10 at 14 10 16" src="https://github.com/user-attachments/assets/21ff9055-1a75-476a-9f9c-40e33156c181" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-10 at 14 40 16" src="https://github.com/user-attachments/assets/2448f8f3-cfb0-4c1e-8c33-04f1d7efa6d1" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-10 at 14 40 22" src="https://github.com/user-attachments/assets/671bc68f-c292-4c70-bca2-dd013d1a81d4" />
