### PR TITLE
`PopupView` - Update Mac Catalyst list row style

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -128,7 +128,7 @@ extension EmbeddedPopupView {
                     }
                 }
 #if targetEnvironment(macCatalyst)
-                .listRowInsets(.toolkitDefault)
+                .listRowInsets(.init(top: 8, leading: 0, bottom: 8, trailing: 0))
 #endif
             }
             .listStyle(.inset)

--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -127,9 +127,7 @@ extension EmbeddedPopupView {
                         EmptyView()
                     }
                 }
-#if targetEnvironment(macCatalyst)
-                .listRowInsets(.init(top: 8, leading: 0, bottom: 8, trailing: 0))
-#endif
+                .popupListRowStyle()
             }
             .listStyle(.inset)
         }
@@ -139,6 +137,19 @@ extension EmbeddedPopupView {
 extension EnvironmentValues {
     /// The title of the popup associated with the view.
     @Entry var popupTitle = ""
+}
+
+extension View {
+    /// Adds the list row style for the PopupView. This only affects Mac Catalyst.
+    @ViewBuilder
+    func popupListRowStyle() -> some View {
+#if targetEnvironment(macCatalyst)
+        self.listRowBackground(Color(.systemBackground))
+            .listRowInsets(.init(top: 8, leading: 0, bottom: 8, trailing: 0))
+#else
+        self
+#endif
+    }
 }
 
 private extension Logger {

--- a/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
@@ -139,9 +139,7 @@ private struct UtilityAssociationsFilterResultLink: View {
         NavigationLink {
             List(filterResult.groupResults, id: \.id) { groupResult in
                 UtilityAssociationGroupResultView(groupResult: groupResult)
-#if targetEnvironment(macCatalyst)
-                    .listRowInsets(.init(top: 8, leading: 0, bottom: 8, trailing: 0))
-#endif
+                    .popupListRowStyle()
             }
             .listStyle(.inset)
             .navigationTitle(filterResult.filter.displayTitle, subtitle: popupTitle)
@@ -250,9 +248,7 @@ private struct SearchUtilityAssociationResultsView: View {
             } label: {
                 UtilityAssociationResultLabel(result: result)
             }
-#if targetEnvironment(macCatalyst)
-            .listRowInsets(.init(top: 8, leading: 0, bottom: 8, trailing: 0))
-#endif
+            .popupListRowStyle()
         }
         .listStyle(.inset)
         .searchable(

--- a/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
@@ -140,7 +140,7 @@ private struct UtilityAssociationsFilterResultLink: View {
             List(filterResult.groupResults, id: \.id) { groupResult in
                 UtilityAssociationGroupResultView(groupResult: groupResult)
 #if targetEnvironment(macCatalyst)
-                    .listRowInsets(.toolkitDefault)
+                    .listRowInsets(.init(top: 8, leading: 0, bottom: 8, trailing: 0))
 #endif
             }
             .listStyle(.inset)
@@ -251,7 +251,7 @@ private struct SearchUtilityAssociationResultsView: View {
                 UtilityAssociationResultLabel(result: result)
             }
 #if targetEnvironment(macCatalyst)
-            .listRowInsets(.toolkitDefault)
+            .listRowInsets(.init(top: 8, leading: 0, bottom: 8, trailing: 0))
 #endif
         }
         .listStyle(.inset)


### PR DESCRIPTION
## Description

This PR updates the `PopupView` lists on Mac Catalyst:
1. Removes extra horizontal list row insets (in response to [this feedback](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1211#issuecomment-3058388649)).
    - The list rows now only use the horizontal padding that comes default with the `inset` list style. The vertical insets are still needed to give the text more spacing.
2. Fixes the list row background color in dark mode (in response to [this feedback](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1211#pullrequestreview-3006301997)).
   - This now matches the behavior on other platforms. 

These changes affect all presentation modes on Mac Catalyst. Other platforms remain unchanged.

## Screenshots

### 1. List Row Insets

|Before|After|
|:-:|:-:|
|    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 26 44 PM" src="https://github.com/user-attachments/assets/1fe26c8c-0db9-4b37-88d4-4516bc3e9c70" />    |    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 37 58 PM" src="https://github.com/user-attachments/assets/d53e0376-228b-42eb-b014-1f0bc2f31daa" />   |
|    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 26 52 PM" src="https://github.com/user-attachments/assets/3562d4e1-4277-45ae-aacf-c0c1573b7a91" />    |    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 38 04 PM" src="https://github.com/user-attachments/assets/4e31fa24-31cf-40fe-ab7c-8f29624b5b35" />   |
|    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 27 02 PM" src="https://github.com/user-attachments/assets/a5e4aaf7-0247-44dd-8166-fc1ae3123bc6" />    |    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 38 09 PM" src="https://github.com/user-attachments/assets/db90c924-87a2-44ae-ab35-6bca1c00f09a" />   |


### 2. List Row Background Color in Dark Mode

|Before|After|
|:-:|:-:|
|    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 39 43 PM" src="https://github.com/user-attachments/assets/b0c2a4b2-95e8-45ea-8669-79fdeb54938c" />    |    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 4 11 54 PM" src="https://github.com/user-attachments/assets/5ac5b7a3-20ae-47e6-83d9-80eb12316a15" />    |