### PR TITLE
`PopupView` - Fix list bugs

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -54,9 +54,12 @@ struct EmbeddedPopupView: View {
                     )
                     ProgressView()
                 }
-                .frame(maxWidth: .infinity)
             }
         }
+#if targetEnvironment(macCatalyst)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+#endif
         .preference(key: PresentedPopupPreferenceKey.self, value: .init(popup: popup))
         .popupViewHeader(title: popup.title)
         .task(id: ObjectIdentifier(popup)) {

--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -130,9 +130,7 @@ extension EmbeddedPopupView {
                         EmptyView()
                     }
                 }
-#if targetEnvironment(macCatalyst)
-                .listRowInsets(.toolkitDefault)
-#endif
+                .popupListRowStyle()
             }
             .listStyle(.plain)
         }
@@ -148,5 +146,15 @@ private extension Logger {
     /// A logger for the popup view.
     static var popupView: Logger {
         Logger(subsystem: "com.esri.ArcGISToolkit", category: "PopupView")
+    }
+}
+
+extension View {
+    /// Adds the list row style for the PopupView.
+    func popupListRowStyle() -> some View {
+        self.listSectionSeparator(.hidden, edges: .top)
+#if targetEnvironment(macCatalyst)
+            .listRowInsets(.init(top: 8, leading: 19, bottom: 8, trailing: 19))
+#endif
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -131,7 +131,7 @@ extension EmbeddedPopupView {
                 .listRowInsets(.toolkitDefault)
 #endif
             }
-            .listStyle(.inset)
+            .listStyle(.plain)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
@@ -143,7 +143,7 @@ private struct UtilityAssociationsFilterResultLink: View {
                     .listRowInsets(.toolkitDefault)
 #endif
             }
-            .listStyle(.inset)
+            .listStyle(.plain)
             .navigationTitle(filterResult.filter.displayTitle, subtitle: popupTitle)
             .navigationBarTitleDisplayMode(.inline)
             .popupViewToolbar()
@@ -254,7 +254,7 @@ private struct SearchUtilityAssociationResultsView: View {
             .listRowInsets(.toolkitDefault)
 #endif
         }
-        .listStyle(.inset)
+        .listStyle(.plain)
         .searchable(
             text: $text,
             placement: .navigationBarDrawer(displayMode: .always),

--- a/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/UtilityAssociationsPopupElementView.swift
@@ -139,9 +139,7 @@ private struct UtilityAssociationsFilterResultLink: View {
         NavigationLink {
             List(filterResult.groupResults, id: \.id) { groupResult in
                 UtilityAssociationGroupResultView(groupResult: groupResult)
-#if targetEnvironment(macCatalyst)
-                    .listRowInsets(.toolkitDefault)
-#endif
+                    .popupListRowStyle()
             }
             .listStyle(.plain)
             .navigationTitle(filterResult.filter.displayTitle, subtitle: popupTitle)
@@ -250,9 +248,7 @@ private struct SearchUtilityAssociationResultsView: View {
             } label: {
                 UtilityAssociationResultLabel(result: result)
             }
-#if targetEnvironment(macCatalyst)
-            .listRowInsets(.toolkitDefault)
-#endif
+            .popupListRowStyle()
         }
         .listStyle(.plain)
         .searchable(


### PR DESCRIPTION
## Description

This PR fixes a couple of `PopupView` list issues:

1. Removes extra horizontal list row insets added in [#1211](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1211) (see [comment](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1211#issuecomment-3058388649)).
    -  iOS and visionOS remain unaffected by these changes.
2. Fixes a bug where the close button in the toolbar would jump when opening a navigation link.
    - This appears to be a SwiftUI bug when an `inset` list is shown with a parent `NavigationSplitView`. As a result, all of the lists in view had to be changed to `plain`.
3. Continues to resolve the issue where the PopupView background wouldn't display correctly when shown in a `popover` on Mac Catalyst. See [#1211](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1211) for more details/screenshots.

## How To Test

Ensure the PopupView's list insets and background appear as expected on Mac Catalyst and iPad.

## Screenshots

### Mac Catalyst

|Before|After|
|:-:|:-:|
|    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 26 44 PM" src="https://github.com/user-attachments/assets/e4ea661a-948c-45bd-bab8-e358978316ea" />    |    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 37 58 PM" src="https://github.com/user-attachments/assets/0ca3923a-4319-413e-841b-a66f19c48b04" />     |
|    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 26 52 PM" src="https://github.com/user-attachments/assets/d565da3b-92ff-498b-b03a-18fb733a7425" />    |    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 38 04 PM" src="https://github.com/user-attachments/assets/59ab3fa9-ca12-41c9-83d5-6587249907f0" />    |
|    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 27 02 PM" src="https://github.com/user-attachments/assets/d64ed46c-cb2e-4d32-845e-ee1139e95562" />    |    <img width="1136" height="880" alt="Screenshot 2025-07-10 at 2 38 09 PM" src="https://github.com/user-attachments/assets/cef16512-3d4d-45f2-ab3d-c7e8164bd3fe" />    |

### iPad

|Before|After|
|:-:|:-:|
|    <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-10 at 14 34 09" src="https://github.com/user-attachments/assets/f6a9ca11-3ebd-4e60-af84-04a0be434bdc" />    |    <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-11 at 16 17 58" src="https://github.com/user-attachments/assets/c4117758-2ab4-42ef-a6df-738d2b4c858b" />    |
|    <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-10 at 14 34 15" src="https://github.com/user-attachments/assets/56b34449-78e0-4053-b0fc-f40e1f9c5ae8" />    |    <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-11 at 16 18 02" src="https://github.com/user-attachments/assets/d1fef9eb-8713-456f-83a9-b3cbb150bf0d" />    |
|    <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-10 at 14 34 19" src="https://github.com/user-attachments/assets/8ec65acb-f26f-4fba-970d-d50ca710de95" />    |    <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-11 at 16 18 07" src="https://github.com/user-attachments/assets/a1d6402e-2fb5-4355-9555-1a4ca1564684" />    |

