### PR TITLE
`FeatureFormView` - Stabilize UNA test cases 12_3, 12_4, 12_5

### DIFF
--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1493,7 +1493,7 @@ final class FeatureFormViewTests: XCTestCase {
         assertFormOpened(titleElement: formTitle)
         
         XCTAssertTrue(
-            elementTitle.exists,
+            elementTitle.waitForExistence(timeout: 5),
             "The element \"Associations\" doesn't exist."
         )
         
@@ -1530,7 +1530,7 @@ final class FeatureFormViewTests: XCTestCase {
         assertFormOpened(titleElement: formTitle)
         
         XCTAssertTrue(
-            elementTitle.exists,
+            elementTitle.waitForExistence(timeout: 5),
             "The element \"Associations\" doesn't exist."
         )
         
@@ -1574,7 +1574,7 @@ final class FeatureFormViewTests: XCTestCase {
         assertFormOpened(titleElement: formTitle)
         
         XCTAssertTrue(
-            elementTitle.exists,
+            elementTitle.waitForExistence(timeout: 5),
             "The element \"Associations\" doesn't exist."
         )
         


### PR DESCRIPTION
Attempts to resolve flakiness in FeatureFormView UNA test cases 12_3, 12_4, and 12_5 in recent daily test runs.