### PR TITLE
`FeatureFormView` - Always use custom nav stack back button

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormToolbar.swift
@@ -89,10 +89,6 @@ struct FeatureFormToolbar: ViewModifier {
                                 Image(systemName: "chevron.backward")
                             }
                         }
-#if targetEnvironment(macCatalyst)
-                        .buttonStyle(.plain)
-                        .tint(.accentColor)
-#endif
                         .disabled(navigationIsDisabled)
                     }
                 }


### PR DESCRIPTION
I discovered the native NavigationStack back button has a long-press context menu which lets a user jump to an arbitrary item:

<p align="center">
  <img width="30%" src="https://github.com/user-attachments/assets/e7841f64-e5d3-4c02-ae15-60180d4d32eb">
</p>

It was Apollo's intention to net yet support navigating to arbitrary items in the navigation path.

This PR changes the system navigation button to be always disabled and replaced by the custom navigation back button.