### PR TITLE
Offline: Fix offline mode undetermined for no internet

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -158,9 +158,9 @@ public struct OfflineMapAreasView: View {
                         switch mapViewModel.mode {
                         case .preplanned:
                             preplannedMapAreasView
-                        case .onDemand:
+                        case .onDemand, .ambiguous:
                             onDemandMapAreasView
-                        case .undetermined:
+                        case .noInternetAvailable:
                             noInternetNoAreasView
                         }
                     }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -158,8 +158,10 @@ public struct OfflineMapAreasView: View {
                         switch mapViewModel.mode {
                         case .preplanned:
                             preplannedMapAreasView
-                        case .onDemand, .undetermined:
+                        case .onDemand:
                             onDemandMapAreasView
+                        case .undetermined:
+                            noInternetNoAreasView
                         }
                     }
                 }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapViewModel.swift
@@ -152,7 +152,7 @@ class OfflineMapViewModel: ObservableObject {
                 return
             }
             
-            if !hasAnyPreplannedMapAreas, isShowingOnlyOfflineModels {
+            if isShowingOnlyOfflineModels {
                 // In this case there are no preplanned or on-demand map areas and we can
                 // only show offline models (which there are none) because
                 // there is no internet. In that case we set the mode to

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapViewModel.swift
@@ -112,6 +112,15 @@ class OfflineMapViewModel: ObservableObject {
         
         // Note: We don't reset the mode once it is determined.
         
+        // Before loading models, check if the Internet is available.
+        do {
+            _ = try await offlineMapTask.preplannedMapAreas
+        } catch {
+            if error.isNoInternetConnectionError {
+                return
+            }
+        }
+        
         // First load preplanned map models.
         if mode == .undetermined || mode == .preplanned {
             await loadPreplannedMapModels()
@@ -126,9 +135,12 @@ class OfflineMapViewModel: ObservableObject {
         // undetermined.
         if mode == .undetermined || mode == .onDemand {
             await loadOnDemandMapModels()
-            // If there are any on-demand areas at all, and the mode is
-            // undetermined, then set mode to on-demand.
-            if mode == .undetermined, !onDemandMapModels.isEmpty {
+            // If the mode is undetermined, then set mode to on-demand.
+            // If there are on-demand map areas, the mode should be set to
+            // on-demand. If there are no on-demand map areas, we can assume
+            // that the user started with an empty map and want to add on-demand
+            // map areas.
+            if mode == .undetermined {
                 mode = .onDemand
             }
         }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapViewModel.swift
@@ -146,7 +146,6 @@ class OfflineMapViewModel: ObservableObject {
             // Try to load on-demand map models.
             await loadOnDemandMapModels()
             
-            // Try to load on-demand map models.
             // If there are on-demand areas on device, set mode to on-demand.
             if !onDemandMapModels.isEmpty {
                 mode = .onDemand
@@ -154,7 +153,7 @@ class OfflineMapViewModel: ObservableObject {
             }
             
             if !hasAnyPreplannedMapAreas, isShowingOnlyOfflineModels {
-                // In this case there are no preplanned map areas and we can
+                // In this case there are no preplanned or on-demand map areas and we can
                 // only show offline models (which there are none) because
                 // there is no internet. In that case we set the mode to
                 // `noInternetAvailable`.


### PR DESCRIPTION
## Description

Close #1210 . 

Currently, if a specific set of steps are followed:

1. While online, open the example app.
2. Without opening the Offline Maps/Areas screen, disconnect from the internet.
3. Then open the Offline Maps screen.

It would show the `onDemandMapAreasView` even if the mode for the offline component is undetermined

https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/472d484b0190ce12aa90f76fef800e73873cb5e8/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift#L158-L163

Instead, the user propose to show the `noInternetNoAreasView` when there is no Internet connection.

## Discuss

See some more comment in the code below.