### PR TITLE
`PopupView` - Adjust some fonts

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/PopupElementHeader.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupElementHeader.swift
@@ -27,14 +27,13 @@ struct PopupElementHeader: View {
             if !title.isEmpty {
                 Text(title)
                     .multilineTextAlignment(.leading)
-                    .font(.title2)
                     .foregroundStyle(.primary)
             }
             
             if !description.isEmpty {
                 Text(description)
                     .multilineTextAlignment(.leading)
-                    .font(.subheadline)
+                    .font(.caption2)
                     .foregroundStyle(.secondary)
             }
         }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartMediaView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Charts/ChartMediaView.swift
@@ -67,7 +67,6 @@ struct ChartMediaView: View {
                 popupMedia: popupMedia,
                 isShowingDetailView: $isShowingDetailView
             )
-            .padding()
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/ImageMediaView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/Images/ImageMediaView.swift
@@ -37,7 +37,7 @@ struct ImageMediaView: View {
                     refreshInterval: popupMedia.imageRefreshInterval,
                     mediaSize: mediaSize
                 )
-                    .frame(width: mediaSize.width, height: mediaSize.height)
+                .frame(width: mediaSize.width, height: mediaSize.height)
                 VStack {
                     Spacer()
                     PopupMediaFooter(
@@ -60,7 +60,6 @@ struct ImageMediaView: View {
                     popupMedia: popupMedia,
                     isShowingDetailView: $isShowingDetailView
                 )
-                .padding()
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupMedia/MediaDetailView.swift
@@ -20,67 +20,61 @@ struct MediaDetailView : View {
     let popupMedia: PopupMedia
     
     /// A Boolean value specifying whether the media should be drawn in a larger format.
-    var isShowingDetailView: Binding<Bool>
+    let isShowingDetailView: Binding<Bool>
     
     var body: some View {
-        VStack {
-            HStack {
-                Spacer()
-                Button.done {
-                    isShowingDetailView.wrappedValue = false
-                }
-                .padding([.bottom], 4)
-            }
-            HStack {
-                VStack(alignment: .leading) {
-                    Text(popupMedia.title)
-                        .font(.title2)
-                    Text(popupMedia.caption)
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-            }
-            
-            switch popupMedia.kind {
-            case .image:
-                if let sourceURL = popupMedia.value?.sourceURL {
-                    AsyncImageView(
-                        url: sourceURL,
-                        refreshInterval: popupMedia.imageRefreshInterval
-                    )
-                    .onTapGesture {
-                        if let linkURL = popupMedia.value?.linkURL {
-                            UIApplication.shared.open(linkURL)
+        NavigationStack {
+            VStack {
+                switch popupMedia.kind {
+                case .image:
+                    if let sourceURL = popupMedia.value?.sourceURL {
+                        AsyncImageView(
+                            url: sourceURL,
+                            refreshInterval: popupMedia.imageRefreshInterval
+                        )
+                        .onTapGesture {
+                            if let linkURL = popupMedia.value?.linkURL {
+                                UIApplication.shared.open(linkURL)
+                            }
                         }
-                    }
-                    .hoverEffect()
-                    if popupMedia.value?.linkURL != nil {
-                        HStack {
-                            Text(
-                                "Tap on the image for more information.",
-                                bundle: .toolkitModule,
-                                comment: """
+                        .hoverEffect()
+                        if popupMedia.value?.linkURL != nil {
+                            HStack {
+                                Text(
+                                    "Tap on the image for more information.",
+                                    bundle: .toolkitModule,
+                                    comment: """
                                          A label indicating that tapping an image will reveal
                                          additional information.
                                          """
-                            )
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                            Spacer()
+                                )
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                Spacer()
+                            }
                         }
                     }
+                case .barChart, .columnChart, .pieChart, .lineChart:
+                    ChartView(
+                        popupMedia: popupMedia,
+                        data: ChartData.getChartData(from: popupMedia),
+                        isShowingDetailView: true
+                    )
+                default:
+                    EmptyView()
                 }
-            case .barChart, .columnChart, .pieChart, .lineChart:
-                ChartView(
-                    popupMedia: popupMedia,
-                    data: ChartData.getChartData(from: popupMedia),
-                    isShowingDetailView: true
-                )
-            default:
-                EmptyView()
+                Spacer()
             }
-            Spacer()
+            .padding()
+            .navigationTitle(popupMedia.title, subtitle: popupMedia.caption)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button.done {
+                        isShowingDetailView.wrappedValue = false
+                    }
+                }
+            }
         }
     }
 }

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View+NavigationTitle.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View+NavigationTitle.swift
@@ -60,16 +60,20 @@ extension View {
         _ title: T,
         subtitle: S
     ) -> some View where T: StringProtocol, S: StringProtocol {
+        if !subtitle.isEmpty {
 #if swift(>=6.2) && !os(visionOS)
-        if #available(iOS 26.0, *) {
-            self.navigationTitle(title)
-                .navigationSubtitle(subtitle)
-        } else {
-            self.modifier(NavigationTitleModifier(title: title, subtitle: subtitle))
-        }
+            if #available(iOS 26.0, *) {
+                self.navigationTitle(title)
+                    .navigationSubtitle(subtitle)
+            } else {
+                self.modifier(NavigationTitleModifier(title: title, subtitle: subtitle))
+            }
 #else
-        self.modifier(NavigationTitleModifier(title: title, subtitle: subtitle))
+            self.modifier(NavigationTitleModifier(title: title, subtitle: subtitle))
 #endif
+        } else {
+            self.navigationTitle(title)
+        }
     }
     
     /// Conditionally configures the view’s title for purposes of navigation, using a string.


### PR DESCRIPTION
## Description

This PR adjusts some of the fonts found in the `PopupView` in response to [this feedback](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1222#issuecomment-3089895411):

- `PopupElementHeader` now uses the same fonts as [feature form](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/56d92acefc456fba3ef865d4ae27b5893b1b01da/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift#L80-L89). 
- `MediaPopupElementView` now uses `View.navigationTitle(_:subtitle:)` to get the default styling for its title and subtitle.

## Screenshots

### iPhone

|Before|After|
|:-:|:-:|
| <img width="276" alt="Simulator Screenshot - 1 - iPhone 16 Pro - 2025-07-22 at 12 38 34" src="https://github.com/user-attachments/assets/332e34b3-62bb-4d1b-b29f-838c8fbada5e" /> | <img width="276" alt="Simulator Screenshot - 1 - iPhone 16 Pro - 2025-07-22 at 13 42 41" src="https://github.com/user-attachments/assets/5245cb77-7983-4de1-b426-8a2d7b505510" /> |
| <img width="276" alt="Simulator Screenshot - 1 - iPhone 16 Pro - 2025-07-22 at 12 38 38" src="https://github.com/user-attachments/assets/ba49de15-3e98-4c3e-95fa-65a7cdfd356b" /> | <img width="276" alt="Simulator Screenshot - 1 - iPhone 16 Pro - 2025-07-22 at 13 42 46" src="https://github.com/user-attachments/assets/6c7f0567-68b5-44a6-889c-41f04abd7425" /> |
| <img width="276" alt="Simulator Screenshot - 1 - iPhone 16 Pro - 2025-07-22 at 12 38 43" src="https://github.com/user-attachments/assets/2fb7cfd2-7b3a-4d06-9a1a-018498f37294" /> | <img width="276" alt="Simulator Screenshot - 1 - iPhone 16 Pro - 2025-07-22 at 13 42 50" src="https://github.com/user-attachments/assets/33fefeb8-90ba-42c0-934e-6a8a87e48d39" /> |


### iPad

|Before|After|
|:-:|:-:|
| <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 12 39 14" src="https://github.com/user-attachments/assets/0ab5c754-16b5-493c-982f-fc6caa0dea9a" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 13 45 39" src="https://github.com/user-attachments/assets/bb2a0116-e9a0-4def-b9ce-a2ad7aaf4747" /> |
| <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 12 39 20" src="https://github.com/user-attachments/assets/1b44fcf6-50a6-41f1-abbb-87768d83e261" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 13 45 33" src="https://github.com/user-attachments/assets/02822727-d321-4a63-8080-333d1a29e4c3" /> |
| <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 12 39 26" src="https://github.com/user-attachments/assets/0dc38936-97e9-4f8b-8dc3-e38237660827" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 13 45 42" src="https://github.com/user-attachments/assets/51d86247-8c53-4a3f-a174-91546fa07735" /> |


### Mac Catalyst

|Before|After|
|:-:|:-:|
| <img width="1136" height="892" alt="Screenshot 2025-07-22 at 12 40 21 PM" src="https://github.com/user-attachments/assets/9ff22859-f515-434a-b2bc-ecaf0ccc5c14" /> | <img width="1136" height="892" alt="Screenshot 2025-07-22 at 1 48 52 PM" src="https://github.com/user-attachments/assets/3e8ae3db-e37b-4a41-98f0-20173e8f1ff2" /> |
| <img width="1136" height="892" alt="Screenshot 2025-07-22 at 12 40 29 PM" src="https://github.com/user-attachments/assets/e1c935cd-b7a1-416a-9165-3571d12a93f5" /> | <img width="1136" height="892" alt="Screenshot 2025-07-22 at 1 48 58 PM" src="https://github.com/user-attachments/assets/9175f7e1-b022-4103-99ba-fcb06272f49f" /> |
| <img width="1136" height="892" alt="Screenshot 2025-07-22 at 12 40 35 PM" src="https://github.com/user-attachments/assets/af799f89-8ae3-441e-ba85-def542ce1ab1" /> | <img width="1136" height="892" alt="Screenshot 2025-07-22 at 1 49 05 PM" src="https://github.com/user-attachments/assets/fc64784c-0e82-4d91-9ce5-92026ab057b6" /> |


### Vision Pro

|Before|After|
|:-:|:-:|
| <img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-22 at 12 42 06" src="https://github.com/user-attachments/assets/3bf57d0e-870f-4acf-a08d-b0b5b07eb7ac" /> | <img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-22 at 13 46 37" src="https://github.com/user-attachments/assets/d54b28f6-6b2f-4ba8-8184-4c621172cd45" /> |
| <img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-22 at 12 42 09" src="https://github.com/user-attachments/assets/e4ca3799-400b-4f3b-a50f-31d9fb22d053" /> | <img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-22 at 13 46 40" src="https://github.com/user-attachments/assets/7a8cbcdf-7762-425c-ab28-9ffc42c6ed3a" /> |
| <img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-22 at 12 42 17" src="https://github.com/user-attachments/assets/7c2c544b-b291-49c4-8f1a-20af9c9eabfd" /> | <img width="2732" height="2048" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-22 at 13 46 46" src="https://github.com/user-attachments/assets/f5979c24-ecd3-4d4f-9197-619e8080f404" /> |
