### PR TITLE
`FeatureFormView` - Various fixes

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -17,9 +17,6 @@ import SwiftUI
 
 /// A view displaying a list of attachments in a "carousel", with a thumbnail and title.
 struct AttachmentPreview: View {
-    /// An action which scrolls the Carousel to the front.
-    @Binding var scrollToNewAttachmentAction: (() -> Void)?
-    
     /// The name for the existing attachment being edited.
     @State private var currentAttachmentName = ""
     
@@ -47,6 +44,9 @@ struct AttachmentPreview: View {
     /// A Boolean value which determines if the attachment editing controls should be disabled.
     private let editControlsDisabled: Bool
     
+    /// The last time an attachment was added locally.
+    private let lastAttachmentAdded: Date?
+    
     /// The action to perform when the attachment is deleted.
     private let onDelete: (@MainActor (AttachmentModel) -> Void)?
     
@@ -59,28 +59,23 @@ struct AttachmentPreview: View {
     init(
         attachmentModels: [AttachmentModel],
         editControlsDisabled: Bool = true,
+        lastAttachmentAdded: Date? = nil,
         onRename: (@MainActor (AttachmentModel, String) -> Void)? = nil,
         onDelete: (@MainActor (AttachmentModel) -> Void)? = nil,
-        proposedCellSize: CGSize,
-        scrollToNewAttachmentAction: Binding<(() -> Void)?>
+        proposedCellSize: CGSize
     ) {
         self.attachmentModels = attachmentModels
-        self.proposedCellSize = proposedCellSize
         self.editControlsDisabled = editControlsDisabled
+        self.lastAttachmentAdded = lastAttachmentAdded
         self.onRename = onRename
         self.onDelete = onDelete
-        _scrollToNewAttachmentAction = scrollToNewAttachmentAction
+        self.proposedCellSize = proposedCellSize
     }
     
     var body: some View {
-        Carousel { computedCellSize, scrollToLeftAction in
-            Group {
-                makeCarouselContent(for: computedCellSize)
-                    .transition(.asymmetric(insertion: .slide, removal: .scale))
-            }
-            .onAppear {
-                scrollToNewAttachmentAction = scrollToLeftAction
-            }
+        Carousel(lastScroll: lastAttachmentAdded) { computedCellSize in
+            makeCarouselContent(for: computedCellSize)
+                .transition(.asymmetric(insertion: .slide, removal: .scale))
         }
         .cellBaseWidth(proposedCellSize.width)
     }

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -58,11 +58,11 @@ struct AttachmentPreview: View {
     
     init(
         attachmentModels: [AttachmentModel],
+        proposedCellSize: CGSize,
         editControlsDisabled: Bool = true,
         lastAttachmentAdded: AttachmentModel? = nil,
         onRename: (@MainActor (AttachmentModel, String) -> Void)? = nil,
-        onDelete: (@MainActor (AttachmentModel) -> Void)? = nil,
-        proposedCellSize: CGSize
+        onDelete: (@MainActor (AttachmentModel) -> Void)? = nil
     ) {
         self.attachmentModels = attachmentModels
         self.editControlsDisabled = editControlsDisabled

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -44,8 +44,8 @@ struct AttachmentPreview: View {
     /// A Boolean value which determines if the attachment editing controls should be disabled.
     private let editControlsDisabled: Bool
     
-    /// The last time an attachment was added locally.
-    private let lastAttachmentAdded: Date?
+    /// The last locally added attachment.
+    private let lastAttachmentAdded: AttachmentModel?
     
     /// The action to perform when the attachment is deleted.
     private let onDelete: (@MainActor (AttachmentModel) -> Void)?
@@ -59,7 +59,7 @@ struct AttachmentPreview: View {
     init(
         attachmentModels: [AttachmentModel],
         editControlsDisabled: Bool = true,
-        lastAttachmentAdded: Date? = nil,
+        lastAttachmentAdded: AttachmentModel? = nil,
         onRename: (@MainActor (AttachmentModel, String) -> Void)? = nil,
         onDelete: (@MainActor (AttachmentModel) -> Void)? = nil,
         proposedCellSize: CGSize
@@ -73,11 +73,12 @@ struct AttachmentPreview: View {
     }
     
     var body: some View {
-        Carousel(lastScroll: lastAttachmentAdded) { computedCellSize in
+        Carousel { computedCellSize in
             makeCarouselContent(for: computedCellSize)
                 .transition(.asymmetric(insertion: .slide, removal: .scale))
         }
         .cellBaseWidth(proposedCellSize.width)
+        .leftScrollTrigger(lastAttachmentAdded?.id)
     }
     
     /// - Note: Contextual actions are disabled for empty attachments as deletion and rename

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -58,18 +58,18 @@ struct AttachmentPreview: View {
     
     init(
         attachmentModels: [AttachmentModel],
-        proposedCellSize: CGSize,
         editControlsDisabled: Bool = true,
         lastAttachmentAdded: AttachmentModel? = nil,
         onRename: (@MainActor (AttachmentModel, String) -> Void)? = nil,
-        onDelete: (@MainActor (AttachmentModel) -> Void)? = nil
+        onDelete: (@MainActor (AttachmentModel) -> Void)? = nil,
+        proposedCellSize: CGSize
     ) {
         self.attachmentModels = attachmentModels
+        self.proposedCellSize = proposedCellSize
         self.editControlsDisabled = editControlsDisabled
         self.lastAttachmentAdded = lastAttachmentAdded
         self.onRename = onRename
         self.onDelete = onDelete
-        self.proposedCellSize = proposedCellSize
     }
     
     var body: some View {

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -34,10 +34,10 @@ struct AttachmentsFeatureElementView: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
     
-    /// Scrolls an ``AttachmentPreview`` to the front.
+    /// The last time an attachment was added locally.
     ///
-    /// Call this action when a new attachment is added to make it visible to the user.
-    @State private var scrollToNewAttachmentAction: (() -> Void)?
+    /// Set a new date when an attachment is added to make it visible to the user in the preview area.
+    @State private var lastAttachmentAdded: Date? = nil
     
     /// A Boolean value denoting if the view should be shown as regular width.
     var isRegularWidth: Bool {
@@ -126,10 +126,10 @@ struct AttachmentsFeatureElementView: View {
             AttachmentPreview(
                 attachmentModels: attachmentModels,
                 editControlsDisabled: !isEditable,
+                lastAttachmentAdded: lastAttachmentAdded,
                 onRename: onRename,
                 onDelete: onDelete,
-                proposedCellSize: thumbnailSize,
-                scrollToNewAttachmentAction: $scrollToNewAttachmentAction
+                proposedCellSize: thumbnailSize
             )
         case .auto:
             Group {
@@ -137,10 +137,10 @@ struct AttachmentsFeatureElementView: View {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
                         editControlsDisabled: !isEditable,
+                        lastAttachmentAdded: lastAttachmentAdded,
                         onRename: onRename,
                         onDelete: onDelete,
-                        proposedCellSize: thumbnailSize,
-                        scrollToNewAttachmentAction: $scrollToNewAttachmentAction
+                        proposedCellSize: thumbnailSize
                     )
                 } else {
                     AttachmentList(attachmentModels: attachmentModels)
@@ -176,7 +176,7 @@ struct AttachmentsFeatureElementView: View {
         models.insert(newModel, at: 0)
         withAnimation { attachmentModelsState = .initialized(models) }
         embeddedFeatureFormViewModel?.evaluateExpressions()
-        scrollToNewAttachmentAction?()
+        lastAttachmentAdded = .now
     }
     
     /// Renames the attachment associated with the given model.

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -123,22 +123,22 @@ struct AttachmentsFeatureElementView: View {
         case .preview:
             AttachmentPreview(
                 attachmentModels: attachmentModels,
-                proposedCellSize: thumbnailSize,
                 editControlsDisabled: !isEditable,
                 lastAttachmentAdded: lastAttachmentAdded,
                 onRename: onRename,
-                onDelete: onDelete
+                onDelete: onDelete,
+                proposedCellSize: thumbnailSize
             )
         case .auto:
             Group {
                 if isRegularWidth {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
-                        proposedCellSize: thumbnailSize,
                         editControlsDisabled: !isEditable,
                         lastAttachmentAdded: lastAttachmentAdded,
                         onRename: onRename,
-                        onDelete: onDelete
+                        onDelete: onDelete,
+                        proposedCellSize: thumbnailSize
                     )
                 } else {
                     AttachmentList(attachmentModels: attachmentModels)

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -123,22 +123,22 @@ struct AttachmentsFeatureElementView: View {
         case .preview:
             AttachmentPreview(
                 attachmentModels: attachmentModels,
+                proposedCellSize: thumbnailSize,
                 editControlsDisabled: !isEditable,
                 lastAttachmentAdded: lastAttachmentAdded,
                 onRename: onRename,
-                onDelete: onDelete,
-                proposedCellSize: thumbnailSize
+                onDelete: onDelete
             )
         case .auto:
             Group {
                 if isRegularWidth {
                     AttachmentPreview(
                         attachmentModels: attachmentModels,
+                        proposedCellSize: thumbnailSize,
                         editControlsDisabled: !isEditable,
                         lastAttachmentAdded: lastAttachmentAdded,
                         onRename: onRename,
-                        onDelete: onDelete,
-                        proposedCellSize: thumbnailSize
+                        onDelete: onDelete
                     )
                 } else {
                     AttachmentList(attachmentModels: attachmentModels)

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -34,10 +34,8 @@ struct AttachmentsFeatureElementView: View {
     /// A Boolean value indicating whether the input is editable.
     @State private var isEditable = false
     
-    /// The last time an attachment was added locally.
-    ///
-    /// Set a new date when an attachment is added to make it visible to the user in the preview area.
-    @State private var lastAttachmentAdded: Date? = nil
+    /// The last locally added attachment.
+    @State private var lastAttachmentAdded: AttachmentModel?
     
     /// A Boolean value denoting if the view should be shown as regular width.
     var isRegularWidth: Bool {
@@ -176,7 +174,7 @@ struct AttachmentsFeatureElementView: View {
         models.insert(newModel, at: 0)
         withAnimation { attachmentModelsState = .initialized(models) }
         embeddedFeatureFormViewModel?.evaluateExpressions()
-        lastAttachmentAdded = .now
+        lastAttachmentAdded = newModel
     }
     
     /// Renames the attachment associated with the given model.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
@@ -39,12 +39,14 @@ class EmbeddedFeatureFormViewModel {
     var visibleElements = [FormElement]()
     
     /// The expression evaluation task.
+    @ObservationIgnored
     private var evaluateTask: Task<Void, Never>?
     
     /// The feature form.
     private(set) var featureForm: FeatureForm
     
     /// The group of visibility tasks.
+    @ObservationIgnored
     private var isVisibleTasks = [Task<Void, Never>]()
     
     /// Initializes a form view model.
@@ -64,10 +66,13 @@ class EmbeddedFeatureFormViewModel {
     /// Kick off tasks to monitor `isVisible` for each element.
     @MainActor
     private func initializeIsVisibleTasks() {
+        isVisibleTasks.forEach { $0.cancel() }
+        isVisibleTasks.removeAll()
         for element in featureForm.elements {
-            let newTask = Task {
+            let newTask = Task { [weak self] in
                 for await _ in element.$isVisible {
-                    updateVisibleElements()
+                    guard !Task.isCancelled else { return }
+                    self?.updateVisibleElements()
                 }
             }
             isVisibleTasks.append(newTask)


### PR DESCRIPTION
Apollo 1193

- `EmbeddedFeatureFormViewModel`
  - Fixes a retain cycle that causes the model to outlive the FFV component.
- `Carousel`
  - Revised and simplified to fix a retain cycle that causes `AttachmentModel`s to outlive the FFV component.