### PR TITLE
Update BasemapGalleryViewModelTests.testCase_2_5

### DIFF
--- a/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
@@ -312,7 +312,7 @@ class BasemapGalleryViewModelTests: XCTestCase {
         let items = try await viewModel.$items.dropFirst().first
         let basemapGalleryItems = try XCTUnwrap(items)
         XCTAssertFalse(basemapGalleryItems.isEmpty)
-        XCTAssertEqual(basemapGalleryItems.count, 43)
+        XCTAssertEqual(basemapGalleryItems.count, 42)
         
         try await withThrowingTaskGroup(of: Void.self) { group in
             for index in basemapGalleryItems.indices {


### PR DESCRIPTION
The number of vector basemaps returned by an unauthenticated portal appears to have dropped by 1. 