### PR TITLE
location button: fix build errors on visionOS

### DIFF
--- a/Examples/Examples/LocationButtonExampleView.swift
+++ b/Examples/Examples/LocationButtonExampleView.swift
@@ -33,7 +33,11 @@ struct LocationButtonExampleView: View {
             .locationDisplay(locationDisplay)
             .overlay(alignment: .topTrailing) {
                 LocationButton(locationDisplay: locationDisplay)
+#if os(visionOS)
+                    .autoPanModes([.recenter, .off])
+#else
                     .autoPanModes([.recenter, .compassNavigation, .off])
+#endif
                     .imageScale(.large)
                     .frame(minWidth: 50, minHeight: 50)
                     .background(.thinMaterial)

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -46,11 +46,18 @@ public struct LocationButton: View {
     var buttonIsDisabled: Bool {
         status == .starting || status == .stopping || isPerformingButtonAction
     }
-    
+
+#if os(visionOS)
+    /// The auto-pan modes that are selectable by the user.
+    private(set) var autoPanModes: [LocationDisplay.AutoPanMode] = [
+        .recenter, .off
+    ]
+#else
     /// The auto-pan modes that are selectable by the user.
     private(set) var autoPanModes: [LocationDisplay.AutoPanMode] = [
         .recenter, .compassNavigation, .off
     ]
+#endif
     
     /// Creates a location button with a location display.
     /// - Parameter locationDisplay: The location display that the button will control.

--- a/Tests/ArcGISToolkitTests/LocationButtonTests.swift
+++ b/Tests/ArcGISToolkitTests/LocationButtonTests.swift
@@ -56,12 +56,12 @@ struct LocationButtonTests {
         #expect(button.contextMenuAutoPanOptions == [.off, .recenter])
         
         // Test when `off` is last
-        button = button.autoPanModes([.recenter, .compassNavigation, .off])
-        #expect(button.autoPanModes == [.recenter, .compassNavigation, .off])
+        button = button.autoPanModes([.recenter, .off])
+        #expect(button.autoPanModes == [.recenter, .off])
         // Still `off` because the location display hasn't been started.
         #expect(button.autoPanMode == .off)
         #expect(button.initialAutoPanMode == .recenter)
-        #expect(button.contextMenuAutoPanOptions == [.off, .recenter, .compassNavigation])
+        #expect(button.contextMenuAutoPanOptions == [.off, .recenter])
         // Still `.recenter` because the location display hasn't been started.
     }
     
@@ -89,8 +89,8 @@ struct LocationButtonTests {
         #expect(button.nextAutoPanMode(current: .off, initial: .off) == .recenter)
         
         // Test when `off` is last
-        button = button.autoPanModes([.recenter, .compassNavigation, .navigation, .off])
-        #expect(button.nextAutoPanMode(current: .compassNavigation, initial: .recenter) == .navigation)
+        button = button.autoPanModes([.recenter, .navigation, .off])
+        #expect(button.nextAutoPanMode(current: .navigation, initial: .recenter) == .off)
     }
     
     @Suite
@@ -119,7 +119,7 @@ struct LocationButtonTests {
                 Action(status: .started, autoPanOptions: [.off, .recenter]) == .autoPanCycle
             )
             #expect(
-                Action(status: .started, autoPanOptions: [.off, .recenter, .compassNavigation]) == .autoPanCycle
+                Action(status: .started, autoPanOptions: [.off, .recenter, .navigation]) == .autoPanCycle
             )
             #expect(
                 Action(status: .starting, autoPanOptions: []) == nil

--- a/Tests/ArcGISToolkitTests/LocationButtonTests.swift
+++ b/Tests/ArcGISToolkitTests/LocationButtonTests.swift
@@ -25,12 +25,17 @@ struct LocationButtonTests {
         let button = LocationButton(locationDisplay: locationDisplay)
         
         #expect(button.locationDisplay === locationDisplay)
-        #expect(button.autoPanModes == [.recenter, .compassNavigation, .off])
         #expect(button.status == .stopped)
         #expect(button.autoPanMode == .off)
         #expect(button.buttonIsDisabled == false)
         #expect(button.initialAutoPanMode == .recenter)
+#if os(visionOS)
+        #expect(button.autoPanModes == [.recenter, .off])
+        #expect(button.contextMenuAutoPanOptions == [.off, .recenter])
+#else
+        #expect(button.autoPanModes == [.recenter, .compassNavigation, .off])
         #expect(button.contextMenuAutoPanOptions == [.off, .recenter, .compassNavigation])
+#endif
     }
     
     @Test


### PR DESCRIPTION
## Description

This PR fixes the daily build error caused by visionOS not having compass. Related to #1170 