### PR TITLE
`FeatureFormView` - Fix attachment renaming

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -124,14 +124,8 @@ struct AttachmentPreview: View {
             ),
             isPresented: $renameDialogueIsShowing
         ) {
-            TextField(text: $newAttachmentName) {
-                Text(
-                    "New name",
-                    bundle: .toolkitModule,
-                    comment: "A label in reference to the new name of a file, shown in a file rename interface."
-                )
-            }
-            .autocorrectionDisabled()
+            TextField(String.newName, text: $newAttachmentName)
+                .autocorrectionDisabled()
             Button("Cancel", role: .cancel) { }
             Button("OK") {
                 Task {
@@ -273,6 +267,16 @@ private extension AttachmentPreview.AttachmentCell {
             "Attachments larger than \(attachmentDownloadSizeLimit, format: .byteCount(style: .file)) cannot be downloaded.",
             bundle: .toolkitModule,
             comment: "An error message explaining attachments larger than the provided maximum cannot be downloaded."
+        )
+    }
+}
+
+private extension String {
+    static var newName: Self {
+        .init(
+            localized: "New name",
+            bundle: .toolkitModule,
+            comment: "A label in reference to the new name of a file, shown in a file rename interface."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Utility/Carousel.swift
+++ b/Sources/ArcGISToolkit/Utility/Carousel.swift
@@ -22,7 +22,7 @@ struct Carousel<Content: View>: View {
     @State private var cellSize = CGSize.zero
     
     /// The identifier for the Carousel content.
-    let contentIdentifier = UUID()
+    let contentIdentifier = "content"
     
     /// The content shown in the Carousel.
     let content: (_: CGSize) -> Content

--- a/Test Runner/Test Runner/TestViews/FeatureFormTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureFormTestView.swift
@@ -208,6 +208,7 @@ private extension FeatureFormTestView {
     
     /// The set of all Form View UI test cases.
     var cases: [TestCase] {[
+        .init("testAttachmentRenaming", objectID: 1, portalID: .attachmentMapID),
         .init("testCase_1_1", objectID: 1, portalID: .inputValidationMapID),
         .init("testCase_1_2", objectID: 1, portalID: .inputValidationMapID),
         .init("testCase_1_3", objectID: 1, portalID: .inputValidationMapID),

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -47,6 +47,59 @@ final class FeatureFormViewTests: XCTestCase {
         testCaseButton.tap()
     }
     
+    func testAttachmentRenaming() {
+        let app = XCUIApplication()
+        let attachmentLabel = app.staticTexts["EsriHQ.jpeg"]
+        let formTitle = app.staticTexts["Esri Location"]
+        let nameField = app.textFields["New name"]
+        let okButton = app.buttons["OK"]
+        let activityIndicator = app.activityIndicators.firstMatch
+        let rename = app.buttons["Rename"]
+        let renamedAttachmentLabel = app.staticTexts["\(#function).jpeg"]
+        
+        openTestCase()
+        assertFormOpened(titleElement: formTitle)
+        
+        XCTAssertTrue(
+            activityIndicator.waitForNonExistence(timeout: 5.0),
+            "Attachment loading took longer than 5 seconds."
+        )
+        
+        XCTAssertTrue(
+            attachmentLabel.exists,
+            "The attachment was not present after loading completed."
+        )
+        
+        attachmentLabel.press(forDuration: 1)
+        
+        XCTAssertTrue(
+            rename.waitForExistence(timeout: 1),
+            "The rename button doesn't exist."
+        )
+        
+        rename.tap()
+        
+        XCTAssertTrue(
+            nameField.waitForExistence(timeout: 1),
+            "The name field doesn't exist."
+        )
+        
+        nameField.tap()
+        app.typeText(#function)
+        
+        XCTAssertTrue(
+            okButton.exists,
+            "The OK button doesn't exist."
+        )
+        
+        okButton.tap()
+        
+        XCTAssertTrue(
+            renamedAttachmentLabel.exists,
+            "The attachment was not present after renaming."
+        )
+    }
+    
     // - MARK: Test case 1: Text Box with no hint, no description, value not required
     
     /// Test case 1.1: unfocused and focused state, no value

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -49,13 +49,18 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testAttachmentRenaming() {
         let app = XCUIApplication()
+        let activityIndicator = app.activityIndicators.firstMatch
         let attachmentLabel = app.staticTexts["EsriHQ.jpeg"]
         let formTitle = app.staticTexts["Esri Location"]
         let nameField = app.textFields["New name"]
         let okButton = app.buttons["OK"]
-        let activityIndicator = app.activityIndicators.firstMatch
+#if targetEnvironment(macCatalyst)
+        let rename = app.menuItems["Rename"]
+        let renamedAttachmentLabel = app.staticTexts["EsriHQ\(#function).jpeg"]
+#else
         let rename = app.buttons["Rename"]
         let renamedAttachmentLabel = app.staticTexts["\(#function).jpeg"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -70,7 +75,7 @@ final class FeatureFormViewTests: XCTestCase {
             "The attachment was not present after loading completed."
         )
         
-        attachmentLabel.press(forDuration: 1)
+        attachmentLabel.rightClick()
         
         XCTAssertTrue(
             rename.waitForExistence(timeout: 1),
@@ -95,7 +100,7 @@ final class FeatureFormViewTests: XCTestCase {
         okButton.tap()
         
         XCTAssertTrue(
-            renamedAttachmentLabel.exists,
+            renamedAttachmentLabel.waitForExistence(timeout: 2),
             "The attachment was not present after renaming."
         )
     }


### PR DESCRIPTION
Fixes a regression introduced in #1242 which causes the rename attachment alert dialogue to immediately close when typed into.