### PR TITLE
location button: Remove Swift Algorithms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,6 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0"),
         .package(url: "https://github.com/Esri/arcgis-maps-sdk-swift", .upToNextMinor(from: "200.8.0")),
         .package(url: "https://github.com/swiftlang/swift-markdown.git", .upToNextMinor(from: "0.4.0"))
     ],
@@ -39,7 +38,6 @@ let package = Package(
         .target(
             name: "ArcGISToolkit",
             dependencies: [
-                .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "ArcGIS", package: "arcgis-maps-sdk-swift"),
                 .product(name: "Markdown", package: "swift-markdown")
             ]

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Algorithms
 import ArcGIS
 import CoreLocation
 import SwiftUI

--- a/Sources/ArcGISToolkit/Extensions/Swift/Sequence.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/Sequence.swift
@@ -1,0 +1,39 @@
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extension Sequence {
+    /// Returns a sequence with only the unique elements of this sequence,
+    /// in the order of the first occurrence of each unique element. The method
+    /// is adapted from Swift Algorithms.
+    ///
+    ///     let animals = ["dog", "pig", "cat", "ox", "dog", "cat"]
+    ///     let uniqued = animals.uniqued()
+    ///     print(Array(uniqued))
+    ///     // Prints '["dog", "pig", "cat", "ox"]'
+    ///
+    /// - Returns: A sequence with only the unique elements of this sequence.
+    ///  .
+    /// - Complexity: O(1).
+    @inlinable
+    public func uniqued() -> [Element] where Element: Hashable {
+        var seen: Set<Element> = []
+        var result: [Element] = []
+        for element in self {
+            if seen.insert(element).inserted {
+                result.append(element)
+            }
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Description

There was an issue https://github.com/apple/swift-algorithms/issues/189 with using Swift Algorithms that prevents it from being built when library evolution is enabled. While the issue is being solved by Apple, we need to remove swift-algorithms dependency and add the needed algorithm by hand. The method is adapted from [here](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Unique.swift#L74).

Currently, the toolkit daily build is broken due to this.




