### PR TITLE
Revert #1252

### DIFF
--- a/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
@@ -312,7 +312,7 @@ class BasemapGalleryViewModelTests: XCTestCase {
         let items = try await viewModel.$items.dropFirst().first
         let basemapGalleryItems = try XCTUnwrap(items)
         XCTAssertFalse(basemapGalleryItems.isEmpty)
-        XCTAssertEqual(basemapGalleryItems.count, 42)
+        XCTAssertEqual(basemapGalleryItems.count, 43)
         
         try await withThrowingTaskGroup(of: Void.self) { group in
             for index in basemapGalleryItems.indices {


### PR DESCRIPTION
Reverts Esri/arcgis-maps-sdk-swift-toolkit#1252

The number seems to be back to its previous stable amount. The test design doesn't specify an exact amount, so I figure we _could_ remove this check altogether, but I'll keep it for now. If it goes down again, we can refer to this list to see which is missing:

1. Blueprint
2. Charted Territory Map
3. Colored Pencil Map
4. Community Map
5. Dark Gray Canvas
6. Dark Gray Canvas
7. Enhanced Contrast Dark Map
8. Enhanced Contrast Map
9. Environment Map
10. Firefly Imagery Hybrid
11. Human Geography Dark Map
12. Human Geography Map
13. Imagery
14. Imagery Hybrid
15. Light Gray Canvas
16. Light Gray Canvas
17. Mid-Century Map
18. Modern Antique Map
19. NAIP Imagery Hybrid
20. National Geographic Style Map
21. Navigation
22. Navigation
23. Navigation (Dark)
24. Navigation (Dark)
25. Navigation (Dark - Places)
26. Navigation (Places)
27. Newspaper Map
28. Nova Map
29. Oceans
30. OpenStreetMap
31. OpenStreetMap
32. Outdoor
33. Outline Map
34. Streets
35. Streets
36. Streets (Dark)
37. Streets (Night)
38. Terrain with Labels
39. Topographic
40. Topographic
41. Topographic (Vector)
42. USA Topo Maps
43. USGS National Map