### PR TITLE
localization: Clean up localization entries

### DIFF
--- a/Examples/ExamplesApp/Info.plist
+++ b/Examples/ExamplesApp/Info.plist
@@ -13,6 +13,8 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar</string>
+		<string>bg</string>
+		<string>bs</string>
 		<string>ca</string>
 		<string>cs</string>
 		<string>da</string>
@@ -20,6 +22,7 @@
 		<string>el</string>
 		<string>en</string>
 		<string>es</string>
+		<string>et</string>
 		<string>fi</string>
 		<string>fr</string>
 		<string>he</string>
@@ -29,6 +32,8 @@
 		<string>it</string>
 		<string>ja</string>
 		<string>ko</string>
+		<string>lt</string>
+		<string>lv</string>
 		<string>nb</string>
 		<string>nl</string>
 		<string>pl</string>
@@ -37,6 +42,7 @@
 		<string>ro</string>
 		<string>ru</string>
 		<string>sk</string>
+		<string>sl</string>
 		<string>sv</string>
 		<string>th</string>
 		<string>tr</string>

--- a/OfflineMapAreasExample/OfflineMapAreasExample/Info.plist
+++ b/OfflineMapAreasExample/OfflineMapAreasExample/Info.plist
@@ -6,6 +6,49 @@
 	<array>
 		<string>com.esri.ArcGISToolkit.jobManager.offlineManager.statusCheck</string>
 	</array>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>ar</string>
+		<string>bg</string>
+		<string>bs</string>
+		<string>ca</string>
+		<string>cs</string>
+		<string>da</string>
+		<string>de</string>
+		<string>el</string>
+		<string>en</string>
+		<string>es</string>
+		<string>et</string>
+		<string>fi</string>
+		<string>fr</string>
+		<string>he</string>
+		<string>hr</string>
+		<string>hu</string>
+		<string>id</string>
+		<string>it</string>
+		<string>ja</string>
+		<string>ko</string>
+		<string>lt</string>
+		<string>lv</string>
+		<string>nb</string>
+		<string>nl</string>
+		<string>pl</string>
+		<string>pt-BR</string>
+		<string>pt-PT</string>
+		<string>ro</string>
+		<string>ru</string>
+		<string>sk</string>
+		<string>sl</string>
+		<string>sv</string>
+		<string>th</string>
+		<string>tr</string>
+		<string>uk</string>
+		<string>vi</string>
+		<string>zh-Hans-CN</string>
+		<string>zh-Hans</string>
+		<string>zh-Hant-HK</string>
+		<string>zh-Hant-TW</string>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>


### PR DESCRIPTION
## Description

Close #1259 . Add custom localization entries to use them. There are 40 languages (39 translations + English) so I completed the list. Also notified Vivian to update the list on Developer website at https://developers.arcgis.com/swift/reference/supported-languages/

## Links

- `Sources/ArcGIS/Resources`
- https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/tree/main/Sources/ArcGISToolkit/Resources
- https://developers.arcgis.com/swift/reference/supported-languages/
- #1239 : 39 localized languages