### PR TITLE
Fix usages of LocalizedStringResource.key for localizations

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -305,10 +305,11 @@ public struct OfflineMapAreasView: View {
     
     @ViewBuilder private var noInternetNoAreasView: some View {
         ContentUnavailableView {
-            Label(
-                LocalizedStringResource.noInternetConnectionErrorMessage.key,
-                systemImage: "wifi.exclamationmark"
-            )
+            Label {
+                Text(.noInternetConnectionErrorMessage)
+            } icon: {
+                Image(systemName: "wifi.exclamationmark")
+            }
         } description: {
             Text(noMapAreasErrorMessage)
         } actions: {
@@ -318,7 +319,11 @@ public struct OfflineMapAreasView: View {
     
     @ViewBuilder private var emptyPreplannedOfflineAreasView: some View {
         ContentUnavailableView {
-            Label(noMapAreas.key, systemImage: "arrow.down.circle")
+            Label {
+                Text(noMapAreas)
+            } icon: {
+                Image(systemName: "arrow.down.circle")
+            }
         } description: {
             Text(noOfflineMapAreasMessage)
         } actions: {
@@ -328,7 +333,11 @@ public struct OfflineMapAreasView: View {
     
     @ViewBuilder private var preplannedErrorView: some View {
         ContentUnavailableView {
-            Label(errorFetchingAreas.key, systemImage: "exclamationmark.triangle")
+            Label {
+                Text(errorFetchingAreas)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+            }
         } description: {
             Text(errorFetchingAreasMessage)
         } actions: {
@@ -338,7 +347,11 @@ public struct OfflineMapAreasView: View {
     
     @ViewBuilder private var emptyOnDemandOfflineAreasView: some View {
         ContentUnavailableView {
-            Label(noMapAreas.key, systemImage: "arrow.down.circle")
+            Label {
+                Text(noMapAreas)
+            } icon: {
+                Image(systemName: "arrow.down.circle")
+            }
         } description: {
             Text(emptyOnDemandMessage)
         } actions: {
@@ -359,11 +372,15 @@ public struct OfflineMapAreasView: View {
     }
     
     @ViewBuilder private var offlineDisabledView: some View {
-        ContentUnavailableView(
-            offlineDisabled.key,
-            systemImage: "exclamationmark.triangle",
-            description: Text(offlineDisabledMessage)
-        )
+        ContentUnavailableView {
+            Label {
+                Text(offlineDisabled)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+            }
+        } description: {
+            Text(offlineDisabledMessage)
+        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandConfigurationView.swift
@@ -239,17 +239,25 @@ struct OnDemandConfigurationView: View {
     @ViewBuilder private var failedToLoadView: some View {
         VStack {
             if hasNoInternetConnection {
-                ContentUnavailableView(
-                    LocalizedStringResource.noInternetConnectionErrorMessage.key,
-                    systemImage: "wifi.exclamationmark",
-                    description: Text(cannotDownloadMessage)
-                )
+                ContentUnavailableView {
+                    Label {
+                        Text(.noInternetConnectionErrorMessage)
+                    } icon: {
+                        Image(systemName: "wifi.exclamationmark")
+                    }
+                } description: {
+                    Text(cannotDownloadMessage)
+                }
             } else {
-                ContentUnavailableView(
-                    failedToLoadMessage.key,
-                    systemImage: "exclamationmark.triangle",
-                    description: Text(cannotDownloadMessage)
-                )
+                ContentUnavailableView {
+                    Label {
+                        Text(failedToLoadMessage)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle")
+                    }
+                } description: {
+                    Text(cannotDownloadMessage)
+                }
             }
             Button {
                 Task { await loadMap() }


### PR DESCRIPTION
Close #1260 . When working on #1186 I didn't test if the localization worked. `ContentUnavailableView` has a bit problem and using `LocalizedStringResource` within a `Label` is the most stable approach at this point.