### PR TITLE
offline: Don't use clone as the load status will be cloned

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -181,7 +181,7 @@ public struct OfflineMapAreasView: View {
             // or else the state is lost when backgrounding and foregrounding the application.
             .sheet(isPresented: $isAddingOnDemandArea) {
                 OnDemandConfigurationView(
-                    map: onlineMap.clone(),
+                    map: Map(item: onlineMap.item!),
                     title: mapViewModel.nextOnDemandAreaTitle(),
                     titleIsValidCheck: mapViewModel.isProposeOnDemandAreaTitleUnique(_:)
                 ) {


### PR DESCRIPTION
Close #1233 . Instead of using the clone of the web map, create a new map from the web map's item. This allows the new map to make network request and thus, get the load result be either success or failure.

To test:

Web map item ID: 3da658f2492f4cfd8494970ef489d2c5 ; API key is needed

- [ ] When there is no on-demand area on device, device disconnected, Tap "Add Map Area" will lead to no internet view
- [ ] When there is on-demand area on device, device disconnected, Tap "Add Map Area" will lead to no internet view
- [ ] When the device is connected, the map selector view shows up correctly