### PR TITLE
Use done button extension

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -230,7 +230,7 @@ private extension TextInput {
         var body: some View {
             HStack {
                 FormElementHeader(element: element)
-                Button("Done") {
+                Button.done {
                     dismiss()
                 }
 #if !os(visionOS)


### PR DESCRIPTION
Close #853 . Now all the `Button("Done") { // … }` are replaced by `Button.done { // … }` in the toolkit. The examples and tutorials remain unchanged.