### PR TITLE
offline: Consolidate conditions into mode

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -149,21 +149,17 @@ public struct OfflineMapAreasView: View {
     public var body: some View {
         NavigationStack {
             VStack {
-                if mapViewModel.isLoadingModels {
+                switch mapViewModel.mode {
+                case .notLoaded:
                     ProgressView()
-                } else {
-                    if mapViewModel.mapIsOfflineDisabled {
-                        offlineDisabledView
-                    } else {
-                        switch mapViewModel.mode {
-                        case .preplanned:
-                            preplannedMapAreasView
-                        case .onDemand, .ambiguous:
-                            onDemandMapAreasView
-                        case .noInternetAvailable:
-                            noInternetNoAreasView
-                        }
-                    }
+                case .preplanned:
+                    preplannedMapAreasView
+                case .onDemand, .ambiguous:
+                    onDemandMapAreasView
+                case .noInternetAvailable:
+                    noInternetNoAreasView
+                case .offlineDisabled:
+                    offlineDisabledView
                 }
             }
             #if !os(visionOS)
@@ -230,7 +226,7 @@ public struct OfflineMapAreasView: View {
                     }
                 }
                 .refreshable {
-                    Task { await mapViewModel.loadModels() }
+                    await mapViewModel.loadModels()
                 }
             } else if mapViewModel.isShowingOnlyOfflineModels {
                 // If we have no models and no internet, show a content unavailable view.


### PR DESCRIPTION
## Description

Close #1104. This PR fixes a problem with the `refreshable` modifier. It used to give a console warning:

> Attempting to change the refresh control while it is not idle is strongly discouraged and probably won't work properly.

which indicates that the task in `refreshable` was canceled and destroyed prematurely (or the environment [`RefreshAction`](https://developer.apple.com/documentation/swiftui/refreshaction) was changed in an unexpected way).

Previously, this was mitigated by using an unstructured `Task` block, as its lifespan isn't affected by the view; However, it still leads to the drag-down refresh animation to be cut short.

## Proposed Fix

The root cause of the bug was a messed lifecycle of the `refreshable` task. `isLoadingModels` boolean was immediately set to `true` when the `loadModels()` method is called, causing the progress view to show up and destroy the refreshable modifier. Instead of using a conditional view, i.e.,

```swift
if condA {
    ProgressView()
} else {
    switch mode {
        // cases for various views
    }
}
```

moving everything into the `switch-case` allows the refreshable to stay put while the mode is being determined.

Similarly, I moved the `offlineDisabledView` into the `switch-case`. It doesn't have to be moved but I figured why not - now all views are tidily nested under the same level.

## To Discuss

- With the changes, the UI behavior is different

Previously, whenever we pull to refresh, the progress view will be there for the entire time of `loadModels()`. Now, it only appears on the first method call. Is it OK?

- Instead of moving progress view into `switch-case`, an alternative is to move it to an `overlay`. Do you prefer this approach?