### PR TITLE
Update BasemapGalleryViewModelTests.swift

### DIFF
--- a/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/BasemapGalleryViewModelTests.swift
@@ -274,7 +274,6 @@ class BasemapGalleryViewModelTests: XCTestCase {
         let items = try await viewModel.$items.dropFirst().first
         let basemapGalleryItems = try XCTUnwrap(items)
         XCTAssertFalse(basemapGalleryItems.isEmpty)
-        XCTAssertEqual(basemapGalleryItems.count, 37)
         
         try await withThrowingTaskGroup(of: Void.self) { group in
             for index in basemapGalleryItems.indices {
@@ -312,7 +311,6 @@ class BasemapGalleryViewModelTests: XCTestCase {
         let items = try await viewModel.$items.dropFirst().first
         let basemapGalleryItems = try XCTUnwrap(items)
         XCTAssertFalse(basemapGalleryItems.isEmpty)
-        XCTAssertEqual(basemapGalleryItems.count, 43)
         
         try await withThrowingTaskGroup(of: Void.self) { group in
             for index in basemapGalleryItems.indices {


### PR DESCRIPTION
Removes assertions from two BasemapGalleryViewModelTests that aren't in the test designs.