### PR TITLE
Update UtilityAssociationResultLabel

### DIFF
--- a/Sources/ArcGISToolkit/Common/UtilityAssociationsElement/UtilityAssociationResultLabel.swift
+++ b/Sources/ArcGISToolkit/Common/UtilityAssociationsElement/UtilityAssociationResultLabel.swift
@@ -74,7 +74,7 @@ private extension UtilityAssociationResult {
             if associatedFeatureIsToElement {
                 if association.containmentIsVisible {
                     return Text(
-                        "Visible Content",
+                        "Visible: true",
                         bundle: .toolkitModule,
                         comment:
                             """
@@ -84,7 +84,7 @@ private extension UtilityAssociationResult {
                     )
                 } else {
                     return Text(
-                        "Content",
+                        "Visible: false",
                         bundle: .toolkitModule,
                         comment:
                             """

--- a/Sources/ArcGISToolkit/Common/UtilityAssociationsElement/UtilityAssociationResultLabel.swift
+++ b/Sources/ArcGISToolkit/Common/UtilityAssociationsElement/UtilityAssociationResultLabel.swift
@@ -114,13 +114,6 @@ private extension UtilityAssociationResult {
             return nil
         }
     }
-    
-    @ViewBuilder
-    var fractionAlongEdge: Text? {
-        if association.kind == .junctionEdgeObjectConnectivityMidspan {
-            Text(association.fractionAlongEdge, format: .percent)
-        }
-    }
 }
 
 private extension UtilityAssociation.Kind {

--- a/Sources/ArcGISToolkit/Common/UtilityAssociationsElement/UtilityAssociationResultLabel.swift
+++ b/Sources/ArcGISToolkit/Common/UtilityAssociationsElement/UtilityAssociationResultLabel.swift
@@ -24,7 +24,6 @@ struct UtilityAssociationResultLabel: View {
         HStack {
             result.association.kind.icon
                 .accessibilityIdentifier("Association Result Icon")
-            
             VStack(alignment: .leading) {
                 Text(result.title)
                     .lineLimit(4)
@@ -37,12 +36,7 @@ struct UtilityAssociationResultLabel: View {
                         .lineLimit(1)
                 }
             }
-            
             Spacer()
-            
-            result.fractionAlongEdge
-                .font(.caption2)
-                .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("Association Result")
@@ -65,9 +59,31 @@ private extension UtilityAssociationResult {
     var details: Text? {
         switch association.kind {
         case .connectivity, .junctionEdgeObjectConnectivityFromSide, .junctionEdgeObjectConnectivityMidspan, .junctionEdgeObjectConnectivityToSide:
+            var terminalName: String? = nil
+            var fractionAlongEdge: Double? = nil
             if let terminal = associatedElement.terminal, !terminal.name.isEmpty {
-                return Text(terminal.name)
-            } else {
+                terminalName = terminal.name
+            }
+            if association.kind == .junctionEdgeObjectConnectivityMidspan {
+                fractionAlongEdge = association.fractionAlongEdge
+            }
+            switch (terminalName, fractionAlongEdge) {
+            case let (.some(name), .none):
+                return Text(name)
+            case let (.none, .some(fraction)):
+                return Text(fraction, format: .percent)
+            case let (.some(name), .some(fraction)):
+                return Text(
+                    "\(name), \(fraction, format: .percent)",
+                    bundle: .toolkitModule,
+                    comment: """
+                        A label with the name of a terminal on an associated
+                        utility element (first variable) and a fractional value
+                        (second variable) indicating the relative location along
+                        an edge where a utility association is (logically) located.
+                        """
+                )
+            case (.none, .none):
                 return nil
             }
         case .containment:
@@ -76,8 +92,7 @@ private extension UtilityAssociationResult {
                     return Text(
                         "Visible: true",
                         bundle: .toolkitModule,
-                        comment:
-                            """
+                        comment: """
                             A label indicating a utility association's 
                             containment is visible.
                             """
@@ -86,8 +101,7 @@ private extension UtilityAssociationResult {
                     return Text(
                         "Visible: false",
                         bundle: .toolkitModule,
-                        comment:
-                            """
+                        comment: """
                             A label indicating a utility association's 
                             containment is not visible.
                             """

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/* A label with the name of a terminal on an associated
+utility element (first variable) and a fractional value
+(second variable) indicating the relative location along
+an edge where a utility association is (logically) located. */
+"%@, %@" = "%@, %@";
+
 /* A label declaring the number of starting points selected for a utility network trace. */
 "%lld selected" = "%lld selected";
 

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -126,10 +126,6 @@ second being a corresponding cardinal direction (north, northeast,
 east, etc.). */
 "Compass, heading %lld degrees %@" = "Compass, heading %lld degrees %@";
 
-/* A label indicating a utility association's 
-containment is not visible. */
-"Content" = "Content";
-
 /* Continent (Level of Detail) */
 "Continent" = "Continent";
 
@@ -719,8 +715,12 @@ The first and second parameter hold the minimum and maximum values respectively.
 "View" = "View";
 
 /* A label indicating a utility association's 
+containment is not visible. */
+"Visible: false" = "Visible: false";
+
+/* A label indicating a utility association's 
 containment is visible. */
-"Visible Content" = "Visible Content";
+"Visible: true" = "Visible: true";
 
 /* World (Level of Detail) */
 "World" = "World";

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1547,7 +1547,7 @@ final class FeatureFormViewTests: XCTestCase {
         let filterResults = app.staticTexts["Content"]
         let formTitle = app.staticTexts["Structure Boundary"]
         let networkSourceGroupButton = app.buttons["Electric Distribution Device, 1"]
-        let utilityElementButton = app.buttons["Circuit Breaker, Content"]
+        let utilityElementButton = app.buttons["Circuit Breaker, Visible: false"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)

--- a/Test Runner/UI Tests/PopupViewTests.swift
+++ b/Test Runner/UI Tests/PopupViewTests.swift
@@ -528,7 +528,7 @@ final class PopupViewTests: XCTestCase {
             associationResultDescription.exists,
             "The result description doesn't exist."
         )
-        XCTAssertEqual(associationResultDescription.firstMatch.label, "Content")
+        XCTAssertEqual(associationResultDescription.firstMatch.label, "Visible: false")
     }
     
     /// Verifies that the `UtilityAssociationsPopupElement.displayCount` is respected.


### PR DESCRIPTION
Related Apollo 1342, #1288 

Currently, the fractional value is shown in the trailing position. The design spec has been updated to move it into the detail line to accommodate the new association details button when used in FeatureFormViews.

The spec for displaying content visibility was also changed in the re-design.