### PR TITLE
Fix duplicated string keys

### DIFF
--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -99,9 +99,12 @@ public struct Compass: View {
                 .accessibilityAddTraits(.isButton)
                 .accessibilityLabel(
                     Text(
-                        "Compass",
-                        bundle: .toolkitModule,
-                        comment: "The accessibility label of the compass component."
+                        LocalizedStringResource(
+                            "compass-button-label",
+                            defaultValue: "Compass",
+                            bundle: .toolkit,
+                            comment: "The accessibility label of the compass button."
+                        )
                     )
                 )
                 .accessibilityValue(

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -404,9 +404,12 @@ private extension LocationDisplay.AutoPanMode {
             )
         case .compassNavigation:
             Text(
-                "Compass",
-                bundle: .toolkitModule,
-                comment: "The label text for choosing the 'compass navigation' auto-pan mode in the location button context menu."
+                LocalizedStringResource(
+                    "compass-navigation-label",
+                    defaultValue: "Compass",
+                    bundle: .toolkit,
+                    comment: "The label text for choosing the 'compass navigation' auto-pan mode in the location button context menu."
+                )
             )
         case .navigation:
             Text(

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -142,12 +142,14 @@ for the AR experience. */
 /* A label in reference to the color used to display utility trace result graphics. */
 "Color" = "Color";
 
-/* The accessibility label of the compass component.
-The label text for choosing the 'compass navigation' auto-pan mode in the location button context menu. */
-"Compass" = "Compass";
-
 /* The accessibility value of the location button when the auto-pan mode is compass navigation. */
 "Compass navigation" = "Compass navigation";
+
+/* The accessibility label of the compass button. */
+"compass-button-label" = "Compass";
+
+/* The label text for choosing the 'compass navigation' auto-pan mode in the location button context menu. */
+"compass-navigation-label" = "Compass";
 
 /* Continent (Level of Detail) */
 "Continent" = "Continent";


### PR DESCRIPTION
Addresses @philium's [feedback](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1291#discussion_r2323832767) to remove duplicated localized string key definitions.