### PR TITLE
`FeatureFormView` - Remove unused `EmbeddedFeatureFormViewModel` properties

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
@@ -26,9 +26,6 @@ class EmbeddedFeatureFormViewModel {
         }
     }
     
-    /// The currently presented feature form view.
-    var presentedForm: FeatureFormView?
-    
     /// The set of all elements which previously held focus.
     var previouslyFocusedElements = [FormElement]()
     
@@ -54,7 +51,7 @@ class EmbeddedFeatureFormViewModel {
     private var evaluateTask: Task<Void, Never>?
     
     /// The feature form.
-    private(set) var featureForm: FeatureForm
+    let featureForm: FeatureForm
     
     /// The group of visibility tasks.
     @ObservationIgnored


### PR DESCRIPTION
### Description

This PR updates `EmbeddedFeatureFormViewModel` to remove an unused property, `presentedForm`, and the  `featureForm` setter, since it is only ever set in the model's initializer.

### How To Test

Ensure the package still builds.
