### PR TITLE
`Bookmarks`: Remove unused `viewpoint` property

### DIFF
--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -56,9 +56,6 @@ public struct Bookmarks: View {
     /// The selected bookmark.
     private var selection: Binding<Bookmark?>
     
-    /// If non-`nil`, this viewpoint is updated when a bookmark is selected.
-    private var viewpoint: Binding<Viewpoint?>?
-    
     public var body: some View {
         VStack {
             BookmarksHeader(isPresented: $isPresented)
@@ -142,8 +139,6 @@ extension Bookmarks {
             Task {
                 await geoViewProxy.setViewpoint(viewpoint, duration: nil)
             }
-        } else if let viewpoint {
-            viewpoint.wrappedValue = bookmark.viewpoint
         }
     }
     


### PR DESCRIPTION
This PR removes the `Bookmarks.viewpoint` property that is no longer used since the viewpoint initializers were removed in #1285. The package, examples, and tests still build.