### PR TITLE
Repair `FeatureFormViewTests.testAttachmentRenaming()`

### DIFF
--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -47,12 +47,11 @@ final class FeatureFormViewTests: XCTestCase {
         let formTitle = app.staticTexts["Esri Location"]
         let nameField = app.textFields["New name"]
         let okButton = app.buttons["OK"]
+        let renamedAttachmentLabel = app.staticTexts["EsriHQ\(#function).jpeg"]
 #if targetEnvironment(macCatalyst)
         let rename = app.menuItems["Rename"]
-        let renamedAttachmentLabel = app.staticTexts["EsriHQ\(#function).jpeg"]
 #else
         let rename = app.buttons["Rename"]
-        let renamedAttachmentLabel = app.staticTexts["\(#function).jpeg"]
 #endif
         
         openTestCase()


### PR DESCRIPTION
This test started consistently failing on Sept 23. 

I'm not sure exactly why the behavior changed suddenly, but it seems like the text in the rename dialogue is no longer highlighted on presentation and fully-replaced.