### PR TITLE
`FeatureFormView` - Support adding utility network associations (Part 2)

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -134,6 +134,16 @@ public struct FeatureFormView: View {
                         switch itemType {
                         case let .form(form):
                             EmbeddedFeatureFormView(featureForm: form)
+                        case let .utilityAssociationAssetTypesView(embeddedFeatureFormViewModel, element, filter, source):
+                            UtilityAssociationAssetTypesView(
+                                element: element,
+                                embeddedFeatureFormViewModel: embeddedFeatureFormViewModel,
+                                filter: filter,
+                                source: source
+                            )
+                            .featureFormToolbar(embeddedFeatureFormViewModel.featureForm)
+                            .navigationBarTitleDisplayMode(.inline)
+                            .navigationTitle(source.name)
                         case let .utilityAssociationCreationView(embeddedFeatureFormViewModel, candidate, element, filter):
                             UtilityAssociationCreationView(candidate: candidate, element: element, embeddedFeatureFormViewModel: embeddedFeatureFormViewModel, filter: filter)
                                 .featureFormToolbar(embeddedFeatureFormViewModel.featureForm)
@@ -148,8 +158,9 @@ public struct FeatureFormView: View {
                             )
                             .featureFormToolbar(embeddedFeatureFormViewModel.featureForm)
                             .navigationBarTitleDisplayMode(.inline)
-                        case let .utilityAssociationFeatureCandidatesView(embeddedFeatureFormViewModel, element, filter, source):
+                        case let .utilityAssociationFeatureCandidatesView(embeddedFeatureFormViewModel, element, filter, source, assetType):
                             UtilityAssociationFeatureCandidatesView(
+                                assetType: assetType,
                                 element: element,
                                 embeddedFeatureFormViewModel: embeddedFeatureFormViewModel,
                                 filter: filter,
@@ -157,7 +168,7 @@ public struct FeatureFormView: View {
                             )
                             .featureFormToolbar(embeddedFeatureFormViewModel.featureForm)
                             .navigationBarTitleDisplayMode(.inline)
-                            .navigationTitle(source.name)
+                            .navigationTitle(assetType.name)
                         case let .utilityAssociationFeatureSourcesView(embeddedFeatureFormViewModel, element, filter):
                             UtilityAssociationFeatureSourcesView(
                                 element: element,

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/NavigationPathItem.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/NavigationPathItem.swift
@@ -17,9 +17,10 @@ import ArcGIS
 extension FeatureFormView {
     enum NavigationPathItem: Hashable {
         case form(FeatureForm)
+        case utilityAssociationAssetTypesView(EmbeddedFeatureFormViewModel, UtilityAssociationsFormElement, UtilityAssociationsFilter, UtilityAssociationFeatureSource)
         case utilityAssociationCreationView(EmbeddedFeatureFormViewModel, UtilityAssociationFeatureCandidate, UtilityAssociationsFormElement, UtilityAssociationsFilter)
         case utilityAssociationDetailsView(EmbeddedFeatureFormViewModel, AssociationsFilterResultsModel, UtilityAssociationsFormElement, UtilityAssociationResult)
-        case utilityAssociationFeatureCandidatesView(EmbeddedFeatureFormViewModel, UtilityAssociationsFormElement, UtilityAssociationsFilter, UtilityAssociationFeatureSource)
+        case utilityAssociationFeatureCandidatesView(EmbeddedFeatureFormViewModel, UtilityAssociationsFormElement, UtilityAssociationsFilter, UtilityAssociationFeatureSource, UtilityAssetType)
         case utilityAssociationFeatureSourcesView(EmbeddedFeatureFormViewModel, UtilityAssociationsFormElement, UtilityAssociationsFilter)
         case utilityAssociationFilterResultView(EmbeddedFeatureFormViewModel, AssociationsFilterResultsModel, UtilityAssociationsFormElement, String)
         case utilityAssociationGroupResultView(EmbeddedFeatureFormViewModel, AssociationsFilterResultsModel, UtilityAssociationsFormElement, String, String)
@@ -28,6 +29,11 @@ extension FeatureFormView {
             switch (lhs, rhs) {
             case let (.form(a), .form(b)):
                 a === b
+            case let (.utilityAssociationAssetTypesView(_, elementA, filterA, sourceA),
+                      .utilityAssociationAssetTypesView(_, elementB, filterB, sourceB)):
+                elementA === elementB
+                && filterA === filterB
+                && sourceA === sourceB
             case let (.utilityAssociationCreationView(_, candidateA, elementA, filterA),
                       .utilityAssociationCreationView(_, candidateB, elementB, filterB)):
                 candidateA === candidateB
@@ -37,8 +43,8 @@ extension FeatureFormView {
                       .utilityAssociationDetailsView(_, _, elementB, resultB)):
                 elementA === elementB
                 && resultA === resultB
-            case let (.utilityAssociationFeatureCandidatesView(_, elementA, filterA, sourceA),
-                      .utilityAssociationFeatureCandidatesView(_, elementB, filterB, sourceB)):
+            case let (.utilityAssociationFeatureCandidatesView(_, elementA, filterA, sourceA, _),
+                      .utilityAssociationFeatureCandidatesView(_, elementB, filterB, sourceB, _)):
                 elementA === elementB
                 && filterA === filterB
                 && sourceA === sourceB
@@ -65,6 +71,10 @@ extension FeatureFormView {
             switch self {
             case let .form(form):
                 hasher.combine(ObjectIdentifier(form))
+            case let .utilityAssociationAssetTypesView(_, element, filter, source):
+                hasher.combine(element)
+                hasher.combine(ObjectIdentifier(filter))
+                hasher.combine(ObjectIdentifier(source))
             case let .utilityAssociationCreationView(_, candidate, element, filter):
                 hasher.combine(ObjectIdentifier(candidate))
                 hasher.combine(element)
@@ -72,7 +82,7 @@ extension FeatureFormView {
             case let .utilityAssociationDetailsView(_, _, element, result):
                 hasher.combine(element)
                 hasher.combine(ObjectIdentifier(result))
-            case let .utilityAssociationFeatureCandidatesView(_, element, filter, source):
+            case let .utilityAssociationFeatureCandidatesView(_, element, filter, source, _):
                 hasher.combine(element)
                 hasher.combine(ObjectIdentifier(filter))
                 hasher.combine(ObjectIdentifier(source))

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationCreationView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationCreationView.swift
@@ -35,6 +35,10 @@ extension FeatureFormView {
         @State private var options: UtilityAssociationFeatureOptions? = nil
         /// A Boolean value which indicates when the configured association is being added.
         @State private var isAddingAssociation = false
+        /// The terminal selection for the "from" side of the association.
+        @State private var terminalForFromSide: UtilityTerminal? = nil
+        /// The terminal selection for the "to" side of the association.
+        @State private var terminalForToSide: UtilityTerminal? = nil
         
         /// The candidate feature for the new association to be created.
         let candidate: UtilityAssociationFeatureCandidate
@@ -56,6 +60,12 @@ extension FeatureFormView {
             .alert(isPresented: $alertIsPresented, error: addAssociationError) {}
             .task {
                 options = try? await element.options(forAssociationCandidate: candidate.feature)
+                terminalForFromSide = candidateIsToElement
+                ? options?.formFeatureTerminalConfiguration?.terminals.first
+                : options?.candidateFeatureTerminalConfiguration?.terminals.first
+                terminalForToSide = candidateIsToElement
+                ? options?.candidateFeatureTerminalConfiguration?.terminals.first
+                : options?.formFeatureTerminalConfiguration?.terminals.first
             }
             .task(id: isAddingAssociation) {
                 guard isAddingAssociation else { return }
@@ -72,14 +82,30 @@ extension FeatureFormView {
         func addAssociation() async {
             guard let options else { return }
             do {
-                // TODO: (Ref: Apollo 1368) Use addAssociation(feature:featureTerminal:filter: currentFeatureTerminal:) when neither formFeatureTerminalConfiguration and candidateFeatureTerminalConfiguration are null
-                // TODO: (Ref: Apollo 1368) Use addAssociation(feature:filter:fractionAlongEdge:terminal:) when when isFractionAlongEdgeValid AND either formFeatureTerminalConfiguration is set or candidateFeatureTerminalConfiguration is set; but not both.
                 if includeContentVisibility {
                     try await element.addAssociation(feature: candidate.feature, filter: filter, isContainmentVisible: contentIsVisible)
-                } else if options.isFractionAlongEdgeValid {
-                    try await element.addAssociation(feature: candidate.feature, filter: filter, fractionAlongEdge: fractionAlongEdge)
                 } else {
-                    try await element.addAssociation(feature: candidate.feature, filter: filter)
+                    switch (options.isFractionAlongEdgeValid, terminalForFromSide, terminalForToSide) {
+                    case let (true, .some(terminal), .none):
+                        try await element.addAssociation(feature: candidate.feature, filter: filter, fractionAlongEdge: fractionAlongEdge, terminal: terminal)
+                    case let (true, .none, .some(terminal)):
+                        try await element.addAssociation(feature: candidate.feature, filter: filter, fractionAlongEdge: fractionAlongEdge, terminal: terminal)
+                    case (true, .none, .none):
+                        try await element.addAssociation(feature: candidate.feature, filter: filter, fractionAlongEdge: fractionAlongEdge)
+                    case (false, .some, .some):
+                        try await element.addAssociation(
+                            feature: candidate.feature,
+                            featureTerminal: candidateIsToElement
+                            ? terminalForToSide
+                            : terminalForFromSide,
+                            filter: filter,
+                            currentFeatureTerminal: candidateIsToElement
+                            ? terminalForFromSide
+                            : terminalForToSide
+                        )
+                    default:
+                        try await element.addAssociation(feature: candidate.feature, filter: filter)
+                    }
                 }
                 // Bug: Path removal is known to fail if a searchable was
                 // focused in any intermediate path items. Avoid using
@@ -95,8 +121,8 @@ extension FeatureFormView {
         
         /// A Boolean value indicating whether the candidate feature is on the "to" side of the new association.
         ///
-        /// - Note: For connectivity filters, "From" and "To" doesn't have a strong meaning but we
-        /// consider the candidate as "To" anyway.
+        /// - Note: For connectivity filters, "from" and "to" doesn't have a strong meaning but we
+        /// consider the candidate as "to" anyway.
         var candidateIsToElement: Bool {
             switch filter.kind {
             case .attachment, .connectivity, .content:
@@ -167,7 +193,16 @@ extension FeatureFormView {
                 } label: {
                     Text.fromElement
                 }
-                // TODO: (Ref: Apollo 1368) Add terminal configuration settings depending on value of formFeatureTerminalConfiguration and candidateFeatureTerminalConfiguration
+                if let configuration = candidateIsToElement ? options?.formFeatureTerminalConfiguration : options?.candidateFeatureTerminalConfiguration {
+                    Picker(selection: $terminalForFromSide) {
+                        ForEach(configuration.terminals) {
+                            Text($0.name)
+                                .tag($0)
+                        }
+                    } label: {
+                        Text.terminal
+                    }
+                }
             }
         }
         
@@ -179,7 +214,16 @@ extension FeatureFormView {
                 } label: {
                     Text.toElement
                 }
-                // TODO: (Ref: Apollo 1368) Add terminal configuration settings depending on value of formFeatureTerminalConfiguration and candidateFeatureTerminalConfiguration
+                if let configuration = candidateIsToElement ? options?.candidateFeatureTerminalConfiguration : options?.formFeatureTerminalConfiguration {
+                    Picker(selection: $terminalForToSide) {
+                        ForEach(configuration.terminals) {
+                            Text($0.name)
+                                .tag($0)
+                        }
+                    } label: {
+                        Text.terminal
+                    }
+                }
             }
         }
         

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationCreationView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationCreationView.swift
@@ -107,12 +107,19 @@ extension FeatureFormView {
                         try await element.addAssociation(feature: candidate.feature, filter: filter)
                     }
                 }
+                // After the association is created, remove the creation
+                // workflow views from the navigation path. This includes:
+                //  1. UtilityAssociationCreationView
+                //  2. UtilityAssociationFeatureCandidatesView
+                //  3. UtilityAssociationAssetTypesView
+                //  4. UtilityAssociationFeatureSourcesView
+                //
                 // Bug: Path removal is known to fail if a searchable was
                 // focused in any intermediate path items. Avoid using
-                // View.searchable(text:placement:prompt:) in intermediate
+                // View.searchable(text:placement:prompt:) in these intermediate
                 // views to avoid errors here. (FB20395585)
                 // https://developer.apple.com/forums/thread/802221#802221021
-                navigationPath?.wrappedValue.removeLast(3)
+                navigationPath?.wrappedValue.removeLast(4)
             } catch {
                 addAssociationError = .anyError(error)
                 alertIsPresented = true

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationDetailsView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationDetailsView.swift
@@ -59,11 +59,7 @@ extension FeatureFormView {
             LabeledContent {
                 Text(terminal.name)
             } label: {
-                Text(
-                    "Terminal",
-                    bundle: .toolkitModule,
-                    comment: "A label in reference to a utility terminal."
-                )
+                Text.terminal
             }
         }
         

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationFeatureCandidatesView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationFeatureCandidatesView.swift
@@ -23,6 +23,8 @@ extension FeatureFormView {
         /// The phrase used to filter candidates by name.
         @State private var filterPhrase = ""
         
+        /// The asset type to use when querying for feature candidates.
+        let assetType: UtilityAssetType
         /// The element to add the new association to.
         let element: UtilityAssociationsFormElement
         /// The model for the feature form containing the element to add the association to.
@@ -75,7 +77,7 @@ extension FeatureFormView {
             .task {
                 let parameters = QueryParameters()
                 parameters.whereClause = "1=1"
-                candidates = (try? await source.queryFeatures(parameters: parameters).candidates) ?? []
+                candidates = (try? await source.queryFeatures(assetType: assetType, parameters: parameters).candidates) ?? []
             }
         }
         

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
@@ -92,6 +92,15 @@ extension Text {
         )
     }
     
+    /// Localized text for the word "Terminal".
+    static var terminal: Self {
+        .init(
+            "Terminal",
+            bundle: .toolkitModule,
+            comment: "A label in reference to a utility terminal."
+        )
+    }
+    
     /// Localized text for the phrase "To Element".
     static var toElement: Self {
         .init(

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -77,6 +77,11 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A label indicating authentication is required to proceed. */
 "Authentication Required" = "Authentication Required";
 
+/* A section header label in reference to the asset
+types available to use when querying for utility
+association feature candidates. */
+"Available Asset Types" = "Available Asset Types";
+
 /* A generic label for navigating to the previous screen or returning to the previous context. */
 "Back" = "Back";
 
@@ -356,6 +361,10 @@ trace operation. */
 
 /* A label for a text entry field that allows the user to filter a list of values by name. */
 "Filter" = "Filter";
+
+/* A label for a search field to filter utility 
+asset types by name. */
+"Filter asset types by name" = "Filter asset types by name";
 
 /* A label for a search field to filter utility 
 association candidate features by name. */


### PR DESCRIPTION
Ref Apollo 1443

Follow-up to #1177 to use latest API revisions for utility association creation.

- Adds asset type selection into the workflow.
- Adds terminal selection on the "from" and "to" elements.