### PR TITLE
AttachmentPhotoPicker: Remove Sendable conformance

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentPhotoPicker.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentPhotoPicker.swift
@@ -53,5 +53,3 @@ struct AttachmentPhotoPicker: ViewModifier {
             }
     }
 }
-
-extension PhotosPickerItem: @unchecked Swift.Sendable {}


### PR DESCRIPTION
This type seems to have been annotated as Sendable in SwiftUI/PhotosUI, so remove our conformance to get rid of the warning.

See the type's [doc](https://developer.apple.com/documentation/photosui/photospickeritem#conforms-to).

<img width="1474" height="108" alt="Screenshot 2025-10-01 at 3 24 04 PM" src="https://github.com/user-attachments/assets/f4314a06-f5eb-493d-9949-c69105f0ed26" />
<img width="1110" height="140" alt="Screenshot 2025-10-01 at 3 23 16 PM" src="https://github.com/user-attachments/assets/78145726-14f7-445e-87ca-aeed1c18a22b" />

Tested on Xcode 16.4 and 26.0.1 without warning.