### PR TITLE
Fix `Sequence.uniqued()` access level and doc

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/Swift/Sequence.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/Sequence.swift
@@ -23,10 +23,10 @@ extension Sequence {
     ///     // Prints '["dog", "pig", "cat", "ox"]'
     ///
     /// - Returns: A sequence with only the unique elements of this sequence.
-    ///  .
-    /// - Complexity: O(1).
+    ///
+    /// - Complexity: O(*n*), where *n* is the length of the sequence.
     @inlinable
-    public func uniqued() -> [Element] where Element: Hashable {
+    func uniqued() -> [Element] where Element: Hashable {
         var seen: Set<Element> = []
         var result: [Element] = []
         for element in self {


### PR DESCRIPTION
### Description

This PR makes `Sequence.uniqued()` internal instead of public, since it was only intended to be used with the `LocationButton` (see #1266). It also fixes the "Complexity" doc, which should be O(n) (see [swift-algorithms/Unique.swift#L113](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Unique.swift#L113)).