### PR TITLE
Allow PKI challenges during oauth web view challenges

### DIFF
--- a/AuthenticationExample/AuthenticationExample/Info.plist
+++ b/AuthenticationExample/AuthenticationExample/Info.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar</string>

--- a/AuthenticationExample/AuthenticationExample/Info.plist
+++ b/AuthenticationExample/AuthenticationExample/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar</string>

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -99,6 +99,10 @@ public final class Authenticator: ObservableObject {
     /// The current challenge.
     /// This property is not set for OAuth challenges.
     @Published var currentChallenge: ChallengeContinuation?
+    
+    /// A Boolean value indicating if an OAuth challenge is currently being
+    /// handled.
+    @Published var isHandlingOAuthChallenge = false
 }
 
 extension Authenticator: ArcGISAuthenticationChallengeHandler {
@@ -136,6 +140,8 @@ extension Authenticator: ArcGISAuthenticationChallengeHandler {
             }
             
             do {
+                isHandlingOAuthChallenge = true
+                defer { isHandlingOAuthChallenge = false }
                 return .continueWithCredential(try await OAuthUserCredential.credential(for: configuration))
             } catch is CancellationError {
                 // If user cancels the creation of OAuth user credential then catch the
@@ -181,12 +187,6 @@ extension Authenticator: NetworkAuthenticationChallengeHandler {
             return .rejectProtectionSpace
         }
         
-        if challenge.kind == .clientCertificate {
-            if (try? await challenge.isOptional) ?? false {
-                return .continueWithoutCredential
-            }
-        }
-        
         let challengeContinuation = NetworkChallengeContinuation(networkChallenge: challenge)
         
         // Alleviates an error with "already presenting".
@@ -198,56 +198,5 @@ extension Authenticator: NetworkAuthenticationChallengeHandler {
         
         // Wait for it to complete and return the resulting disposition.
         return await challengeContinuation.value
-    }
-}
-
-private extension NetworkAuthenticationChallenge {
-    /// Determines if a network authentication challenge is optional,
-    /// meaning that the request will succeed if you continue without a
-    /// credential.
-    var isOptional: Bool {
-        get async throws {
-            final class Delegate: NSObject, URLSessionDataDelegate {
-                func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-                    print("-- challenge received: \(challenge.protectionSpace)")
-                    if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-                       let serverTrust = challenge.protectionSpace.serverTrust {
-                        completionHandler(
-                            URLSession.AuthChallengeDisposition.useCredential,
-                            URLCredential(trust: serverTrust)
-                        )
-                    } else {
-                        completionHandler(URLSession.AuthChallengeDisposition.performDefaultHandling, nil)
-                    }
-                }
-            }
-            
-            guard let url = failureResponse?.url ?? protectionSpace.url else { return false }
-            let session = URLSession(configuration: .ephemeral)
-            do {
-                var request = URLRequest(url: url)
-                request.httpMethod = "HEAD"
-                let (_, response) = try await session.data(for: request, delegate: Delegate())
-                if let response = response as? HTTPURLResponse, response.statusCode == 200 {
-                    return true
-                }
-                return false
-            } catch {
-                return false
-            }
-        }
-    }
-}
-
-private extension URLProtectionSpace {
-    /// A url for the protection space.
-    var url: URL? {
-//        URL(string: "https://rt-saml2.esri.com/portal")!
-        let protocolString = `protocol` ?? "https"
-        var urlString = "\(protocolString)://\(host)"
-        if port != 0 && port != 80 && port != 443 {
-            urlString += ":\(port)"
-        }
-        return URL(string: urlString)
     }
 }

--- a/Sources/ArcGISToolkit/Components/Authentication/AuthenticatorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/AuthenticatorModifier.swift
@@ -38,8 +38,14 @@ private struct AuthenticatorOverlayModifier: ViewModifier {
             content
             Color.clear
                 .frame(width: 0, height: 0)
-                .modifier(AuthenticatorModifier(authenticator: authenticator, showsNestedChallenges: false))
-                ._oAuthWebViewSheet(contentModifier: AuthenticatorModifier(authenticator: authenticator, showsNestedChallenges: true))
+                .modifier(AuthenticatorModifier(authenticator: authenticator))
+                ._oAuthWebViewSheet(
+                    contentModifier: AuthenticatorModifier(
+                        authenticator: authenticator,
+                        showsNestedChallenges: true,
+                        allowSkippingCertificateChallenges: true
+                    )
+                )
         }
     }
 }
@@ -49,7 +55,10 @@ private struct AuthenticatorModifier: ViewModifier {
     @ObservedObject var authenticator: Authenticator
     /// A Boolean value indicating if challenges that arrive during the handling
     /// of an OAuth challenge are to be shown.
-    let showsNestedChallenges: Bool
+    var showsNestedChallenges: Bool = false
+    
+    /// A Boolean value indicating if certificate challenges can be skipped.
+    var allowSkippingCertificateChallenges: Bool = false
     
     @ViewBuilder func body(content: Content) -> some View {
         if !showsNestedChallenges && authenticator.isHandlingOAuthChallenge {
@@ -63,7 +72,7 @@ private struct AuthenticatorModifier: ViewModifier {
                 case .serverTrust:
                     content.modifier(TrustHostViewModifier(challenge: challenge))
                 case .certificate:
-                    content.modifier(CertificatePickerViewModifier(challenge: challenge))
+                    content.modifier(CertificatePickerViewModifier(challenge: challenge, showsSkipButton: allowSkippingCertificateChallenges))
                 case .login:
                     content.modifier(LoginViewModifier(challenge: challenge))
                 }

--- a/Sources/ArcGISToolkit/Components/Authentication/AuthenticatorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/AuthenticatorModifier.swift
@@ -42,8 +42,7 @@ private struct AuthenticatorOverlayModifier: ViewModifier {
                 ._oAuthWebViewSheet(
                     contentModifier: AuthenticatorModifier(
                         authenticator: authenticator,
-                        showsNestedChallenges: true,
-                        allowSkippingCertificateChallenges: true
+                        showsNestedChallenges: true
                     )
                 )
         }
@@ -57,9 +56,6 @@ private struct AuthenticatorModifier: ViewModifier {
     /// of an OAuth challenge are to be shown.
     var showsNestedChallenges: Bool = false
     
-    /// A Boolean value indicating if certificate challenges can be skipped.
-    var allowSkippingCertificateChallenges: Bool = false
-    
     @ViewBuilder func body(content: Content) -> some View {
         if !showsNestedChallenges && authenticator.isHandlingOAuthChallenge {
             content
@@ -72,7 +68,7 @@ private struct AuthenticatorModifier: ViewModifier {
                 case .serverTrust:
                     content.modifier(TrustHostViewModifier(challenge: challenge))
                 case .certificate:
-                    content.modifier(CertificatePickerViewModifier(challenge: challenge, showsSkipButton: allowSkippingCertificateChallenges))
+                    content.modifier(CertificatePickerViewModifier(challenge: challenge))
                 case .login:
                     content.modifier(LoginViewModifier(challenge: challenge))
                 }

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -110,6 +110,11 @@ import UniformTypeIdentifiers
         challenge.resume(with: .cancel)
     }
     
+    /// Continue challenge without credential.
+    func continueWithoutCredential() {
+        challenge.resume(with: .continueWithoutCredential)
+    }
+    
     private func showCertificateError(_ error: CertificateError) {
         certificateError = error
         showCertificateError = true
@@ -235,57 +240,73 @@ private extension View {
         viewModel: CertificatePickerViewModel
     ) -> some View {
         sheet(isPresented: isPresented) {
-            VStack(alignment: .center) {
-                Text(
-                    "Certificate Required",
-                    bundle: .toolkitModule,
-                    comment: "A label indicating that a certificate is required to proceed."
-                )
-                .font(.title)
-                .multilineTextAlignment(.center)
-                .padding(.vertical)
-                Text(
-                    "A certificate is required to access content on \(viewModel.challengingHost).",
-                    bundle: .toolkitModule,
-                    comment: """
+            NavigationStack {
+                VStack(alignment: .center) {
+                    Text(
+                        "A certificate is required to access content on \(viewModel.challengingHost).",
+                        bundle: .toolkitModule,
+                        comment: """
                              An alert message indicating that a certificate is required to access
                              content on a remote host. The variable is the host that prompted the challenge.
                              """
-                )
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.bottom)
-                HStack {
-                    Spacer()
-                    Button(role: .cancel) {
-                        isPresented.wrappedValue = false
-                        viewModel.cancel()
-                    } label: {
-                        Text.cancel
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom)
+                    HStack {
+                        Spacer()
+                        Button {
+                            isPresented.wrappedValue = false
+                            viewModel.continueWithoutCredential()
+                        } label: {
+                            Text(
+                                "Skip",
+                                bundle: .toolkitModule,
+                                comment: "A label indicating that a challenge should be skipped."
+                            )
                             .padding(.horizontal)
+                        }
+                        .buttonStyle(.bordered)
+                        Spacer()
+                        
+                        Button {
+                            isPresented.wrappedValue = false
+                            viewModel.proceedToPicker()
+                        } label: {
+                            Text(
+                                "Browse",
+                                bundle: .toolkitModule,
+                                comment: "A label for a button to open the system file browser."
+                            )
+                            .padding(.horizontal)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        Spacer()
                     }
-                    .buttonStyle(.bordered)
-                    Spacer()
-                    Button(role: .cancel) {
-                        isPresented.wrappedValue = false
-                        viewModel.proceedToPicker()
-                    } label: {
-                        Text(
-                            "Browse",
-                            bundle: .toolkitModule,
-                            comment: "A label for a button to open the system file browser."
-                        )
-                        .padding(.horizontal)
-                    }
-                    .buttonStyle(.borderedProminent)
                     Spacer()
                 }
-                Spacer()
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(role: .cancel) {
+                            isPresented.wrappedValue = false
+                            viewModel.cancel()
+                        } label: {
+                            Text.cancel
+                        }
+                    }
+                }
+                .navigationTitle(
+                    String(
+                        localized: "Certificate Required",
+                        bundle: .toolkitModule,
+                        comment: "A label indicating that a certificate is required to proceed."
+                    )
+                )
+                .interactiveDismissDisabled()
+                .presentationDetents([.medium])
+                .padding()
             }
-            .interactiveDismissDisabled()
-            .presentationDetents([.medium])
-            .padding()
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -168,16 +168,12 @@ extension CertificatePickerViewModel.CertificateError: LocalizedError {
 struct CertificatePickerViewModifier: ViewModifier {
     /// Creates a certificate picker view modifier.
     /// - Parameter challenge: The challenge that requires a certificate.
-    init(challenge: NetworkChallengeContinuation, showsSkipButton: Bool) {
+    init(challenge: NetworkChallengeContinuation) {
         viewModel = CertificatePickerViewModel(challenge: challenge)
-        self.showsSkipButton = showsSkipButton
     }
     
     /// The view model.
     @ObservedObject private var viewModel: CertificatePickerViewModel
-    
-    /// Whether or not the skip button is shown.
-    private let showsSkipButton: Bool
     
     func body(content: Content) -> some View {
         content
@@ -190,7 +186,6 @@ struct CertificatePickerViewModifier: ViewModifier {
             }
             .promptBrowseCertificate(
                 isPresented: $viewModel.showPrompt,
-                showsSkipButton: showsSkipButton,
                 viewModel: viewModel
             )
             .certificateFilePicker(
@@ -242,7 +237,6 @@ private extension View {
     ///   - viewModel: The view model associated with the view.
     @MainActor @ViewBuilder func promptBrowseCertificate(
         isPresented: Binding<Bool>,
-        showsSkipButton: Bool,
         viewModel: CertificatePickerViewModel
     ) -> some View {
         sheet(isPresented: isPresented) {
@@ -262,21 +256,19 @@ private extension View {
                     .padding(.bottom)
                     HStack {
                         Spacer()
-                        if showsSkipButton {
-                            Button {
-                                isPresented.wrappedValue = false
-                                viewModel.continueWithoutCredential()
-                            } label: {
-                                Text(
-                                    "Skip",
-                                    bundle: .toolkitModule,
-                                    comment: "A label indicating that a challenge should be skipped."
-                                )
-                                .padding(.horizontal)
-                            }
-                            .buttonStyle(.bordered)
-                            Spacer()
+                        Button {
+                            isPresented.wrappedValue = false
+                            viewModel.continueWithoutCredential()
+                        } label: {
+                            Text(
+                                "Ignore",
+                                bundle: .toolkitModule,
+                                comment: "A label indicating that a challenge should be ignored."
+                            )
+                            .padding(.horizontal)
                         }
+                        .buttonStyle(.bordered)
+                        Spacer()
                         
                         Button {
                             isPresented.wrappedValue = false

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -168,12 +168,16 @@ extension CertificatePickerViewModel.CertificateError: LocalizedError {
 struct CertificatePickerViewModifier: ViewModifier {
     /// Creates a certificate picker view modifier.
     /// - Parameter challenge: The challenge that requires a certificate.
-    init(challenge: NetworkChallengeContinuation) {
+    init(challenge: NetworkChallengeContinuation, showsSkipButton: Bool) {
         viewModel = CertificatePickerViewModel(challenge: challenge)
+        self.showsSkipButton = showsSkipButton
     }
     
     /// The view model.
     @ObservedObject private var viewModel: CertificatePickerViewModel
+    
+    /// Whether or not the skip button is shown.
+    private let showsSkipButton: Bool
     
     func body(content: Content) -> some View {
         content
@@ -186,6 +190,7 @@ struct CertificatePickerViewModifier: ViewModifier {
             }
             .promptBrowseCertificate(
                 isPresented: $viewModel.showPrompt,
+                showsSkipButton: showsSkipButton,
                 viewModel: viewModel
             )
             .certificateFilePicker(
@@ -237,6 +242,7 @@ private extension View {
     ///   - viewModel: The view model associated with the view.
     @MainActor @ViewBuilder func promptBrowseCertificate(
         isPresented: Binding<Bool>,
+        showsSkipButton: Bool,
         viewModel: CertificatePickerViewModel
     ) -> some View {
         sheet(isPresented: isPresented) {
@@ -256,19 +262,21 @@ private extension View {
                     .padding(.bottom)
                     HStack {
                         Spacer()
-                        Button {
-                            isPresented.wrappedValue = false
-                            viewModel.continueWithoutCredential()
-                        } label: {
-                            Text(
-                                "Skip",
-                                bundle: .toolkitModule,
-                                comment: "A label indicating that a challenge should be skipped."
-                            )
-                            .padding(.horizontal)
+                        if showsSkipButton {
+                            Button {
+                                isPresented.wrappedValue = false
+                                viewModel.continueWithoutCredential()
+                            } label: {
+                                Text(
+                                    "Skip",
+                                    bundle: .toolkitModule,
+                                    comment: "A label indicating that a challenge should be skipped."
+                                )
+                                .padding(.horizontal)
+                            }
+                            .buttonStyle(.bordered)
+                            Spacer()
                         }
-                        .buttonStyle(.bordered)
-                        Spacer()
                         
                         Button {
                             isPresented.wrappedValue = false


### PR DESCRIPTION
swift 7358

- Now supports challenges while an oauth web view is showing.
- Adds an "Ignore" button which does a "continue without credential" on the challenge
- ~~Ignore button only shown for PKI challenges during an OAuth workflow (this can easily be changed to always show the Skip button)~~
- This allows SAML+PKI to work, along with other workflows
- Note: The UI with the ignore button does not look great. Follow up PR [here](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1312) which provides a more standardized look and feel.


UPDATE: Button verbiage has been changed from "Skip" to "Ignore". And ignore button will show for any PKI challenge now.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ad903cbf-7678-4548-9650-d9c534948256" />