### PR TITLE
AR: Fix `ARCoachingOverlay` safe area for iOS 26

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -141,6 +141,7 @@ public struct TableTopSceneView: View {
                         .sessionProvider(arViewProxy)
                         .active(coachingOverlayIsActive)
                         .allowsHitTesting(false)
+                        .ignoresSafeArea()
                         .overlay (alignment: .top) {
                             if !helpText.isEmpty {
                                 Text(helpText)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -133,6 +133,7 @@ public struct GeoTrackingSceneView: View {
                         arViewProxy.session.run(configuration, options: .resetTracking)
                     }
                     .allowsHitTesting(false)
+                    .ignoresSafeArea()
             }
 #endif
         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -141,6 +141,7 @@ struct WorldTrackingSceneView: View {
                         }
                     }
                     .allowsHitTesting(false)
+                    .ignoresSafeArea()
             }
         }
         .observingInterfaceOrientation($interfaceOrientation)


### PR DESCRIPTION
Related to `swift/7444`

Fixes a UI issue in iOS 26 where the `ARCoachingOverlay` does not extend into the safe area.