### PR TITLE
CredentialInputView: Sheet -> Alert

### DIFF
--- a/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
+++ b/Sources/ArcGISToolkit/Utility/CredentialInputView.swift
@@ -119,7 +119,6 @@ struct CredentialInputModifier: ViewModifier {
                         .padding(.horizontal)
                 }
                 .disabled(!isContinueEnabled)
-                
             } message: {
                 Text(message)
             }


### PR DESCRIPTION
Follow up to #1312 

Note: I also can confirm that the alerts work with other alerts, but the current sheet does not. It will get dismissed without responding to the challenge and result in a deadlocked challenge queue.

|   | Sheet | Alert iOS 26 | Alert iOS 18 |
| :--- | :---: | :---: | :---: |
| Credential Input | <img width="300" alt="image" src="https://github.com/user-attachments/assets/7a0f44ed-7416-419c-b683-1d68cb7179c3" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/a437acfa-5c5e-49d0-8e86-195b31afce50" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/5f307157-8337-49c1-8a3d-a26c993111c1" /> |

