### PR TITLE
Apply feedback on server trust alert so it is in line with HIG

### DIFF
--- a/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/TrustHostViewModifier.swift
@@ -41,18 +41,18 @@ struct TrustHostViewModifier: ViewModifier {
             }
             .alert(
                 String(
-                    localized: "Certificate Trust Warning",
+                    localized: "Cannot Verify Server Identity",
                     bundle: .toolkitModule,
                     comment: "A label indicating that the remote host's certificate is not trusted."
                 ),
                 isPresented: $isPresented,
                 actions: {
-                    Button(role: .destructive) {
+                    Button {
                         isPresented = false
                         challenge.resume(with: .continueWithCredential(.serverTrust))
                     } label: {
                         Text(
-                            "Allow",
+                            "Continue",
                             bundle: .toolkitModule,
                             comment: "A button indicating the user accepts a potentially dangerous action."
                         )
@@ -66,7 +66,7 @@ struct TrustHostViewModifier: ViewModifier {
                 },
                 message: {
                     Text(
-                        "Dangerous: The certificate provided by '\(challenge.host)' is not signed by a trusted authority.",
+                        "The identity of \"\(challenge.host)\" cannot be verified. Would you like to connect anyway?",
                         bundle: .toolkitModule,
                         comment: "A warning that the host service (challenge.host) is providing a potentially unsafe certificate."
                     )


### PR DESCRIPTION
Address feedback from @PeggyDu09 [here](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1312#issuecomment-3444397219).

- Changed title, message, button text
- Made "Continue" button non destructive

My question is, since I changed "Allow" to "Continue" does that mean I can make the button "destructive" again?

|   | Before | After |
| :--- | :---: | :---: |
| Server Trust | <img width="300" alt="image" src="https://github.com/user-attachments/assets/a2408884-1693-41b7-adef-14fe507e25db" /> | <img width="300" height="1525" alt="image" src="https://github.com/user-attachments/assets/95cc54f8-078f-4d5b-9acc-285f011882cd" /> |
