### PR TITLE
Fix timing issue with navigation path

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationGroupResultView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationGroupResultView.swift
@@ -77,7 +77,7 @@ extension FeatureFormView {
                     subtitle: featureFormViewModel.getModel(form)?.title ?? ""
                 )
                 .onChange(of: associationResults.count) {
-                    if associationResults.isEmpty {
+                    if associationResults.isEmpty, !featureFormViewModel.navigationPath.isEmpty {
                         featureFormViewModel.navigationPath.removeLast()
                     }
                 }


### PR DESCRIPTION
There was a crash when closing the feature form after UNA editing. Adding a check to verify the `navigationPath` was not empty fixed it. If you put break statements in while debugging when the `navigationPath` changed, the crash didn't happen; nor did it crash if you manually backed out to the main FF view.

<img width="613" height="136" alt="image" src="https://github.com/user-attachments/assets/56a045ba-e8a3-4cfd-b7b8-1b8697460fd0" />

Crash happened on line 81 because the `navigationPath` was empty.
