### PR TITLE
Don't show UNA "Locate" button if feature has no geometry

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
@@ -38,8 +38,6 @@ extension FeatureFormView {
                         Image(systemName: "scope")
                     }
                 }
-            } else {
-                EmptyView()
             }
         }
     }


### PR DESCRIPTION
Apollo #1467

When viewing or adding associated elements, do not show the locate button if the feature (actually the feature's table) doesn't support geometries (i.e., non-spatial data).

Viewing associations:
| Before | After |
|----------|--------|
|<img width="237" height="177" alt="image" src="https://github.com/user-attachments/assets/b1e595e3-73d3-4dee-b6e7-e531e5f59119" />|<img width="249" height="136" alt="image" src="https://github.com/user-attachments/assets/84f753fa-1fb0-467b-95ed-2c1f29c86686" />|

Adding associations:

| Before | After |
|----------|--------|
|<img width="232" height="185" alt="image" src="https://github.com/user-attachments/assets/55580ac2-c0ff-4323-bd79-8e0513546bc1" />|<img width="246" height="216" alt="image" src="https://github.com/user-attachments/assets/125d0bb0-b653-499b-bc3a-8322b491d8cd" />|
