### PR TITLE
Use different method to hide the "Locate" button

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
@@ -23,8 +23,7 @@ extension FeatureFormView {
         let feature: ArcGISFeature
         
         var body: some View {
-            if let table = feature.table,
-               table.hasGeometry {
+            if feature.geometry != nil {
                 Button {
                     onFormEditingEventAction?(.showOnMapRequested(feature))
                 } label: {


### PR DESCRIPTION
Puneet suggesting using a check for `geometry != nil` instead of checking the table's `hasGeometry` property. The thought was this will also catch the case where a spatial feature's geometry was `nil`.

Follow up to Apollo 1467.