### PR TITLE
`AttachmentsFeatureElementView` - Fix cancellation error on initial load

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -50,6 +50,8 @@ struct AttachmentsFeatureElementView: View {
         case initializing
         /// Attachments have been fetched and wrapped with models.
         case initialized([AttachmentModel])
+        /// Attachments failed to load.
+        case loadFailed
     }
     
     /// The current state of the attachment models.
@@ -85,6 +87,7 @@ struct AttachmentsFeatureElementView: View {
                             attachments = try await featureElement.featureAttachments
                         } catch {
                             Logger.attachmentsFeatureElementView.error("Attachments failed load. \(error.localizedDescription)")
+                            attachmentModelsState = .loadFailed
                             return
                         }
                         let attachmentModels = attachments
@@ -114,6 +117,12 @@ struct AttachmentsFeatureElementView: View {
                     }
                     .disclosureGroupPadding()
                 }
+            case .loadFailed:
+                Text(
+                    "Attachments failed to load.",
+                    bundle: .toolkitModule,
+                    comment: "The status text when attachments failed to load."
+                )
             }
         }
         .onAttachmentIsEditableChange(of: featureElement) { newIsEditable in

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -65,6 +65,9 @@ content on a remote host. The variable is the host that prompted the challenge. 
 /* A label in reference to attachments. */
 "Attachments" = "Attachments";
 
+/* The status text when attachments failed to load. */
+"Attachments failed to load." = "Attachments failed to load.";
+
 /* An error message explaining attachments larger than the provided maximum cannot be downloaded. */
 "Attachments larger than %@ cannot be downloaded." = "Attachments larger than %@ cannot be downloaded.";
 


### PR DESCRIPTION
Fixes a cancellation error on initial load of `AttachmentsFeatureElementView`.

Originating report: https://community.esri.com/t5/swift-maps-sdk-questions/popupview-does-not-display-attachments-if-outside/m-p/1666246