### PR TITLE
Fix warning in `AttachmentCameraControllerTests`

### DIFF
--- a/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
+++ b/Test Runner/UI Tests/AttachmentCameraControllerTests.swift
@@ -22,9 +22,13 @@ final class AttachmentCameraControllerTests: XCTestCase {
     
     /// Test `AttachmentCameraController.onCameraCaptureModeChanged(perform:)`
     func testOnCameraCaptureModeChanged() throws {
+        let isUnsupportedEnvironment: Bool
 #if targetEnvironment(simulator) || targetEnvironment(macCatalyst)
-        throw XCTSkip("This test intended for iOS devices only.")
+        isUnsupportedEnvironment = true
+#else
+        isUnsupportedEnvironment = false
 #endif
+        try XCTSkipIf(isUnsupportedEnvironment, "This test intended for iOS devices only.")
         
         guard #available(iOS 26.0, *) else {
             throw XCTSkip("Unsupported iOS version")


### PR DESCRIPTION
Fixes a warning when running UI tests on a simulator by reverting a change made in #1344:

<img width="973" height="62" alt="Screenshot 2026-01-07 at 2 48 23 PM" src="https://github.com/user-attachments/assets/f03611e8-b0f7-410d-a40f-66532eeef445" />
