### PR TITLE
Increase timeout on flaky test

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationCreationView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationCreationView.swift
@@ -124,7 +124,9 @@ extension FeatureFormView {
                 // View.searchable(text:placement:prompt:) in these intermediate
                 // views to avoid errors here. (FB20395585)
                 // https://developer.apple.com/forums/thread/802221#802221021
-                featureFormViewModel.navigationPath.removeLast(4)
+                await MainActor.run {
+                    featureFormViewModel.navigationPath.removeLast(4)
+                }
             } catch let error as ArcGIS.InvalidArgumentError {
                 addAssociationError = .other(error.details)
                 alertIsPresented = true


### PR DESCRIPTION
FeatureFormViewTest 13.1 has failed several times in the last few weeks, all with the error `The network source group "Electric Distribution Device" doesn't exist`. This increases the timeout to help fix the flaky test.