### PR TITLE
`FeatureFormView` - Use `DismissButton` in more inputs

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
@@ -193,18 +193,9 @@ extension ComboBoxInput {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
+                    DismissButton(kind: .confirm) {
                         isPresented = false
-                    } label: {
-                        Text.done
-                            .fontWeight(.semibold)
-#if !os(visionOS)
-                            .foregroundStyle(Color.accentColor)
-#endif
                     }
-#if !os(visionOS)
-                    .buttonStyle(.plain)
-#endif
                 }
             }
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -252,27 +252,25 @@ private extension TextInput {
         let embeddedFeatureFormViewModel: EmbeddedFeatureFormViewModel
         
         var body: some View {
-            HStack {
-                FormElementHeader(element: element)
-                Button.done {
-                    dismiss()
-                }
-#if !os(visionOS)
-                .buttonStyle(.plain)
-                .foregroundStyle(Color.accentColor)
-#endif
+            NavigationStack {
+                TextEditor(text: $text)
+                    .focused($isFocused)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .navigationTitle(element.label)
+                    .onAppear {
+                        isFocused = true
+                    }
+                    .onChange(of: isFocused) {
+                        embeddedFeatureFormViewModel.focusedElement = isFocused ? element : nil
+                    }
+                    .scrollContentBackground(.hidden)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            DismissButton(kind: .confirm)
+                        }
+                    }
+                FormElementFooter(element: element)
             }
-            TextEditor(text: $text)
-                .focused($isFocused)
-                .onAppear {
-                    isFocused = true
-                }
-                .onChange(of: isFocused) {
-                    embeddedFeatureFormViewModel.focusedElement = isFocused ? element : nil
-                }
-                .scrollContentBackground(.hidden)
-            Spacer()
-            FormElementFooter(element: element)
         }
     }
 }


### PR DESCRIPTION
Addresses feedback in Apollo 332

## ComboBoxInput

### iOS
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/7dede9b2-9245-4557-ae75-6184a9942e27"> | <img src="https://github.com/user-attachments/assets/38b4023f-2bf4-484f-afeb-f491309b4f6b"> |

### Mac Catalyst
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/17cac6ee-c11a-41d5-9412-ae3bc6156d6d"> | <img src="https://github.com/user-attachments/assets/4996cec0-df43-4a36-ab1a-ac9e85a5f59a"> |

### visionOS
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/f65b09e5-f6d4-4f87-8cac-2b294a72923f"> | <img src="https://github.com/user-attachments/assets/7fd1e29a-c476-48b3-b3c2-b6db08562bc4"> |

## TextInput

### iOS
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/71427ce6-fc20-4a3c-a8a2-3a622649c7be"> | <img src="https://github.com/user-attachments/assets/886f1ab3-4331-4fac-94d5-be0e3d71463e"> |

### Mac Catalyst
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/5cd35112-ab02-41b7-94c7-0522a6e89453"> | <img src="https://github.com/user-attachments/assets/f3d3aa6d-4842-41cc-969e-8502ca7c9ecf"> |

### visionOS
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/696ad0dd-cf94-4165-a174-2257f8621049"> | <img src="https://github.com/user-attachments/assets/c26eb035-e2a0-4a51-b6f8-38441c4e3082"> |