### PR TITLE
`FeatureFormView`: Fix `EditingEvent` doc

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -309,18 +309,20 @@ public struct FeatureFormView: View {
 
 public extension FeatureFormView {
     /// Represents events that occur during the form editing lifecycle.
-    /// These events notify you when the user has either saved or discarded their edits.
+    /// These events notify you when the user has performed an action within the form.
     /// - Since: 200.8
     enum EditingEvent {
         /// Indicates that the user has discarded their edits.
         /// - Parameter willNavigate: A Boolean value indicating whether the view will navigate after discarding.
         case discardedEdits(willNavigate: Bool)
         /// The view presented in the view changed.
+        /// - Since: 300.0
         case navigationChanged(NavigationPathItem)
         /// Indicates that the user has saved their edits.
         /// - Parameter willNavigate: A Boolean value indicating whether the view will navigate after saving.
         case savedEdits(willNavigate: Bool)
         /// Indicates that the user has tapped on an option to visualize a feature on the map.
+        /// - Since: 300.0
         case showOnMapRequested(ArcGISFeature)
     }
     


### PR DESCRIPTION
### Description

This PR fixes some issues with the `FeatureFormView.EditingEvent` doc that I noticed. I wasn't sure what to change the second sentence in the description to now that `navigationChanged(NavigationPathItem)` and `showOnMapRequested(ArcGISFeature)` have been added, so please let me know if you have any better ideas.

Related to:
- #1317
