### PR TITLE
`FeatureFormView` - Stabilize test case 6.2

### DIFF
--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1287,7 +1287,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         // Confirm the option to show the elements exists.
         XCTAssertTrue(
-            radioButtonPicker.exists,
+            radioButtonPicker.waitForExistence(timeout: 5),
             "The Radio Button picker doesn't exist."
         )
         

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1292,14 +1292,14 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
 #if !os(visionOS)
+        radioButtonPicker.adjust(toPickerWheelValue: "Everything is working great")
+        radioButtonPicker.adjust(toPickerWheelValue: "Everything could be working greater")
+        radioButtonPicker.adjust(toPickerWheelValue: "Its good Enough!")
+        radioButtonPicker.adjust(toPickerWheelValue: "Show Group Visible Dependent")
         radioButtonPicker.adjust(toPickerWheelValue: "show invisible form element")
 #endif
         
-#if targetEnvironment(simulator)
-        XCTExpectFailure("The Radio Button picker fails to take the \"show invisible form element\" selection.")
-#endif
-        
-        // Confirm the first element of the conditional group doesn't exist.
+        // Confirm the first element of the conditional group exists.
         XCTAssertTrue(
             groupElement.exists,
             "The first group element doesn't exist."

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1287,7 +1287,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         // Confirm the option to show the elements exists.
         XCTAssertTrue(
-            radioButtonPicker.waitForExistence(timeout: 5),
+            radioButtonPicker.exists,
             "The Radio Button picker doesn't exist."
         )
         
@@ -1301,7 +1301,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         // Confirm the first element of the conditional group exists.
         XCTAssertTrue(
-            groupElement.exists,
+            groupElement.waitForExistence(timeout: 5),
             "The first group element doesn't exist."
         )
     }


### PR DESCRIPTION
Since #1349 was merged, this test has been a bit flaky. 

The test needs to select the last element in the picker and I believe it may be falling out of the accessibility hierarchy in some conditions. Stepping through each of the picker's values seems to be much more reliable; it's passed 100/100 times on the daily test runner device.