### PR TITLE
`PopupView` - edit summary

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -31,8 +31,10 @@ struct EmbeddedPopupView: View {
         VStack(spacing: 0) {
             switch evaluationResult {
             case .success(let evaluatedElements):
-                PopupElementList(popupElements: evaluatedElements)
-                    .environment(\.popupTitle, popup.title)
+                PopupElementList(popupElements: evaluatedElements) {
+                    !popup.editSummary.isEmpty ? editSummary : nil
+                }
+                .environment(\.popupTitle, popup.title)
             case .failure(let error):
                 Text(
                     "Popup evaluation failed: \(error.localizedDescription)",
@@ -90,31 +92,44 @@ struct EmbeddedPopupView: View {
             return popup.evaluatedElements
         }
     }
+    
+    /// The edit summary of the popup.
+    private var editSummary: some View {
+        Text(popup.editSummary)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .listSectionSeparator(.hidden, edges: .top)
+    }
 }
 
 extension EmbeddedPopupView {
-    private struct PopupElementList: View {
+    private struct PopupElementList<Content>: View where Content: View {
         let popupElements: [PopupElement]
         
+        let editSummary: () -> Content?
+        
         var body: some View {
-            List(popupElements) { popupElement in
-                Group {
-                    switch popupElement {
-                    case let popupElement as AttachmentsPopupElement:
-                        AttachmentsFeatureElementView(popupElement: popupElement)
-                    case let popupElement as FieldsPopupElement:
-                        FieldsPopupElementView(popupElement: popupElement)
-                    case let popupElement as MediaPopupElement:
-                        MediaPopupElementView(popupElement: popupElement)
-                    case let popupElement as TextPopupElement:
-                        TextPopupElementView(popupElement: popupElement)
-                    case let popupElement as UtilityAssociationsPopupElement:
-                        UtilityAssociationsPopupElementView(popupElement: popupElement)
-                    default:
-                        EmptyView()
+            List {
+                ForEach(popupElements) { popupElement in
+                    Group {
+                        switch popupElement {
+                        case let popupElement as AttachmentsPopupElement:
+                            AttachmentsFeatureElementView(popupElement: popupElement)
+                        case let popupElement as FieldsPopupElement:
+                            FieldsPopupElementView(popupElement: popupElement)
+                        case let popupElement as MediaPopupElement:
+                            MediaPopupElementView(popupElement: popupElement)
+                        case let popupElement as TextPopupElement:
+                            TextPopupElementView(popupElement: popupElement)
+                        case let popupElement as UtilityAssociationsPopupElement:
+                            UtilityAssociationsPopupElementView(popupElement: popupElement)
+                        default:
+                            EmptyView()
+                        }
                     }
+                    .popupListRowStyle()
                 }
-                .popupListRowStyle()
+                editSummary()
             }
             .listStyle(.plain)
         }

--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -31,9 +31,10 @@ struct EmbeddedPopupView: View {
         VStack(spacing: 0) {
             switch evaluationResult {
             case .success(let evaluatedElements):
-                PopupElementList(popupElements: evaluatedElements) {
-                    !popup.editSummary.isEmpty ? editSummary : nil
-                }
+                PopupElementList(
+                    popupElements: evaluatedElements,
+                    editSummary: popup.editSummary
+                )
                 .environment(\.popupTitle, popup.title)
             case .failure(let error):
                 Text(
@@ -92,21 +93,12 @@ struct EmbeddedPopupView: View {
             return popup.evaluatedElements
         }
     }
-    
-    /// The edit summary of the popup.
-    private var editSummary: some View {
-        Text(popup.editSummary)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .listSectionSeparator(.hidden, edges: .top)
-    }
 }
 
 extension EmbeddedPopupView {
-    private struct PopupElementList<Content>: View where Content: View {
+    private struct PopupElementList: View {
         let popupElements: [PopupElement]
-        
-        let editSummary: () -> Content?
+        let editSummary: String
         
         var body: some View {
             List {
@@ -129,7 +121,13 @@ extension EmbeddedPopupView {
                     }
                     .popupListRowStyle()
                 }
-                editSummary()
+                
+                if !editSummary.isEmpty {
+                    Text(editSummary)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .listSectionSeparator(.hidden, edges: .top)
+                }
             }
             .listStyle(.plain)
         }


### PR DESCRIPTION
Related to `swift/7692`.

Integrates the `Popup.editSummary` property into the PopupView.

- Refactors EmbeddedPopupView popupElements list to use ForEach so the edit summary text can be added to the bottom of the List
- Adds optional Content closure for editSummary view
- Passes `nil` to closure when the edit summary text is empty

<img width="300" alt="edit summary" src="https://github.com/user-attachments/assets/ba2ce3b4-2f28-40f1-bab4-97188c9e2d01" />
<img width="300" alt="Popup edit summary" src="https://github.com/user-attachments/assets/264177f1-53c7-4342-a291-d49a1205f8ef" />
