### PR TITLE
`FeatureFormView` - Remove "Add Association" menu

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationsFilterResultView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationsFilterResultView.swift
@@ -97,42 +97,20 @@ extension FeatureFormView {
                 associationsFilterResultsModel?.fetchResults()
             }
             .overlay(alignment: .bottomLeading) {
-                addAssociationMenu
+                addAssociationButton
                     .padding()
             }
         }
         
-        var addAssociationMenu: some View {
-            Menu {
-                Button {
-                    featureFormViewModel.navigationPath.append(
-                        FeatureFormView.NavigationPathItem.utilityAssociationFeatureSourcesView(
-                            form,
-                            element,
-                            filter
-                        )
+        var addAssociationButton: some View {
+            Button {
+                featureFormViewModel.navigationPath.append(
+                    FeatureFormView.NavigationPathItem.utilityAssociationFeatureSourcesView(
+                        form,
+                        element,
+                        filter
                     )
-                } label: {
-                    Text(
-                        "From Network Data Source",
-                        bundle: .toolkitModule,
-                        comment: """
-                            A label for a button to choose a feature for a new
-                            utility association from a network data source.
-                            """
-                    )
-                }
-                Button {} label: {
-                    Text(
-                        "On Map",
-                        bundle: .toolkitModule,
-                        comment: """
-                            A label indicating features can be selected by
-                            interactively tapping on the map.
-                            """
-                    )
-                }
-                .disabled(true)
+                )
             } label: {
                 Label {
                     Text(

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -407,10 +407,6 @@ edge of a utility network element. */
 /* A label for the element on the "from" side of a utility association. */
 "From Element" = "From Element";
 
-/* A label for a button to choose a feature for a new
-utility association from a network data source. */
-"From Network Data Source" = "From Network Data Source";
-
 /* A label in reference to function outputs returned as results of a utility network
 trace operation. */
 "Function Results" = "Function Results";
@@ -619,10 +615,6 @@ filter results were found. */
 
 /* A label for button to proceed with an operation. */
 "OK" = "OK";
-
-/* A label indicating features can be selected by
-interactively tapping on the map. */
-"On Map" = "On Map";
 
 /* A message explaining that the online map failed to load. */
 "Online Map Failed to Load" = "Online Map Failed to Load";

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1883,10 +1883,8 @@ final class FeatureFormViewTests: XCTestCase {
         
 #if targetEnvironment(macCatalyst)
         let addAssociationButton = app.buttons["Add Association"]
-        let fromNetworkDataSourceButton = app.menuItems["From Network Data Source"]
 #else
         let addAssociationButton = app.staticTexts["Add Association"]
-        let fromNetworkDataSourceButton = app.buttons["From Network Data Source"]
 #endif
         
         openTestCase()
@@ -1910,13 +1908,6 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         addAssociationButton.tap()
-        
-        XCTAssertTrue(
-            fromNetworkDataSourceButton.waitForExistence(timeout: 5),
-            "The \"From Network Data Source\" button doesn't exist."
-        )
-        
-        fromNetworkDataSourceButton.tap()
         
         XCTAssertTrue(
             electricDistributionDeviceDataSourceButton.waitForExistence(timeout: 5),
@@ -2040,12 +2031,10 @@ final class FeatureFormViewTests: XCTestCase {
         
 #if targetEnvironment(macCatalyst)
         let addAssociationButton = app.buttons["Add Association"]
-        let fromNetworkDataSourceButton = app.menuItems["From Network Data Source"]
         let terminalHighButton = app.menuItems["high"]
         let terminalLowButton = app.menuItems["low"]
 #else
         let addAssociationButton = app.staticTexts["Add Association"]
-        let fromNetworkDataSourceButton = app.buttons["From Network Data Source"]
         let terminalHighButton = app.buttons["High"]
         let terminalLowButton = app.buttons["Low"]
 #endif
@@ -2081,13 +2070,6 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         addAssociationButton.tap()
-        
-        XCTAssertTrue(
-            fromNetworkDataSourceButton.waitForExistence(timeout: 5),
-            "The \"From Network Data Source\" button doesn't exist."
-        )
-        
-        fromNetworkDataSourceButton.tap()
         
         XCTAssertTrue(
             electricDistributionDeviceDataSourceButton.waitForExistence(timeout: 5),
@@ -2258,13 +2240,6 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         addAssociationButton.tap()
-        
-        XCTAssertTrue(
-            fromNetworkDataSourceButton.waitForExistence(timeout: 5),
-            "The \"From Network Data Source\" button doesn't exist."
-        )
-        
-        fromNetworkDataSourceButton.tap()
         
         XCTAssertTrue(
             structureJunctionDataSourceButton.waitForExistence(timeout: 5),


### PR DESCRIPTION
Apollo 1599

Previously, we planned to support adding associations via map interaction. This is no longer planned, so the intermediate menu is no longer needed.