### PR TITLE
Mhd/filter view updates

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
@@ -163,7 +163,8 @@ class FieldFilter {
     /// The operators supported for the given `FieldFilter` field type.
     /// - Returns: A list of operators appropriate for the given `FieldFilter` field type.
     var supportedConditions: [FilterOperator] {
-        field.type?.isNumeric == true
+        guard let fieldType = field.type else { return [] }
+        return (fieldType.isNumeric || fieldType == .oid)
         ? FilterOperator.numericFilterOperators(field.isNullable)
         : FilterOperator.textFilterOperators(field.isNullable)
     }
@@ -211,7 +212,7 @@ extension FilterViewModel {
     /// `ASSETGROUP` and `ASSETTYPE` fields, as those are special fields for Utility Networks.
     private func supportedUNFields(_ allFields: [Field]) -> [Field] {
         supportedFields(allFields).filter { field in
-            field.name != "assetgroup" && field.name != "assettype"
+            field.name.lowercased() != "assetgroup" && field.name.lowercased() != "assettype"
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -380,7 +380,7 @@ extension FieldView {
     var keyboardType: UIKeyboardType {
         guard let fieldType = fieldFilter.field.type else { return .default }
         
-        return if fieldType.isNumeric {
+        return if fieldType.isNumeric || fieldType == .oid {
 #if os(visionOS)
             // On visionOS, the `positiveNegativeButton` is not available.
             // Show the keyboard instead so the user can manually enter a negative number.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationFeatureCandidatesView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationFeatureCandidatesView.swift
@@ -84,6 +84,7 @@ extension FeatureFormView {
                     candidates.removeAll()
                     whereClause = filterViewModel.whereClause()
                 }
+                .interactiveDismissDisabled()
             }
             .task(id: whereClause) {
                 // Only query on whereClause change if the first page query is complete.


### PR DESCRIPTION
Apollo #1627

There are a couple of issues found in the initial FieldView implementation verification. They are:

- Tapping outside the FieldView sheet closes it, but does not display the "are you sure" alert and now the list of candidates shown are out of sync with the conditions in the dialog. _Fix: do not allow interactive dismissal of the view; force users to use the provided buttons_
- When I choose objectid field, the conditions presented seem to be for a string field and not a number field. (condition does not seem to work in this case). _Fix: show the number pad for field types .oid._
- We need to remove the "Asset Group" and "Asset Type" fields from list of fields we allow user to add conditions on. _Fix: user lowercase compare._
