### PR TITLE
Feature Form Add Attachments from File

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportData.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportData.swift
@@ -19,6 +19,19 @@ import UniformTypeIdentifiers
 /// Data used to create the attachment.
 struct AttachmentImportData: Equatable {
     let contentType: UTType
-    let data: Data
+    var data: Data? = nil
     var fileName: String? = nil
+    var filePath: URL? = nil
+    
+    init(contentType: UTType, fileName: String? = nil, data: Data) {
+        self.contentType = contentType
+        self.fileName = fileName
+        self.data = data
+    }
+    
+    init(contentType: UTType, fileName: String? = nil, filePath: URL) {
+        self.contentType = contentType
+        self.fileName = fileName
+        self.filePath = filePath
+    }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -174,7 +174,6 @@ struct AttachmentImportMenu: View {
                     contentType: newAttachmentImportData.contentType,
                     fileURL: url
                 )
-
             } else if let data = newAttachmentImportData.data {
                 newAttachment = element.addAttachment(
                     name: fileName,

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -182,7 +182,7 @@ struct AttachmentImportMenu: View {
                     data: data
                 )
             }
-
+            
             guard let newAttachment else {
                 importState = .errored(.creationFailed)
                 return

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -141,17 +141,19 @@ struct AttachmentImportMenu: View {
         .task(id: importState) {
             guard case let .finalizing(newAttachmentImportData) = importState else { return }
             
-            let attachmentSize = Measurement(
-                value: Double(newAttachmentImportData.data.count),
-                unit: UnitInformationStorage.bytes
-            )
-            guard attachmentSize <= attachmentUploadSizeLimit else {
-                importState = .errored(.sizeLimitExceeded)
-                return
-            }
-            guard attachmentSize.value > .zero else {
-                importState = .errored(.emptyFilesNotSupported)
-                return
+            if let data = newAttachmentImportData.data {
+                let attachmentSize = Measurement(
+                    value: Double(data.count),
+                    unit: UnitInformationStorage.bytes
+                )
+                guard attachmentSize <= attachmentUploadSizeLimit else {
+                    importState = .errored(.sizeLimitExceeded)
+                    return
+                }
+                guard attachmentSize.value > .zero else {
+                    importState = .errored(.emptyFilesNotSupported)
+                    return
+                }
             }
             
             let fileName: String
@@ -164,11 +166,24 @@ struct AttachmentImportMenu: View {
                     fileName = "Unnamed Attachment"
                 }
             }
-            guard let newAttachment = element.addAttachment(
-                name: fileName,
-                contentType: newAttachmentImportData.contentType,
-                data: newAttachmentImportData.data
-            ) else {
+            
+            var newAttachment: FeatureAttachment? = nil
+            if let url = newAttachmentImportData.filePath {
+                newAttachment = try? await element.addAttachment(
+                    named: fileName,
+                    contentType: newAttachmentImportData.contentType,
+                    fileURL: url
+                )
+
+            } else if let data = newAttachmentImportData.data {
+                newAttachment = element.addAttachment(
+                    name: fileName,
+                    contentType: newAttachmentImportData.contentType,
+                    data: data
+                )
+            }
+
+            guard let newAttachment else {
                 importState = .errored(.creationFailed)
                 return
             }
@@ -179,11 +194,10 @@ struct AttachmentImportMenu: View {
             importState = .importing
             switch result {
             case .success(let url):
-                // gain access to the url resource and verify there's data.
+                // gain access to the url resource.
                 if url.startAccessingSecurityScopedResource(),
-                   let contentType = url.contentType,
-                   let data = FileManager.default.contents(atPath: url.path) {
-                    importState = .finalizing(AttachmentImportData(contentType: contentType, data: data, fileName: url.lastPathComponent))
+                   let contentType = url.contentType {
+                    importState = .finalizing(AttachmentImportData(contentType: contentType, fileName: url.lastPathComponent, filePath: url))
                 } else {
                     importState = .errored(.dataInaccessible)
                 }


### PR DESCRIPTION
This adds the ability to add attachments directly from a file, without loading the file's data into memory. It works for files from the Photo Library or loaded directly from a file on the device.

Apollo #1590 as part of the "large attachment" work.

Note: this is dependent on the Swift API Audit #7823