### PR TITLE
`FeatureFormView` - General refactoring

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -108,10 +108,8 @@ struct AttachmentPreview: View {
                                 }
                             }
                         }
-                        Button(role: .destructive) {
+                        Button.delete {
                             deletedAttachmentModel = attachmentModel
-                        } label: {
-                            Label("Delete", systemImage: "trash")
                         }
                     }
                 }

--- a/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentPreview.swift
@@ -124,8 +124,8 @@ struct AttachmentPreview: View {
         ) {
             TextField(String.newName, text: $newAttachmentName)
                 .autocorrectionDisabled()
-            Button("Cancel", role: .cancel) { }
-            Button("OK") {
+            Button.cancel {}
+            Button.ok {
                 Task {
                     if let renamedAttachmentModel {
                         let currentName = renamedAttachmentModel.name

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -149,19 +149,17 @@ struct AttachmentsFeatureElementView: View {
                 proposedCellSize: thumbnailSize
             )
         case .auto:
-            Group {
-                if isRegularWidth {
-                    AttachmentPreview(
-                        attachmentModels: attachmentModels,
-                        editControlsDisabled: !isEditable,
-                        lastAttachmentAdded: lastAttachmentAdded,
-                        onRename: onRename,
-                        onDelete: onDelete,
-                        proposedCellSize: thumbnailSize
-                    )
-                } else {
-                    AttachmentList(attachmentModels: attachmentModels)
-                }
+            if isRegularWidth {
+                AttachmentPreview(
+                    attachmentModels: attachmentModels,
+                    editControlsDisabled: !isEditable,
+                    lastAttachmentAdded: lastAttachmentAdded,
+                    onRename: onRename,
+                    onDelete: onDelete,
+                    proposedCellSize: thumbnailSize
+                )
+            } else {
+                AttachmentList(attachmentModels: attachmentModels)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
@@ -26,27 +26,20 @@ struct EmbeddedFeatureFormView: View {
         if let embeddedFeatureFormViewModel {
             ScrollViewReader { scrollView in
                 Group {
-                    let form = Form { sections }
+                    let form = Form {
+                        sections
+                    }
 #if RELEASE
                     form
 #else
                     if CommandLine.arguments.contains("-testCase") {
-                        @Bindable var model = embeddedFeatureFormViewModel
-                        form
-                            .modify {
-                                $0
-                                    .searchable(
-                                        text: $model.elementFilterPhrase,
-                                        prompt: Text(
-                                            "Filter Elements",
-                                            bundle: .toolkitModule,
-                                            comment: """
-                                                Label for a text field used to 
-                                                filter visible elements in a form.
-                                            """
-                                        )
-                                    )
+                        // Use a ScrollView and VStack during UI testing
+                        // to make all form elements accessible.
+                        ScrollView {
+                            VStack {
+                                sections
                             }
+                        }
                     } else {
                         form
                     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
@@ -33,21 +33,18 @@ struct EmbeddedFeatureFormView: View {
                     if CommandLine.arguments.contains("-testCase") {
                         @Bindable var model = embeddedFeatureFormViewModel
                         form
-                            .modify {
-                                $0
-                                    .searchable(
-                                        text: $model.elementFilterPhrase,
-                                        placement: .navigationBarDrawer(displayMode: .always),
-                                        prompt: Text(
-                                            "Filter Elements",
-                                            bundle: .toolkitModule,
-                                            comment: """
-                                                Label for a text field used to 
-                                                filter visible elements in a form.
-                                                """
-                                        )
-                                    )
-                            }
+                            .searchable(
+                                text: $model.elementFilterPhrase,
+                                placement: .navigationBarDrawer(displayMode: .always),
+                                prompt: Text(
+                                    "Filter Elements",
+                                    bundle: .toolkitModule,
+                                    comment: """
+                                        Label for a text field used to 
+                                        filter visible elements in a form.
+                                        """
+                                )
+                            )
                     } else {
                         form
                     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
@@ -26,20 +26,27 @@ struct EmbeddedFeatureFormView: View {
         if let embeddedFeatureFormViewModel {
             ScrollViewReader { scrollView in
                 Group {
-                    let form = Form {
-                        sections
-                    }
+                    let form = Form { sections }
 #if RELEASE
                     form
 #else
                     if CommandLine.arguments.contains("-testCase") {
-                        // Use a ScrollView and VStack during UI testing
-                        // to make all form elements accessible.
-                        ScrollView {
-                            VStack {
-                                sections
+                        @Bindable var model = embeddedFeatureFormViewModel
+                        form
+                            .modify {
+                                $0
+                                    .searchable(
+                                        text: $model.elementFilterPhrase,
+                                        prompt: Text(
+                                            "Filter Elements",
+                                            bundle: .toolkitModule,
+                                            comment: """
+                                                Label for a text field used to 
+                                                filter visible elements in a form.
+                                            """
+                                        )
+                                    )
                             }
-                        }
                     } else {
                         form
                     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
@@ -44,7 +44,7 @@ struct EmbeddedFeatureFormView: View {
                                             comment: """
                                                 Label for a text field used to 
                                                 filter visible elements in a form.
-                                            """
+                                                """
                                         )
                                     )
                             }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormView.swift
@@ -37,6 +37,7 @@ struct EmbeddedFeatureFormView: View {
                                 $0
                                     .searchable(
                                         text: $model.elementFilterPhrase,
+                                        placement: .navigationBarDrawer(displayMode: .always),
                                         prompt: Text(
                                             "Filter Elements",
                                             bundle: .toolkitModule,

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
@@ -22,9 +22,6 @@ final class EmbeddedFeatureFormViewModel {
     /// The models for fetching association filter results for each utility associations form element in the form.
     var associationsFilterResultsModels: [UtilityAssociationsFormElement: AssociationsFilterResultsModel] = [:]
     
-    /// The phrase used to filter which elements are visible when running UI tests.
-    var elementFilterPhrase = ""
-    
     /// The current focused element, if one exists.
     var focusedElement: FormElement? {
         didSet {
@@ -63,11 +60,7 @@ final class EmbeddedFeatureFormViewModel {
            elementVisibility.count == featureForm.elements.count {
             elements.append(attachmentsElement)
         }
-        return elementFilterPhrase.isEmpty
-        ? elements
-        : elements.filter {
-            $0.label.localizedCaseInsensitiveContains(elementFilterPhrase)
-        }
+        return elements
     }
     
     /// A dictionary of each form element and whether or not it is visible.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
@@ -22,6 +22,9 @@ final class EmbeddedFeatureFormViewModel {
     /// The models for fetching association filter results for each utility associations form element in the form.
     var associationsFilterResultsModels: [UtilityAssociationsFormElement: AssociationsFilterResultsModel] = [:]
     
+    /// The phrase used to filter which elements are visible when running UI tests.
+    var elementFilterPhrase = ""
+    
     /// The current focused element, if one exists.
     var focusedElement: FormElement? {
         didSet {
@@ -60,7 +63,11 @@ final class EmbeddedFeatureFormViewModel {
            elementVisibility.count == featureForm.elements.count {
             elements.append(attachmentsElement)
         }
-        return elements
+        return elementFilterPhrase.isEmpty
+        ? elements
+        : elements.filter {
+            $0.label.localizedCaseInsensitiveContains(elementFilterPhrase)
+        }
     }
     
     /// A dictionary of each form element and whether or not it is visible.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
@@ -18,7 +18,7 @@ import Observation
 private import os
 
 @MainActor @Observable
-class EmbeddedFeatureFormViewModel {
+final class EmbeddedFeatureFormViewModel {
     /// The models for fetching association filter results for each utility associations form element in the form.
     var associationsFilterResultsModels: [UtilityAssociationsFormElement: AssociationsFilterResultsModel] = [:]
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormViewModel.swift
@@ -15,7 +15,7 @@
 import ArcGIS
 import Observation
 
-@Observable class FeatureFormViewModel {
+@Observable final class FeatureFormViewModel {
     /// The models for each feature form in the navigation path.
     private var formModels: [ObjectIdentifier: EmbeddedFeatureFormViewModel] = [:]
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
@@ -17,7 +17,7 @@ import Foundation
 import SwiftUI
 
 @MainActor @Observable
-class FilterViewModel {
+final class FilterViewModel {
     /// The feature table containing the fields to filter on.
     ///
     /// Use this to auto-populate the filterable fields. Alternatively, use `setFields(_:)` to customize

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -159,19 +159,9 @@ struct FilterView: View {
     /// - Parameter filter: The `FieldFilter` to delete.
     /// - Returns: The delete `Button`.
     private func deleteButton(_ filter: FieldFilter) -> Button<some View> {
-        Button(role: .destructive) {
+        Button.delete {
             if let index = model.fieldFilters.firstIndex(of: filter) {
                 model.fieldFilters.remove(at: index)
-            }
-        } label: {
-            Label {
-                Text(
-                    "Delete",
-                    bundle: .toolkitModule,
-                    comment: "A label for a button to delete a field filter."
-                )
-            } icon: {
-                Image(systemName: "trash")
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/FormElementWrapper/FormElementFooter.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/FormElementWrapper/FormElementFooter.swift
@@ -378,18 +378,16 @@ extension FormElementFooter {
 private extension RangeDomain {
     /// String representations of the numeric minimum and maximum value of the range domain.
     var displayableNumericMinAndMax: (min: String, max: String)? {
-        if let min = minValue as? Float32, let max = maxValue as? Float32 {
-            return (min.formatted(.number.precision(.fractionLength(1...))), max.formatted(.number.precision(.fractionLength(1...))))
-        } else if let min = minValue as? Float64, let max = maxValue as? Float64 {
-            return (min.formatted(.number.precision(.fractionLength(1...))), max.formatted(.number.precision(.fractionLength(1...))))
-        } else if let min = minValue as? Int16, let max = maxValue as? Int16 {
-            return (min.formatted(), max.formatted())
-        } else if let min = minValue as? Int32, let max = maxValue as? Int32 {
-            return (min.formatted(), max.formatted())
-        } else if let min = minValue as? Int64, let max = maxValue as? Int64 {
-            return (min.formatted(), max.formatted())
-        } else {
-            return nil
+        func formatted<T: BinaryFloatingPoint>(_ value: T) -> String {
+            Double(value).formatted(.number.precision(.fractionLength(1...)))
+        }
+        
+        switch (minValue, maxValue) {
+        case let (min, max) as (Float32, Float32): return (formatted(min), formatted(max))
+        case let (min, max) as (Float64, Float64): return (formatted(min), formatted(max))
+        case let (min, max) as (any BinaryInteger, any BinaryInteger):
+            return ("\(min)", "\(max)")
+        default: return nil
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
@@ -151,7 +151,6 @@ extension ComboBoxInput {
         }
     }
     
-    
     /// The view that allows the user to filter and select coded values by name.
     ///
     /// Adds navigation context to support toolbar items and other visual elements in the picker.

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -320,7 +320,7 @@ public struct UtilityNetworkTrace: View {
                             isPresented: $deleteAllStartingPointsConfirmationIsPresented,
                             titleVisibility: .visible
                         ) {
-                            Button(String.deleteButtonLabel, role: .destructive) {
+                            Button.delete {
                                 for startingPoint in viewModel.pendingTrace.startingPoints {
                                     viewModel.deleteStartingPoint(startingPoint)
                                     externalStartingPoints.removeAll()
@@ -424,7 +424,7 @@ public struct UtilityNetworkTrace: View {
                         updateViewpoint(to: resultExtent)
                     }
                 }
-                Button(String.deleteButtonLabel) {
+                Button.delete {
                     if viewModel.completedTraces.count == 1 {
                         currentActivity = .creatingTrace(nil)
                     }
@@ -557,7 +557,7 @@ public struct UtilityNetworkTrace: View {
                     updateViewpoint(to: extent)
                 }
             }
-            Button(String.deleteButtonLabel, role: .destructive) {
+            Button.delete {
                 if let startingPoint = selectedStartingPoint {
                     viewModel.deleteStartingPoint(startingPoint)
                     externalStartingPoints.removeAll { $0 == startingPoint }
@@ -916,14 +916,6 @@ private extension String {
             localized: "Delete all starting points?",
             bundle: .toolkitModule,
             comment: "The title of the dialogue confirming deletion of all points."
-        )
-    }
-    
-    static var deleteButtonLabel: Self {
-        .init(
-            localized: "Delete",
-            bundle: .toolkitModule,
-            comment: "A label for a button used to delete a utility network trace input component or result."
         )
     }
     

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
@@ -14,6 +14,26 @@
 
 import SwiftUI
 
+extension Button<Label<Text, Image>> {
+    /// Returns a button with the title "Delete" and the given action.
+    /// - Parameter action: The action to perform when the user triggers the
+    /// button.
+    /// - Returns: A button.
+    static nonisolated func delete(action: @escaping @MainActor () -> Void) -> Self {
+        Button(role: .destructive, action: action) {
+            Label {
+                Text(
+                    "Delete",
+                    bundle: .toolkitModule,
+                    comment: "A label for a \"Delete\" button."
+                )
+            } icon: {
+                Image(systemName: "trash")
+            }
+        }
+    }
+}
+
 extension Button<Text> {
     /// Returns a button with the title "Cancel" and the given action.
     /// - Parameter action: The action to perform when the user triggers the

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Text.swift
@@ -32,7 +32,7 @@ extension Text {
             comment: "A label in reference to a utility association type."
         )
     }
-
+    
     /// Localized text for the word "Cancel".
     static var cancel: Self {
         .init(LocalizedStringResource.cancel)

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -411,6 +411,10 @@ asset types by name. */
 association candidate features by name. */
 "Filter candidates by name" = "Filter candidates by name";
 
+/* Label for a text field used to 
+filter visible elements in a form. */
+"Filter Elements" = "Filter Elements";
+
 /* A field allowing the user to filter a list of facilities by name. A
 facility contains one or more levels in a floor-aware map or scene. */
 "Filter facilities" = "Filter facilities";
@@ -985,6 +989,9 @@ without saving. */
 
 /* A label in reference to a credential username. */
 "Username" = "Username";
+
+/* A label for an unknown utility association kind. */
+"utility-association-unknown-label" = "Unknown";
 
 /* A label indicating the feature form has validation errors. */
 "Validation Errors" = "Validation Errors";

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -417,7 +417,7 @@ association feature sources by name. */
 contains one or more facilities in a floor-aware map or scene. */
 "Filter sites" = "Filter sites";
 
-/* A notice used when closing the view and the filters have been applied/saved. */
+/* A notice used when closing the view that the filters have not been applied/saved. */
 "Filters have not been applied" = "Filters have not been applied";
 
 /* A hint for the user on what to search for in a search bar. */

--- a/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ArcGISToolkit/Resources/en.lproj/Localizable.strings
@@ -246,8 +246,7 @@ A label for a button used to continue the authentication operation. */
 /* Text indicating a field's value must be on or before the maximum date specified in the variable. */
 "Date must be on or before %@" = "Date must be on or before %@";
 
-/* A label for a button to delete a field filter.
-A label for a button used to delete a utility network trace input component or result. */
+/* A label for a "Delete" button. */
 "Delete" = "Delete";
 
 /* A label for a button used to delete all starting points on a pending utility network trace. */

--- a/Test Runner/Test Runner/Extensions/XCUIAutomation/XCUIElement.swift
+++ b/Test Runner/Test Runner/Extensions/XCUIAutomation/XCUIElement.swift
@@ -56,6 +56,27 @@ extension XCUIElement {
         tap()
     }
     
+    /// Asserts that the element's label equals an expected value after an amount of time.
+    /// - Parameters:
+    ///   - expectedLabel: The expected value of the label.
+    func assertLabel(
+        _ expectedLabel: String,
+        timeout: TimeInterval = .standard,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let predicate = NSPredicate(format: "label == %@", expectedLabel)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        XCTWaiter().wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(
+            label,
+            expectedLabel,
+            "Expected label '\(expectedLabel)' but got '\(label)'.",
+            file: file,
+            line: line
+        )
+    }
+    
     /// Asserts that the element does not exist after an amount of time.
     /// - Parameters:
     ///   - timeout: The time, in seconds, the test allows for the element to become unavailable. The

--- a/Test Runner/Test Runner/Extensions/XCUIAutomation/XCUIElement.swift
+++ b/Test Runner/Test Runner/Extensions/XCUIAutomation/XCUIElement.swift
@@ -56,6 +56,19 @@ extension XCUIElement {
         tap()
     }
     
+    /// Asserts that the system can compute a hit point for the element.
+    func assertHittable(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            isHittable,
+            "The \(description) isn't hittable.",
+            file: file,
+            line: line
+        )
+    }
+    
     /// Asserts that the element's label equals an expected value after an amount of time.
     /// - Parameters:
     ///   - expectedLabel: The expected value of the label.

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1479,6 +1479,10 @@ final class FeatureFormViewTests: XCTestCase {
         transformerButton.swipeLeft()
 #endif
         
+#if os(visionOS)
+        XCTExpectFailure("The \"Remove Association\" button does not trigger properly in visionOS.")
+#endif
+        
         removeAssociationButton.assertExistenceAndTap()
         
         cancelButton.assertExistenceAndTap()

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1696,7 +1696,7 @@ final class FeatureFormViewTests: XCTestCase {
         let contentVisibleSwitch = app.checkBoxes["Content Visible"]
 #else
         let addAssociationButton = app.staticTexts["Add Association"]
-        let contentVisibleSwitch = app.switches["Content Visible"].switches.firstMatch
+        let contentVisibleSwitch = app.switches["Content Visible"]
 #endif
         
         openTestCase()

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -341,6 +341,8 @@ final class FeatureFormViewTests: XCTestCase {
             "The now button isn't hittable."
         )
         
+        fieldValue.tap()
+        
         XCTAssertEqual(
             footer.label,
             "Date Entry is Required"
@@ -363,9 +365,16 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.filterElements(fieldTitle)
         
+        fieldLabel.assertExistence()
+        
+        XCTAssertEqual(
+            footer.label,
+            "Enter the launch date and time (July 16, 1969 13:32 UTC)"
+        )
+        
         fieldValue.tap()
         
-        fieldLabel.assertExistence()
+        datePicker.assertExistence()
         
         let localDate = Calendar.current.date(
             from: DateComponents(
@@ -377,13 +386,6 @@ final class FeatureFormViewTests: XCTestCase {
             fieldValue.label,
             localDate?.formatted()
         )
-        
-        XCTAssertEqual(
-            footer.label,
-            "Enter the launch date and time (July 16, 1969 13:32 UTC)"
-        )
-        
-        datePicker.assertExistence()
         
         XCTAssertTrue(
             nowButton.isHittable,
@@ -415,10 +417,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            footer.isHittable,
-            "The footer isn't hittable."
-        )
+        footer.assertExistence()
         
         fieldValue.tap()
         
@@ -473,9 +472,9 @@ final class FeatureFormViewTests: XCTestCase {
             clearButton.tap()
         }
         
-        fieldValue.tap()
-        
         footer.assertExistence()
+        
+        fieldValue.tap()
         
         nowButton.assertExistence()
         
@@ -527,12 +526,11 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.filterElements(fieldTitle)
         
-        fieldValue.assertExistenceAndTap()
-        
-        // Swipe up to reveal the entire date picker.
-        app.scrollViews.firstMatch.swipeUp()
+        fieldValue.assertExistence()
         
         footer.assertExistence()
+        
+        fieldValue.tap()
         
         XCTAssertEqual(
             footer.label,
@@ -687,12 +685,6 @@ final class FeatureFormViewTests: XCTestCase {
         let firstOptionButton = app.buttons["String 1"]
         let formTitle = app.staticTexts["comboBox"]
         
-#if os(visionOS)
-        let doneButton = app.buttons["Confirm"]
-#else
-        let doneButton = app.buttons["Done"]
-#endif
-        
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
@@ -721,11 +713,11 @@ final class FeatureFormViewTests: XCTestCase {
         firstOptionButton.tap()
         
         XCTAssertTrue(
-            doneButton.isHittable,
+            app.doneButton.isHittable,
             "The done button isn't hittable."
         )
         
-        doneButton.tap()
+        app.doneButton.tap()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -739,12 +731,6 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Combo String"]
         let fieldValue = app.staticTexts["Combo String Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
-        
-#if os(visionOS)
-        let doneButton = app.buttons["Confirm"]
-#else
-        let doneButton = app.buttons["Done"]
-#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -768,7 +754,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.noValueComboBoxOption.tap()
         
-        doneButton.assertExistenceAndTap()
+        app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -786,12 +772,6 @@ final class FeatureFormViewTests: XCTestCase {
         let footer = app.staticTexts["\(fieldTitle) Footer"]
         let formTitle = app.staticTexts["comboBox"]
         let oakButton = app.buttons["Oak"]
-        
-#if os(visionOS)
-        let doneButton = app.buttons["Confirm"]
-#else
-        let doneButton = app.buttons["Done"]
-#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -818,7 +798,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         oakButton.assertExistenceAndTap()
         
-        doneButton.assertExistenceAndTap()
+        app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -829,28 +809,22 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.6: noValueOption is 'Hide'
     func testCase_3_6() throws {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["Combo No Value False"]
+        let fieldTitle = "Combo No Value False"
+        let fieldLabel = app.staticTexts[fieldTitle]
         let fieldValue = app.staticTexts["Combo No Value False Combo Box Value"]
         let firstOption = app.buttons["First"]
         let formTitle = app.staticTexts["comboBox"]
         let noValueButton = app.buttons["No Value"]
         let optionsButton = app.images["Combo No Value False Options Button"]
         
-#if os(visionOS)
-        let doneButton = app.buttons["Confirm"]
-#else
-        let doneButton = app.buttons["Done"]
-#endif
-        
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldTitle.assertExistence()
+        app.filterElements(fieldTitle)
         
-        XCTAssertEqual(
-            fieldValue.label,
-            ""
-        )
+        fieldLabel.assertExistence()
+        
+        XCTAssertTrue(fieldValue.label.isEmpty)
         
         optionsButton.assertExistenceAndTap()
         
@@ -865,7 +839,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         firstOption.tap()
         
-        doneButton.assertExistenceAndTap()
+        app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -982,7 +956,6 @@ final class FeatureFormViewTests: XCTestCase {
         let switchView = app.checkBoxes["\(fieldTitle) Switch"]
 #else
         let switchView = app.switches["\(fieldTitle) Switch"]
-        let control = switchView.switches.firstMatch
 #endif
         
         openTestCase()
@@ -997,12 +970,10 @@ final class FeatureFormViewTests: XCTestCase {
             "2"
         )
       
-#if targetEnvironment(macCatalyst)
-        switchView.assertExistenceAndTap()
-#elseif os(visionOS)
+#if targetEnvironment(macCatalyst) || os(visionOS)
         switchView.assertExistenceAndTap()
 #else
-        control.assertExistenceAndTap()
+        switchView.switches.firstMatch.assertExistenceAndTap()
 #endif
         
         XCTAssertEqual(
@@ -1022,7 +993,6 @@ final class FeatureFormViewTests: XCTestCase {
         let switchView = app.checkBoxes["\(fieldTitle) Switch"]
 #else
         let switchView = app.switches["\(fieldTitle) Switch"]
-        let control = switchView.switches.firstMatch
 #endif
         
         openTestCase()
@@ -1045,12 +1015,10 @@ final class FeatureFormViewTests: XCTestCase {
             "The switch isn't hittable."
         )
         
-#if targetEnvironment(macCatalyst)
-        switchView.assertExistenceAndTap()
-#elseif os(visionOS)
+#if targetEnvironment(macCatalyst) || os(visionOS)
         switchView.assertExistenceAndTap()
 #else
-        control.assertExistenceAndTap()
+        switchView.switches.firstMatch.assertExistenceAndTap()
 #endif
         
         XCTAssertEqual(
@@ -1111,13 +1079,12 @@ final class FeatureFormViewTests: XCTestCase {
     
     /// Test case 6.2: Test visibility of empty group
     func testCase_6_2() throws {
-        try skipIf(visionOS: true)
-        
         let app = XCUIApplication()
         let elementTitle = "Group with children that are visible dependent"
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
         let groupElement = app.staticTexts["single line text 3"]
-        let radioButtonPicker = app.pickers["Radio Button"].pickerWheels.firstMatch
+        let radioOptionA = app.buttons["Everything is working great"]
+        let radioOptionB = app.buttons["show invisible form element"]
         
 #if targetEnvironment(macCatalyst)
         let hiddenElementsGroup = app.disclosureTriangles["Group with children that are visible dependent"]
@@ -1146,16 +1113,9 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.filterElements("Group with Multiple Form Elements")
         
-        // Confirm the option to show the elements exists.
-        radioButtonPicker.assertExistence()
-        
-#if !os(visionOS)
-        radioButtonPicker.adjust(toPickerWheelValue: "Everything is working great")
-        radioButtonPicker.adjust(toPickerWheelValue: "Everything could be working greater")
-        radioButtonPicker.adjust(toPickerWheelValue: "Its good Enough!")
-        radioButtonPicker.adjust(toPickerWheelValue: "Show Group Visible Dependent")
-        radioButtonPicker.adjust(toPickerWheelValue: "show invisible form element")
-#endif
+        // Show the invisible elements.
+        radioOptionA.assertExistenceAndTap()
+        radioOptionB.assertExistenceAndTap()
         
         app.filterElements(elementTitle)
         
@@ -1167,51 +1127,84 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_7_1() throws {
         let app = XCUIApplication()
         let formTitle = app.staticTexts["Test Case 7.1 - Read only elements"]
-        let elementsAreEditableSwitch = app.switches["Elements are editable Switch"]
-        let elementInTheGroupIsEditableReadOnlyInput = app.staticTexts["Element in the group is editable Read Only Input"]
-        let elementInTheGroupIsEditableSwitch = app.switches["Element in the group is editable Switch"]
         
         let comboBoxReadOnlyInput = app.staticTexts["Combo box Read Only Input"]
         let comboBox = app.staticTexts["Combo box Combo Box Value"]
+        let dateFieldTitle = "Date"
+        let dateReadOnlyInput = app.staticTexts["\(dateFieldTitle) Read Only Input"]
+        let dateInput = app.buttons["\(dateFieldTitle) Value"]
+        let groupElementTitle = "Group"
+        let longTextFieldTitle = "Long text"
+        let longTextReadOnlyInput = app.staticTexts["\(longTextFieldTitle) Read Only Input"]
+        let longTextTextInputPreview = app.staticTexts["\(longTextFieldTitle) Text Input Preview"]
+        let radioButtonsFieldTitle = "Radio buttons"
+        let radioButtonsOption0 = app.buttons["0"]
+        let radioButtonsReadOnlyInput = app.staticTexts["\(radioButtonsFieldTitle) Read Only Input"]
+        let shortTextFieldTitle = "Short text"
+        let shortTextReadOnlyInput = app.staticTexts["\(shortTextFieldTitle) Read Only Input"]
+        let shortTextTextInput = app.textFields["\(shortTextFieldTitle) Text Input"]
+        let switch1FieldTitle = "Elements are editable"
+        let switch2FieldTitle = "Element in the group is editable"
+        let switchReadOnlyInput = app.staticTexts["\(switch2FieldTitle) Read Only Input"]
         
-        let radioButtonsPicker = app.pickers["Radio buttons"].pickerWheels.firstMatch
-        let radioButtonsReadOnlyInput = app.staticTexts["Radio buttons Read Only Input"]
-        
-        let dateReadOnlyInput = app.staticTexts["Date Read Only Input"]
-        let dateInput = app.buttons["Date Value"]
-        
-        let shortTextReadOnlyInput = app.staticTexts["Short text Read Only Input"]
-        let shortTextTextInput = app.textFields["Short text Text Input"]
-        
-        let longTextReadOnlyInput = app.staticTexts["Long text Read Only Input"]
-        let longTextTextInputPreview = app.staticTexts["Long text Text Input Preview"]
+#if targetEnvironment(macCatalyst)
+        let switch1 = app.checkBoxes["\(switch1FieldTitle) Switch"]
+        let switch2 = app.checkBoxes["\(switch2FieldTitle) Switch"]
+#else
+        let switch1 = app.switches["\(switch1FieldTitle) Switch"]
+        let switch2 = app.switches["\(switch2FieldTitle) Switch"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementInTheGroupIsEditableReadOnlyInput.assertExistence()
+        switchReadOnlyInput.assertExistence()
         
         comboBoxReadOnlyInput.assertExistence()
         
+        app.filterElements(radioButtonsFieldTitle)
+        
         radioButtonsReadOnlyInput.assertExistence()
+        
+        app.filterElements(dateFieldTitle)
         
         dateReadOnlyInput.assertExistence()
         
+        app.filterElements(shortTextFieldTitle)
+        
         shortTextReadOnlyInput.assertExistence()
+        
+        app.filterElements(groupElementTitle)
         
         longTextReadOnlyInput.assertExistence()
         
-        elementsAreEditableSwitch.assertExistenceAndTap()
+        app.clearElementFilter()
         
-        elementInTheGroupIsEditableSwitch.assertExistenceAndTap()
+#if targetEnvironment(macCatalyst) || os(visionOS)
+        switch1.assertExistenceAndTap()
+        switch2.assertExistenceAndTap()
+#else
+        switch1.switches.firstMatch.assertExistenceAndTap()
+        switch2.switches.firstMatch.assertExistenceAndTap()
+#endif
         
         comboBox.assertExistence()
         
-        XCTAssertEqual(radioButtonsPicker.stringValue, "0")
+        app.filterElements(radioButtonsFieldTitle)
+        
+        radioButtonsOption0.assertExistence()
+        
+        XCTAssertTrue(radioButtonsOption0.isSelected)
+        
+        app.filterElements(dateFieldTitle)
         
         dateInput.assertExistence()
         
+        app.filterElements(shortTextFieldTitle)
+        
         shortTextTextInput.assertExistence()
+        
+        app.filterElements(groupElementTitle)
         
         longTextTextInputPreview.assertExistence()
     }
@@ -1257,11 +1250,15 @@ final class FeatureFormViewTests: XCTestCase {
         titleTextField.assertExistence()
         
         XCTAssertEqual(
-            titleTextField.value as? String,
+            titleTextField.stringValue,
             "Redlands"
         )
         
         redlandsText.assertExistence()
+        
+#if os(visionOS)
+        XCTExpectFailure("The clear button doesn't work as expected on visionOS.")
+#endif
         
         titleClearButton.assertExistenceAndTap()
         titleTextField.assertExistenceAndTap()
@@ -1312,7 +1309,8 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_12_1() {
         let app = XCUIApplication()
         let assetGroup = app.staticTexts["Asset group"]
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let fieldValue = app.staticTexts["Asset group Read Only Input"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let filterResults1 = app.staticTexts["Connected"]
@@ -1327,7 +1325,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         filterResults1.assertExistence()
         
@@ -1364,7 +1364,8 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_12_3() {
         let app = XCUIApplication()
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let filterResults = app.staticTexts["Content"]
         let formTitle = app.staticTexts["Structure Boundary"]
         let networkSourceGroupButton = app.buttons["Electric Distribution Device, 1"]
@@ -1373,7 +1374,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         filterResults.assertExistenceAndTap()
         
@@ -1385,7 +1388,8 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_12_4() {
         let app = XCUIApplication()
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let filterResults = app.staticTexts["Container"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let networkSourceGroup = app.staticTexts["Structure Boundary"]
@@ -1394,13 +1398,15 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         filterResults.assertExistenceAndTap()
         
         networkSourceGroup.assertExistenceAndTap()
         
-        // Expectation: a list of one utility elements with no "Containment Visible" label
+        // Expectation: a list of one utility element with no "Containment Visible" label
         utilityElementButton.assertExistence()
     }
     
@@ -1409,7 +1415,8 @@ final class FeatureFormViewTests: XCTestCase {
         let assetType = app.staticTexts["Asset type *"]
         let backButton = app.buttons["Back"]
         let discardEditsButton = app.buttons["Discard Edits"]
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let fieldValue = app.staticTexts["Asset type Combo Box Value"]
         let filterResults = app.staticTexts["Connected"]
         let firstOptionButton = app.buttons["Unknown Combo Box Option"]
@@ -1418,16 +1425,12 @@ final class FeatureFormViewTests: XCTestCase {
         let networkSourceGroupButton = app.buttons["Electric Distribution Device, 1"]
         let utilityElementButton = app.buttons["Transformer, High"]
         
-#if os(visionOS)
-        let doneButton = app.buttons["Confirm"]
-#else
-        let doneButton = app.buttons["Done"]
-#endif
-        
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         filterResults.assertExistenceAndTap()
         
@@ -1449,11 +1452,11 @@ final class FeatureFormViewTests: XCTestCase {
         firstOptionButton.tap()
         
         XCTAssertTrue(
-            doneButton.isHittable,
+            app.doneButton.isHittable,
             "The done button isn't hittable."
         )
         
-        doneButton.tap()
+        app.doneButton.tap()
         
         // Tap the "Back" button
         backButton.tap()
@@ -1471,7 +1474,8 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let cancelButton = app.buttons["Cancel"].firstMatch
         let discardButton = app.buttons["Discard"].firstMatch
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let connectedFilterTitle = app.staticTexts["Connected"]
         let electricDistributionDevice = app.staticTexts["Electric Distribution Device"]
         let networkSourceGroupButton = app.buttons["Electric Distribution Device, 1"]
@@ -1490,7 +1494,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: electricDistributionDevice)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         connectedFilterTitle.assertExistenceAndTap()
         
@@ -1549,7 +1555,6 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_13_1() {
         let app = XCUIApplication()
-        
         let addButton = app.buttons["Add"]
         let associationTypeLabel = app.staticTexts["Association Type"]
         let cabinetFuseButton = app.buttons["Cabinet Fuse"]
@@ -1559,7 +1564,8 @@ final class FeatureFormViewTests: XCTestCase {
         let electricDistributionDeviceDataSourceButton = app.buttons["Electric Distribution Device"]
         let electricDistributionJunctionDataSourceButton = app.buttons["Electric Distribution Junction"]
         let electricDistributionDeviceLabel = app.staticTexts["Electric Distribution Device"]
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let fromElementLabel = app.staticTexts["From Element"]
         let fuseButton = app.staticTexts["Fuse"].firstMatch
@@ -1579,7 +1585,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         connectedFilterTitle.assertExistenceAndTap()
         
@@ -1624,7 +1632,6 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_13_2() {
         let app = XCUIApplication()
-        
         let addButton = app.buttons["Add"]
         let associationTypeLabel = app.staticTexts["Association Type"]
         let connectedFilterTitle = app.staticTexts["Connected"]
@@ -1636,7 +1643,8 @@ final class FeatureFormViewTests: XCTestCase {
         let electricDistributionDeviceLabel = app.staticTexts["Electric Distribution Device"]
         let electricDistributionJunctionButton5 = app.buttons["Electric Distribution Junction, 5"]
         let electricDistributionJunctionDataSourceButton = app.buttons["Electric Distribution Junction"]
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let fromElementLabel = app.staticTexts["From Element"]
         let newAssociationText = app.staticTexts["New Association"]
@@ -1662,7 +1670,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         connectedFilterTitle.assertExistenceAndTap()
         
@@ -1727,7 +1737,6 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_13_3() {
         let app = XCUIApplication()
-        
         let addButton = app.buttons["Add"]
         let associationTypeLabel = app.staticTexts["Association Type"]
         let containerFilterTitle = app.staticTexts["Container"].firstMatch
@@ -1806,7 +1815,7 @@ final class FeatureFormViewTests: XCTestCase {
     }
     
     func testCase_13_4() throws {
-        try skipIf(macCatalyst: true, visionOS: true)
+        try skipIf(macCatalyst: true)
         
         let app = XCUIApplication()
         let addAssociationButton = app.staticTexts["Add Association"]
@@ -1817,26 +1826,34 @@ final class FeatureFormViewTests: XCTestCase {
         let connectedFilterTitle = app.staticTexts["Connected"]
         let deleteButton = app.buttons["Delete"]
         let discardEditsButton = app.buttons["Discard Edits"]
-        let doneButton = app.buttons["Done"]
         let electricDistributionJunctionDataSourceButton = app.buttons["Electric Distribution Junction"]
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let equalOption = app.buttons["="]
         let filterButton = app.buttons["Filter Candidates"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
-        let isBlankLabel = app.staticTexts["is blank"]
         let isBlankOption = app.buttons["is blank"]
         let lineEndCandidates = app.buttons.matching(identifier: "Line End")
         let lowVoltageSinglePhaseLineEnd = app.buttons["Low Voltage Single Phase Line End"]
-        let objectIDConditionLabel = app.staticTexts["Object ID"]
         let optionAButton = app.buttons["A"]
         let phasesCurrentState = app.buttons["Phases Current State"]
         let unsavedChangesAlert = app.alerts["Filters have not been applied"]
         let valueButton = app.buttons["Value"]
         
+#if os(visionOS)
+        let isBlankLabel = app.buttons["Condition, is blank"]
+        let objectIDField = app.buttons["Field, Object ID"]
+#else
+        let isBlankLabel = app.staticTexts["is blank"]
+        let objectIDField = app.staticTexts["Object ID"]
+#endif
+        
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         connectedFilterTitle.assertExistenceAndTap()
         
@@ -1871,13 +1888,15 @@ final class FeatureFormViewTests: XCTestCase {
         
         unsavedChangesAlert.assertNonExistence()
         
+        lineEndCandidates.firstMatch.assertExistence()
+        
         XCTAssertEqual(lineEndCandidates.count, 2)
         
         filterButton.assertExistenceAndTap()
         
         addConditionButton.assertExistenceAndTap()
         
-        objectIDConditionLabel.assertExistence()
+        objectIDField.assertExistence()
         
         condition1Options.assertExistenceAndTap()
         
@@ -1885,7 +1904,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         addConditionButton.assertExistenceAndTap()
         
-        objectIDConditionLabel.assertExistenceAndTap()
+        objectIDField.assertExistenceAndTap()
         
         phasesCurrentState.assertExistenceAndTap()
         
@@ -1893,7 +1912,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         isBlankOption.assertExistenceAndTap()
         
-        doneButton.assertExistenceAndTap()
+        app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(lineEndCandidates.count, 0)
         
@@ -1907,13 +1926,15 @@ final class FeatureFormViewTests: XCTestCase {
         
         optionAButton.assertExistenceAndTap()
         
-        doneButton.assertExistenceAndTap()
+        app.doneButton.assertExistenceAndTap()
+        
+        lineEndCandidates.firstMatch.assertExistence()
         
         XCTAssertEqual(lineEndCandidates.count, 1)
     }
     
     func testCase_13_5() throws {
-        try skipIf(macCatalyst: true, visionOS: true)
+        try skipIf(macCatalyst: true)
         
         let app = XCUIApplication()
         let addAssociationButton = app.staticTexts["Add Association"]
@@ -1927,11 +1948,10 @@ final class FeatureFormViewTests: XCTestCase {
         let datePicker1 = datePickers.firstMatch
         let datePicker2 = datePickers.element(boundBy: 1)
         let dismissPopover = app.buttons["PopoverDismissRegion"]
-        let doneButton = app.buttons["Done"]
         let duplicateButton = app.buttons["Duplicate"]
         let electricDistributionDeviceDataSourceButton = app.buttons["Electric Distribution Device"]
-        let elementTitle = app.staticTexts["Associations"]
-        let equalStaticText = app.staticTexts["="]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let filterButton = app.buttons["Filter Candidates"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let greaterThanButton = app.buttons[">"]
@@ -1939,13 +1959,24 @@ final class FeatureFormViewTests: XCTestCase {
         let jan2014Label = app.staticTexts["January 2014"]
         let lessThanButton = app.buttons["<"]
         let municipalButton = app.buttons["Municipal"]
-        let objectIDConditionLabel = app.staticTexts["Object ID"]
         let streetLightCandidates = app.buttons.matching(identifier: "Street Light")
+        
+#if os(visionOS)
+        let currentMonthYearOption = app.buttons[currentMonthYear]
+        let equalsCondition = app.buttons["Condition, ="]
+        let objectIDField = app.buttons["Field, Object ID"]
+#else
+        let currentMonthYearOption = app.staticTexts[currentMonthYear]
+        let equalsCondition = app.staticTexts["="]
+        let objectIDField = app.staticTexts["Object ID"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         connectedFilterTitle.assertExistenceAndTap()
         
@@ -1963,15 +1994,19 @@ final class FeatureFormViewTests: XCTestCase {
         
         addConditionButton.assertExistenceAndTap()
         
-        objectIDConditionLabel.assertExistenceAndTap()
+        objectIDField.assertExistenceAndTap()
         
         dateInstalledButton.assertExistenceAndTap()
         
-        equalStaticText.assertExistenceAndTap()
+        equalsCondition.assertExistenceAndTap()
         
         greaterThanButton.assertExistenceAndTap()
         
         datePicker1.assertExistenceAndTap()
+        
+#if os(visionOS)
+        XCTExpectFailure("Opening the date picker's month & year picker doesn't work as expected on visionOS.")
+#endif
         
         currentMonthYearLabel.assertExistenceAndTap()
         
@@ -1997,23 +2032,23 @@ final class FeatureFormViewTests: XCTestCase {
         
         dismissPopover.firstMatch.assertExistenceAndTap()
         
-        doneButton.assertExistenceAndTap()
+        app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(streetLightCandidates.count, 1)
     }
     
     func testCase_13_6() throws {
-        try skipIf(macCatalyst: true, visionOS: true)
+        try skipIf(macCatalyst: true)
         
         let app = XCUIApplication()
         let addAssociationButton = app.staticTexts["Add Association"]
         let addButton = app.buttons["Add"]
         let addConditionButton = app.buttons["Add Condition"]
         let attachmentFilterTitle = app.staticTexts["Attachment"]
-        let doneButton = app.buttons["Done"]
         let electricDistributionDevice2Button = app.buttons["Electric Distribution Device, 2"]
         let electricDistributionDeviceDataSourceButton = app.buttons["Electric Distribution Device"]
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let textField = app.textFields["Enter a value"]
         let filterButton = app.buttons["Filter Candidates"]
         let formTitle = app.staticTexts["Structure Junction"]
@@ -2024,7 +2059,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        elementTitle.assertExistence()
+        app.filterElements(elementTitle)
+        
+        elementLabel.assertExistence()
         
         attachmentFilterTitle.assertExistenceAndTap()
         
@@ -2046,7 +2083,9 @@ final class FeatureFormViewTests: XCTestCase {
         
         textField.typeText("449")
         
-        doneButton.assertExistenceAndTap()
+        app.doneButton.assertExistenceAndTap()
+        
+        streetLightCandidates.firstMatch.assertExistence()
         
         XCTAssertEqual(streetLightCandidates.count, 1)
         
@@ -2073,6 +2112,14 @@ private extension String {
 }
 
 private extension XCUIApplication {
+    var doneButton: XCUIElement {
+#if os(visionOS)
+        buttons["Confirm"]
+#else
+        buttons["Done"]
+#endif
+    }
+    
     /// The element filter field.
     var filterElementsField: XCUIElement {
         searchFields["Filter Elements"]
@@ -2083,6 +2130,9 @@ private extension XCUIApplication {
         buttons["No value Combo Box Option"]
     }
     
+    func clearElementFilter() {
+        buttons["Clear text"].assertExistenceAndTap()
+    }
     
     func filterElements(_ text: String) {
         func focusFilter() {
@@ -2100,8 +2150,8 @@ private extension XCUIApplication {
         
         focusFilter()
         
-        if buttons["Clear text"].exists {
-            buttons["Clear text"].tap()
+        if !(filterElementsField.stringValue?.isEmpty ?? true) {
+            clearElementFilter()
             focusFilter()
         }
         

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -189,7 +189,6 @@ final class FeatureFormViewTests: XCTestCase {
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
         let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
-        let returnButton = app.buttons["Return"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
         
         openTestCase()
@@ -210,18 +209,11 @@ final class FeatureFormViewTests: XCTestCase {
         
         characterIndicator.assertExistence()
         
-        XCTAssertEqual(
-            characterIndicator.label,
-            "257"
-        )
+        characterIndicator.assertLabel("257")
         
         clearButton.assertExistence()
         
-#if targetEnvironment(macCatalyst)
         app.typeText("\r")
-#else
-        returnButton.tap()
-#endif
         
         fieldTitle.assertExistence()
         

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -57,15 +57,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            activityIndicator.waitForNonExistence(timeout: 5.0),
-            "Attachment loading took longer than 5 seconds."
-        )
+        activityIndicator.assertNonExistence()
         
-        XCTAssertTrue(
-            attachmentLabel.exists,
-            "The attachment was not present after loading completed."
-        )
+        attachmentLabel.assertExistence()
         
 #if targetEnvironment(macCatalyst)
         attachmentLabel.rightClick()
@@ -73,32 +67,15 @@ final class FeatureFormViewTests: XCTestCase {
         attachmentLabel.press(forDuration: 1)
 #endif
         
-        XCTAssertTrue(
-            rename.waitForExistence(timeout: 1),
-            "The rename button doesn't exist."
-        )
+        rename.assertExistenceAndTap()
         
-        rename.tap()
+        nameField.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            nameField.waitForExistence(timeout: 1),
-            "The name field doesn't exist."
-        )
-        
-        nameField.tap()
         app.typeText(#function)
         
-        XCTAssertTrue(
-            okButton.exists,
-            "The OK button doesn't exist."
-        )
+        okButton.assertExistenceAndTap()
         
-        okButton.tap()
-        
-        XCTAssertTrue(
-            renamedAttachmentLabel.waitForExistence(timeout: 2),
-            "The attachment was not present after renaming."
-        )
+        renamedAttachmentLabel.assertExistence()
     }
     
     // - MARK: Test case 1: Text Box with no hint, no description, value not required
@@ -115,10 +92,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
 #if !targetEnvironment(macCatalyst)
         XCTAssertFalse(
@@ -135,25 +109,16 @@ final class FeatureFormViewTests: XCTestCase {
         // Give focus to the target text field.
         textField.tap()
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
-        XCTAssertTrue(
-            footer.exists,
-            "The footer doesn't exist."
-        )
+        footer.assertExistence()
         
         XCTAssertEqual(
             footer.label,
             "Maximum 256 characters"
         )
         
-        XCTAssertTrue(
-            characterIndicator.exists,
-            "The character indicator doesn't exist."
-        )
+        characterIndicator.assertExistence()
         
         XCTAssertEqual(
             characterIndicator.label,
@@ -175,39 +140,27 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        textField.tap()
+        textField.assertExistenceAndTap()
         
         app.typeText("Sample text")
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
-        XCTAssertTrue(
-            footer.exists,
-            "The footer doesn't exist."
-        )
+        footer.assertExistence()
         
         XCTAssertEqual(
             footer.label,
             "Maximum 256 characters"
         )
         
-        XCTAssertTrue(
-            characterIndicator.exists,
-            "The character count doesn't exist."
-        )
+        characterIndicator.assertExistence()
         
         XCTAssertEqual(
             characterIndicator.label,
             "11"
         )
         
-        XCTAssertTrue(
-            clearButton.exists,
-            "The clear button doesn't exist."
-        )
+        clearButton.assertExistence()
         
 #if targetEnvironment(macCatalyst)
         app.typeText("\r")
@@ -254,35 +207,23 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.typeText(.loremIpsum257)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
-        XCTAssertTrue(
-            footer.exists,
-            "The footer doesn't exist."
-        )
+        footer.assertExistence()
         
         XCTAssertEqual(
             footer.label,
             "Maximum 256 characters"
         )
         
-        XCTAssertTrue(
-            characterIndicator.exists,
-            "The character count doesn't exist."
-        )
+        characterIndicator.assertExistence()
         
         XCTAssertEqual(
             characterIndicator.label,
             "257"
         )
         
-        XCTAssertTrue(
-            clearButton.exists,
-            "The clear button doesn't exist."
-        )
+        clearButton.assertExistence()
         
 #if targetEnvironment(macCatalyst)
         app.typeText("\r")
@@ -290,25 +231,16 @@ final class FeatureFormViewTests: XCTestCase {
         returnButton.tap()
 #endif
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
-        XCTAssertTrue(
-            footer.exists,
-            "The footer doesn't exist."
-        )
+        footer.assertExistence()
         
         XCTAssertEqual(
             footer.label,
             "Maximum 256 characters"
         )
         
-        XCTAssertFalse(
-            characterIndicator.exists,
-            "The character count exists."
-        )
+        characterIndicator.assertNonExistence()
         
         XCTAssertTrue(
             clearButton.isHittable,
@@ -394,27 +326,18 @@ final class FeatureFormViewTests: XCTestCase {
             "No Value"
         )
         
-        XCTAssertTrue(
-            footer.exists,
-            "The required label doesn't exist."
-        )
+        footer.assertExistence()
         
         XCTAssertEqual(
             footer.label,
             "Date Entry is Required"
         )
         
-        XCTAssertTrue(
-            calendarImage.exists,
-            "The calendar image doesn't exist."
-        )
+        calendarImage.assertExistence()
         
         fieldValue.tap()
         
-        XCTAssertTrue(
-            datePicker.exists,
-            "The date picker doesn't exist."
-        )
+        datePicker.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -468,10 +391,7 @@ final class FeatureFormViewTests: XCTestCase {
             "Enter the launch date and time (July 16, 1969 13:32 UTC)"
         )
         
-        XCTAssertTrue(
-            datePicker.exists,
-            "The date picker doesn't exist."
-        )
+        datePicker.assertExistence()
         
         XCTAssertTrue(
             nowButton.isHittable,
@@ -560,15 +480,9 @@ final class FeatureFormViewTests: XCTestCase {
         
         fieldValue.tap()
         
-        XCTAssertTrue(
-            footer.exists,
-            "The footer doesn't exist."
-        )
+        footer.assertExistence()
         
-        XCTAssertTrue(
-            nowButton.waitForExistence(timeout: 2.5),
-            "The Now button doesn't exist."
-        )
+        nowButton.assertExistence()
         
         XCTAssertTrue(
             nowButton.isHittable,
@@ -620,10 +534,7 @@ final class FeatureFormViewTests: XCTestCase {
         // Swipe up to reveal the entire date picker.
         app.scrollViews.firstMatch.swipeUp()
         
-        XCTAssertTrue(
-            footer.exists,
-            "The footer doesn't exist."
-        )
+        footer.assertExistence()
         
         XCTAssertEqual(
             footer.label,
@@ -849,12 +760,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.noValueComboBoxOption.tap()
         
-        XCTAssertTrue(
-            doneButton.exists,
-            "The done button doesn't exist."
-        )
-        
-        doneButton.tap()
+        doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -876,10 +782,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -891,31 +794,15 @@ final class FeatureFormViewTests: XCTestCase {
             "The clear button is hittable."
         )
         
-        XCTAssertTrue(
-            footer.exists,
-            "The footer doesn't exist."
-        )
+        footer.assertExistence()
         
         fieldValue.tap()
         
-        XCTAssertFalse(
-            app.noValueComboBoxOption.exists,
-            "The no value button exists but it should not."
-        )
+        app.noValueComboBoxOption.assertNonExistence()
         
-        XCTAssertTrue(
-            oakButton.exists,
-            "The Oak button doesn't exist."
-        )
+        oakButton.assertExistenceAndTap()
         
-        oakButton.tap()
-        
-        XCTAssertTrue(
-            doneButton.exists,
-            "The done button doesn't exist."
-        )
-        
-        doneButton.tap()
+        doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -937,27 +824,18 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
             ""
         )
         
-        optionsButton.tap()
+        optionsButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            firstOption.waitForExistence(timeout: 1),
-            "The First option doesn't exist."
-        )
+        firstOption.assertExistence()
         
-        XCTAssertFalse(
-            noValueButton.exists,
-            "No Value exists as an option but it shouldn't."
-        )
+        noValueButton.assertNonExistence()
         
         XCTAssertTrue(
             firstOption.isHittable,
@@ -966,12 +844,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         firstOption.tap()
         
-        XCTAssertTrue(
-            doneButton.exists,
-            "The done button doesn't exist."
-        )
-        
-        doneButton.tap()
+        doneButton.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -991,10 +864,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -1003,27 +873,13 @@ final class FeatureFormViewTests: XCTestCase {
         
         fieldValue.tap()
         
-        XCTAssertTrue(
-            unsupportedValueSectionHeader.waitForExistence(timeout: 1),
-            "The Unsupported Value section doesn't exist."
-        )
+        unsupportedValueSectionHeader.assertExistence()
         
-        XCTAssertTrue(
-            unsupportedValue.exists,
-            "The Unsupported Value doesn't exist."
-        )
+        unsupportedValue.assertExistence()
         
-        XCTAssertTrue(
-            app.noValueComboBoxOption.exists,
-            "No Value doesn't exist."
-        )
+        app.noValueComboBoxOption.assertExistenceAndTap()
         
-        app.noValueComboBoxOption.tap()
-        
-        XCTAssertFalse(
-            unsupportedValueSectionHeader.exists,
-            "The Unsupported Value section exists."
-        )
+        unsupportedValueSectionHeader.assertNonExistence()
     }
     
     // - MARK: Test case 4: Radio Buttons input type
@@ -1040,10 +896,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
         XCTAssertEqual(
             radioButtonTextPicker.stringValue,
@@ -1089,10 +942,7 @@ final class FeatureFormViewTests: XCTestCase {
         assertFormOpened(titleElement: formTitle)
         
         // Verify the Radio Button fallback to Combo Box was successful.
-        XCTAssertTrue(
-            field1.exists,
-            "The combo box doesn't exist."
-        )
+        field1.assertExistence()
         
         // Verify the radio buttons are shown even when the no value option is enabled.
         XCTAssertEqual(
@@ -1119,17 +969,14 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title isn't hittable."
-        )
+        fieldTitle.assertExistence()
         
         XCTAssertEqual(
             switchView.label,
             "2"
         )
         
-        switchView.tap()
+        switchView.assertExistenceAndTap()
         
         XCTAssertEqual(
             switchView.label,
@@ -1180,15 +1027,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.exists,
-            "The field title doesn't exist."
-        )
+        fieldTitle.assertExistence()
         
-        XCTAssertTrue(
-            fieldValue.exists,
-            "The combo box doesn't exist."
-        )
+        fieldValue.assertExistence()
     }
     
     /// Test case 6.1: Test initially expanded and collapsed
@@ -1211,15 +1052,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            expandedGroup.exists,
-            "The first group header doesn't exist."
-        )
+        expandedGroup.assertExistence()
         
-        XCTAssertTrue(
-            expandedGroupDescription.exists,
-            "The expanded group's description doesn't exist."
-        )
+        expandedGroupDescription.assertExistence()
         
         XCTAssertEqual(
             expandedGroupDescription.label,
@@ -1227,21 +1062,12 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         // Confirm the first element of the expanded group exists.
-        XCTAssertTrue(
-            expandedGroupFirstElement.exists,
-            "The first group element doesn't exist."
-        )
+        expandedGroupFirstElement.assertExistence()
         
-        XCTAssertTrue(
-            collapsedGroup.exists,
-            "The collapsed group header doesn't exist."
-        )
+        collapsedGroup.assertExistence()
         
         // Confirm the first element of the collapsed group doesn't exist.
-        XCTAssertFalse(
-            collapsedGroupFirstElement.exists,
-            "The first group element exists but should be hidden."
-        )
+        collapsedGroupFirstElement.assertNonExistence()
     }
     
     /// Test case 6.2: Test visibility of empty group
@@ -1264,15 +1090,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            hiddenElementsGroup.exists,
-            "The group header doesn't exist."
-        )
+        hiddenElementsGroup.assertExistence()
         
-        XCTAssertTrue(
-            hiddenElementsGroupDescription.exists,
-            "The expanded group's description doesn't exist."
-        )
+        hiddenElementsGroupDescription.assertExistence()
         
         XCTAssertEqual(
             hiddenElementsGroupDescription.label,
@@ -1280,16 +1100,10 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         // Confirm the first element of the conditional group doesn't exist.
-        XCTAssertFalse(
-            groupElement.exists,
-            "The first group element exists but should be hidden."
-        )
+        groupElement.assertNonExistence()
         
         // Confirm the option to show the elements exists.
-        XCTAssertTrue(
-            radioButtonPicker.exists,
-            "The Radio Button picker doesn't exist."
-        )
+        radioButtonPicker.assertExistence()
         
 #if !os(visionOS)
         radioButtonPicker.adjust(toPickerWheelValue: "Everything is working great")
@@ -1300,10 +1114,7 @@ final class FeatureFormViewTests: XCTestCase {
 #endif
         
         // Confirm the first element of the conditional group exists.
-        XCTAssertTrue(
-            groupElement.waitForExistence(timeout: 5),
-            "The first group element doesn't exist."
-        )
+        groupElement.assertExistence()
     }
     
     /// Test case 7.1: Test read only elements
@@ -1332,33 +1143,31 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(elementInTheGroupIsEditableReadOnlyInput.exists)
+        elementInTheGroupIsEditableReadOnlyInput.assertExistence()
         
-        XCTAssertTrue(comboBoxReadOnlyInput.exists)
+        comboBoxReadOnlyInput.assertExistence()
         
-        XCTAssertTrue(radioButtonsReadOnlyInput.exists)
+        radioButtonsReadOnlyInput.assertExistence()
         
-        XCTAssertTrue(dateReadOnlyInput.exists)
+        dateReadOnlyInput.assertExistence()
         
-        XCTAssertTrue(shortTextReadOnlyInput.exists)
+        shortTextReadOnlyInput.assertExistence()
         
-        XCTAssertTrue(longTextReadOnlyInput.exists)
+        longTextReadOnlyInput.assertExistence()
         
-        elementsAreEditableSwitch.tap()
+        elementsAreEditableSwitch.assertExistenceAndTap()
         
-        XCTAssertTrue(elementInTheGroupIsEditableSwitch.exists)
+        elementInTheGroupIsEditableSwitch.assertExistenceAndTap()
         
-        elementInTheGroupIsEditableSwitch.tap()
-        
-        XCTAssertTrue(comboBox.exists)
+        comboBox.assertExistence()
         
         XCTAssertEqual(radioButtonsPicker.stringValue, "0")
         
-        XCTAssertTrue(dateInput.exists)
+        dateInput.assertExistence()
         
-        XCTAssertTrue(shortTextTextInput.exists)
+        shortTextTextInput.assertExistence()
         
-        XCTAssertTrue(longTextTextInputPreview.exists)
+        longTextTextInputPreview.assertExistence()
     }
     
     func testCase_8_1() {
@@ -1374,17 +1183,17 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(attachmentElementTitle.waitForExistence(timeout: 10))
-        XCTAssertTrue(placeholderImage.exists)
-        XCTAssertTrue(attachmentName.exists)
-        XCTAssertTrue(sizeLabel.exists)
-        XCTAssertTrue(downloadIcon.exists)
+        attachmentElementTitle.assertExistence()
+        placeholderImage.assertExistence()
+        attachmentName.assertExistence()
+        sizeLabel.assertExistence()
+        downloadIcon.assertExistence()
         
-        placeholderImage.tap()
+        placeholderImage.assertExistenceAndTap()
         
-        XCTAssertTrue(thumbnailImage.waitForExistence(timeout: 10))
-        XCTAssertFalse(placeholderImage.exists)
-        XCTAssertFalse(downloadIcon.exists)
+        thumbnailImage.assertExistence()
+        placeholderImage.assertNonExistence()
+        downloadIcon.assertNonExistence()
     }
     
     /// Test substitution
@@ -1399,24 +1208,21 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            titleTextField.waitForExistence(timeout: 10),
-            "The text field wasn't found after 10 seconds."
-        )
+        titleTextField.assertExistence()
         
         XCTAssertEqual(
             titleTextField.value as? String,
             "Redlands"
         )
         
-        XCTAssertTrue(redlandsText.exists)
+        redlandsText.assertExistence()
         
-        titleClearButton.tap()
-        titleTextField.tap()
+        titleClearButton.assertExistenceAndTap()
+        titleTextField.assertExistenceAndTap()
         
         titleTextField.typeText("Los Angeles")
         
-        XCTAssertTrue(losAngelesText.exists)
+        losAngelesText.assertExistence()
     }
     
     /// Test plain text
@@ -1428,7 +1234,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(plainText.exists)
+        plainText.assertExistence()
     }
     
     /// Test case 11.1: Barcode Scan and Clear buttons
@@ -1444,15 +1250,15 @@ final class FeatureFormViewTests: XCTestCase {
         assertFormOpened(titleElement: formTitle)
         
 #if !os(visionOS)
-        XCTAssertTrue(scanButton.exists, "The scan button doesn't exist.")
+        scanButton.assertExistence()
 #endif
-        XCTAssertFalse(clearButton.exists, "The clear button exists.")
+        clearButton.assertNonExistence()
         
-        fieldValue.tap()
+        fieldValue.assertExistenceAndTap()
         fieldValue.typeText("https://esri.com/this_is_a_string_longer_than_50_count_on_it")
         
 #if !os(visionOS)
-        XCTAssertTrue(scanButton.exists, "The scan button doesn't exist.")
+        scanButton.assertExistence()
 #endif
         XCTAssertEqual(barcodeValidationString.label, "Maximum 50 characters")
     }
@@ -1475,59 +1281,30 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            filterResults1.waitForExistence(timeout: 5),
-            "The filter result \"Connected\" doesn't exist."
-        )
+        filterResults1.assertExistence()
         
-        XCTAssertTrue(
-            filterResults2.exists,
-            "The filter result \"Structure\" doesn't exist."
-        )
+        filterResults2.assertExistence()
         
-        XCTAssertTrue(
-            filterResults3.exists,
-            "The filter result \"Container\" doesn't exist."
-        )
+        filterResults3.assertExistence()
         
         filterResults1.tap()
         
-        XCTAssertTrue(
-            networkSourceGroup1.exists,
-            "The network source group \"Electric Distribution Junction\" doesn't exist."
-        )
+        networkSourceGroup1.assertExistence()
         
-        XCTAssertTrue(
-            networkSourceGroup2Button.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
+        networkSourceGroup2Button.assertExistenceAndTap()
         
-        networkSourceGroup2Button.tap()
+        utilityElement1Button.assertExistence()
         
-        XCTAssertTrue(
-            utilityElement1Button.waitForExistence(timeout: 30),
-            "Feature \"Fuse\" failed to appear after 30 seconds."
-        )
-        
-        XCTAssertTrue(
-            utilityElement2Button.exists,
-            "The utility element \"Fuse\" doesn't exist."
-        )
+        utilityElement2Button.assertExistence()
         
         utilityElement1Button.tap()
         
         // Open new form
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            assetGroup.exists,
-            "The asset group \"Asset group\" doesn't exist."
-        )
+        assetGroup.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -1550,30 +1327,14 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            filterResults.waitForExistence(timeout: 5),
-            "The filter result \"Content\" doesn't exist."
-        )
+        filterResults.assertExistenceAndTap()
         
-        filterResults.tap()
-        
-        XCTAssertTrue(
-            networkSourceGroupButton.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
-        
-        networkSourceGroupButton.tap()
+        networkSourceGroupButton.assertExistenceAndTap()
         
         // Expectation: a list of one utility elements with "Content"
-        XCTAssertTrue(
-            utilityElementButton.exists,
-            "The utility element \"Circuit Breaker\" doesn't exist."
-        )
+        utilityElementButton.assertExistence()
     }
     
     func testCase_12_4() {
@@ -1587,30 +1348,14 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            filterResults.waitForExistence(timeout: 5),
-            "The filter result \"Container\" doesn't exist."
-        )
+        filterResults.assertExistenceAndTap()
         
-        filterResults.tap()
-        
-        XCTAssertTrue(
-            networkSourceGroup.waitForExistence(timeout: 5),
-            "The network source group \"Structure Boundary\" doesn't exist."
-        )
-        
-        networkSourceGroup.tap()
+        networkSourceGroup.assertExistenceAndTap()
         
         // Expectation: a list of one utility elements with no "Containment Visible" label
-        XCTAssertTrue(
-            utilityElementButton.exists,
-            "The utility element \"Substation\" doesn't exist."
-        )
+        utilityElementButton.assertExistence()
     }
     
     func testCase_12_5() {
@@ -1631,38 +1376,17 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            filterResults.waitForExistence(timeout: 5),
-            "The filter result \"Connected\" doesn't exist."
-        )
+        filterResults.assertExistenceAndTap()
         
-        filterResults.tap()
+        networkSourceGroupButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            networkSourceGroupButton.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
-        
-        networkSourceGroupButton.tap()
-        
-        XCTAssertTrue(
-            utilityElementButton.waitForExistence(timeout: 5),
-            "The utility element \"Transformer\" doesn't exist."
-        )
-        
-        utilityElementButton.tap()
+        utilityElementButton.assertExistenceAndTap()
         
         assertFormOpened(titleElement: formTitle2)
         
-        XCTAssertTrue(
-            assetType.exists,
-            "The field form element \"Asset type *\"doesn't exist."
-        )
+        assetType.assertExistence()
         
         fieldValue.tap()
         
@@ -1684,21 +1408,12 @@ final class FeatureFormViewTests: XCTestCase {
         backButton.tap()
         
         // Expectation: an alert appears with "Discard Edits", "Save Edits", and "Continue Editing" options
-        XCTAssertTrue(
-            discardEditsButton.exists,
-            "The alert \"Discard Edits\" doesn't exist."
-        )
-        
-        // Tap the "Discard" option. Note that some platforms may use "Discard Edits".
-        discardEditsButton.tap()
+        discardEditsButton.assertExistenceAndTap()
         
         // Access the new `FeatureForm`
         // Expectation: the form title should be "Electric Distribution Junction"
         // Expectation: a list of one utility elements entitled "Transformer - 2552"
-        XCTAssertTrue(
-            utilityElementButton.waitForExistence(timeout: 5),
-            "The utility element \"Transformer - 2552\" doesn't exist."
-        )
+        utilityElementButton.assertExistence()
     }
     
     func testCase_12_6() {
@@ -1724,85 +1439,34 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: electricDistributionDevice)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            connectedFilterTitle.waitForExistence(timeout: 5),
-            "The filter result \"Connected\" doesn't exist."
-        )
+        connectedFilterTitle.assertExistenceAndTap()
         
-        connectedFilterTitle.tap()
+        networkSourceGroupButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            networkSourceGroupButton.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
+        transformerButton.assertExistence()
         
-        networkSourceGroupButton.tap()
+        moreOptionsButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            transformerButton.waitForExistence(timeout: 5),
-            "The \"Transformer\" association doesn't exist."
-        )
+        removeAssociationButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            moreOptionsButton.waitForExistence(timeout: 5),
-            "The association settings button doesn't exist."
-        )
-        
-        moreOptionsButton.tap()
-        
-        XCTAssertTrue(
-            removeAssociationButton.waitForExistence(timeout: 5),
-            "The remove association button doesn't exist."
-        )
-        
-        removeAssociationButton.tap()
-        
-        XCTAssertTrue(
-            cancelButton.waitForExistence(timeout: 5),
-            "The cancel button doesn't exist."
-        )
-        
-        cancelButton.tap()
+        cancelButton.assertExistenceAndTap()
         
         moreOptionsButton.tap()
         
         removeAssociationButton.tap()
         
-        XCTAssertTrue(
-            removeButton.waitForExistence(timeout: 5),
-            "The remove button doesn't exist."
-        )
+        removeButton.assertExistenceAndTap()
         
-        removeButton.tap()
+        // Expectation: Navigation returns to the "Connected" filter results page.
+        connectedFilterTitle.assertExistence()
         
-        XCTAssertTrue(
-            connectedFilterTitle.waitForExistence(timeout: 5),
-            #"Navigation did not return to the "Connected" filter results page."#
-        )
+        discardButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            discardButton.waitForExistence(timeout: 5),
-            "The discard button doesn't exist."
-        )
+        networkSourceGroupButton.assertExistenceAndTap()
         
-        discardButton.tap()
-        
-        XCTAssertTrue(
-            networkSourceGroupButton.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
-        
-        networkSourceGroupButton.tap()
-        
-        XCTAssertTrue(
-            transformerButton.waitForExistence(timeout: 5),
-            "The \"Transformer\" association doesn't exist."
-        )
+        transformerButton.assertExistence()
         
 #if targetEnvironment(macCatalyst)
         moreOptionsButton.tap()
@@ -1810,52 +1474,22 @@ final class FeatureFormViewTests: XCTestCase {
         transformerButton.swipeLeft()
 #endif
         
-        XCTAssertTrue(
-            removeAssociationButton.waitForExistence(timeout: 5),
-            "The delete button doesn't exist."
-        )
+        removeAssociationButton.assertExistenceAndTap()
         
-        removeAssociationButton.tap()
-        
-        XCTAssertTrue(
-            cancelButton.waitForExistence(timeout: 5),
-            "The cancel button doesn't exist."
-        )
-        
-        cancelButton.tap()
+        cancelButton.assertExistenceAndTap()
         
 #if targetEnvironment(macCatalyst)
         moreOptionsButton.tap()
-        XCTAssertTrue(
-            removeAssociationButton.waitForExistence(timeout: 5),
-            "The delete button doesn't exist."
-        )
-        removeAssociationButton.tap()
 #else
         transformerButton.swipeLeft()
-        XCTAssertTrue(
-            removeAssociationButton.waitForExistence(timeout: 5),
-            "The delete button doesn't exist."
-        )
-        removeAssociationButton.tap()
 #endif
+        removeAssociationButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            removeButton.waitForExistence(timeout: 5),
-            "The remove button doesn't exist."
-        )
+        removeButton.assertExistenceAndTap()
         
-        removeButton.tap()
+        discardButton.assertExistence()
         
-        XCTAssertTrue(
-            discardButton.waitForExistence(timeout: 5),
-            "The discard button doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            connectedFilterTitle.waitForExistence(timeout: 5),
-            #"Navigation did not return to the "Connected" filter results page."#
-        )
+        connectedFilterTitle.assertExistence()
     }
     
     func testCase_13_1() {
@@ -1890,116 +1524,47 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            connectedFilterTitle.waitForExistence(timeout: 5),
-            "The filter result \"Connected\" doesn't exist."
-        )
+        connectedFilterTitle.assertExistenceAndTap()
         
-        connectedFilterTitle.tap()
+        addAssociationButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            addAssociationButton.waitForExistence(timeout: 5),
-            "The \"Add Association\" button doesn't exist."
-        )
+        electricDistributionDeviceDataSourceButton.assertExistence()
         
-        addAssociationButton.tap()
-        
-        XCTAssertTrue(
-            electricDistributionDeviceDataSourceButton.waitForExistence(timeout: 5),
-            "The \"Electric Distribution Device\" button doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            electricDistributionJunctionDataSourceButton.waitForExistence(timeout: 5),
-            "The \"Electric Distribution Junction\" button doesn't exist."
-        )
+        electricDistributionJunctionDataSourceButton.assertExistence()
         
         electricDistributionDeviceDataSourceButton.tap()
         
-        XCTAssertTrue(
-            searchField.waitForExistence(timeout: 5),
-            "The \"Search\" field doesn't exist."
-        )
-        
-        searchField.tap()
+        searchField.assertExistenceAndTap()
         
         searchField.typeText("Cabinet Fuse")
         
-        XCTAssertTrue(
-            cabinetFuseButton.waitForExistence(timeout: 5),
-            "The \"Search\" field doesn't exist."
-        )
+        cabinetFuseButton.assertExistenceAndTap()
         
-        cabinetFuseButton.tap()
+        fuseButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            fuseButton.firstMatch.waitForExistence(timeout: 5),
-            "The \"Fuse\" candidate doesn't exist."
-        )
+        newAssociationText.assertExistence()
         
-        fuseButton.tap()
+        associationTypeLabel.assertExistence()
         
-        XCTAssertTrue(
-            newAssociationText.waitForExistence(timeout: 5),
-            "The New Association header text doesn't exist."
-        )
+        connectivityLabel.assertExistence()
         
-        XCTAssertTrue(
-            associationTypeLabel.waitForExistence(timeout: 5),
-            "The association type label doesn't exist."
-        )
+        fromElementLabel.assertExistence()
         
-        XCTAssertTrue(
-            connectivityLabel.waitForExistence(timeout: 5),
-            "The association type value doesn't exist."
-        )
+        electricDistributionDeviceLabel.assertExistence()
         
-        XCTAssertTrue(
-            fromElementLabel.waitForExistence(timeout: 5),
-            "The from element label doesn't exist."
-        )
+        toElementLabel.assertExistence()
         
-        XCTAssertTrue(
-            electricDistributionDeviceLabel.waitForExistence(timeout: 5),
-            "The from element value doesn't exist."
-        )
+        fuseLabel.assertExistence()
         
-        XCTAssertTrue(
-            toElementLabel.waitForExistence(timeout: 5),
-            "The to element label doesn't exist."
-        )
+        addButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            fuseLabel.waitForExistence(timeout: 5),
-            "The to element value doesn't exist."
-        )
+        networkSourceGroupButtonAfter.assertExistence()
         
-        XCTAssertTrue(
-            addButton.waitForExistence(timeout: 5),
-            "The add button doesn't exist."
-        )
+        saveButton.assertExistence()
         
-        addButton.tap()
-        
-        XCTAssertTrue(
-            networkSourceGroupButtonAfter.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            saveButton.waitForExistence(timeout: 5),
-            "The save button doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            discardButton.waitForExistence(timeout: 5),
-            "The discard button doesn't exist."
-        )
+        discardButton.assertExistence()
     }
     
     func testCase_13_2() {
@@ -2042,150 +1607,67 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            connectedFilterTitle.waitForExistence(timeout: 5),
-            "The filter result \"Connected\" doesn't exist."
-        )
+        connectedFilterTitle.assertExistenceAndTap()
         
-        connectedFilterTitle.tap()
+        electricDistributionJunctionButton5.assertExistence()
         
-        XCTAssertTrue(
-            electricDistributionJunctionButton5.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Junction\" doesn't exist."
-        )
+        electricDistributionDevice2.assertExistence()
         
-        XCTAssertTrue(
-            electricDistributionDevice2.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
+        addAssociationButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            addAssociationButton.waitForExistence(timeout: 5),
-            "The \"Add Association\" button doesn't exist."
-        )
+        electricDistributionDeviceDataSourceButton.assertExistence()
         
-        addAssociationButton.tap()
-        
-        XCTAssertTrue(
-            electricDistributionDeviceDataSourceButton.waitForExistence(timeout: 5),
-            "The \"Electric Distribution Device\" button doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            electricDistributionJunctionDataSourceButton.waitForExistence(timeout: 5),
-            "The \"Electric Distribution Junction\" button doesn't exist."
-        )
+        electricDistributionJunctionDataSourceButton.assertExistence()
         
         electricDistributionDeviceDataSourceButton.tap()
         
-        searchField.tap()
+        searchField.assertExistenceAndTap()
         
         searchField.typeText("Disconnect")
         
-        XCTAssertTrue(
-            undergroundMediumVoltageThreePhaseDisconnectButton.firstMatch.waitForExistence(timeout: 5),
-            "The Underground Medium Voltage Three Phase Disconnect button doesn't exist."
-        )
+        undergroundMediumVoltageThreePhaseDisconnectButton.firstMatch.assertExistenceAndTap()
         
-        undergroundMediumVoltageThreePhaseDisconnectButton.firstMatch.tap()
+        switchButton.firstMatch.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            switchButton.firstMatch.waitForExistence(timeout: 5),
-            "The \"Switch\" candidate doesn't exist."
-        )
+        newAssociationText.assertExistence()
         
-        switchButton.firstMatch.tap()
+        associationTypeLabel.assertExistence()
         
-        XCTAssertTrue(
-            newAssociationText.waitForExistence(timeout: 5),
-            "The New Association header text doesn't exist."
-        )
+        connectivityLabel.assertExistence()
         
-        XCTAssertTrue(
-            associationTypeLabel.waitForExistence(timeout: 5),
-            "The association type label doesn't exist."
-        )
+        fromElementLabel.assertExistence()
         
-        XCTAssertTrue(
-            connectivityLabel.waitForExistence(timeout: 5),
-            "The association type value doesn't exist."
-        )
+        electricDistributionDeviceLabel.assertExistence()
         
-        XCTAssertTrue(
-            fromElementLabel.waitForExistence(timeout: 5),
-            "The from element label doesn't exist."
-        )
+        terminalLabel.assertExistence()
         
-        XCTAssertTrue(
-            electricDistributionDeviceLabel.waitForExistence(timeout: 5),
-            "The from element value doesn't exist."
-        )
+        terminalPicker.assertExistence()
         
-        XCTAssertTrue(
-            terminalLabel.waitForExistence(timeout: 5),
-            "The terminal label doesn't exist."
-        )
+        toElementLabel.assertExistence()
         
-        XCTAssertTrue(
-            terminalPicker.waitForExistence(timeout: 5),
-            "The terminal picker doesn't exist."
-        )
+        switchLabel.assertExistence()
         
-        XCTAssertTrue(
-            toElementLabel.waitForExistence(timeout: 5),
-            "The to element label doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            switchLabel.waitForExistence(timeout: 5),
-            "The to element value doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            addButton.waitForExistence(timeout: 5),
-            "The add button doesn't exist."
-        )
+        addButton.assertExistence()
         
         terminalPicker.tap()
         
-        XCTAssertTrue(
-            terminalHighButton.waitForExistence(timeout: 5),
-            "The High terminal option doesn't exist."
-        )
+        terminalHighButton.assertExistence()
         
-        XCTAssertTrue(
-            terminalLowButton.waitForExistence(timeout: 5),
-            "The Low terminal option doesn't exist."
-        )
+        terminalLowButton.assertExistence()
         
         terminalHighButton.tap()
         
         addButton.tap()
         
-        XCTAssertTrue(
-            electricDistributionJunctionButton5.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Junction\" doesn't exist."
-        )
+        electricDistributionJunctionButton5.assertExistence()
         
-        XCTAssertTrue(
-            electricDistributionDevice3.waitForExistence(timeout: 5),
-            "The network source group \"Electric Distribution Device\" doesn't exist."
-        )
+        electricDistributionDevice3.assertExistence()
         
-        XCTAssertTrue(
-            saveButton.waitForExistence(timeout: 5),
-            "The save button doesn't exist."
-        )
+        saveButton.assertExistence()
         
-        XCTAssertTrue(
-            discardButton.waitForExistence(timeout: 5),
-            "The discard button doesn't exist."
-        )
+        discardButton.assertExistence()
     }
     
     func testCase_13_3() {
@@ -2220,109 +1702,45 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            elementTitle.waitForExistence(timeout: 5),
-            "The element \"Associations\" doesn't exist."
-        )
+        elementTitle.assertExistence()
         
-        XCTAssertTrue(
-            containerFilterTitle.waitForExistence(timeout: 5),
-            "The filter result \"Container\" doesn't exist."
-        )
+        containerFilterTitle.assertExistenceAndTap()
         
-        containerFilterTitle.tap()
+        addAssociationButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            addAssociationButton.waitForExistence(timeout: 5),
-            "The \"Add Association\" button doesn't exist."
-        )
+        structureJunctionDataSourceButton.assertExistenceAndTap()
         
-        addAssociationButton.tap()
+        vaultAssetTypeButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            structureJunctionDataSourceButton.waitForExistence(timeout: 5),
-            "The \"Structure Junction\" button doesn't exist."
-        )
+        vaultCandidateButton.assertExistenceAndTap()
         
-        structureJunctionDataSourceButton.tap()
+        newAssociationText.assertExistence()
         
-        XCTAssertTrue(
-            vaultAssetTypeButton.firstMatch.waitForExistence(timeout: 5),
-            "The Vault button doesn't exist."
-        )
+        associationTypeLabel.assertExistence()
         
-        vaultAssetTypeButton.tap()
+        containmentLabel.assertExistence()
         
-        XCTAssertTrue(
-            vaultCandidateButton.waitForExistence(timeout: 5),
-            "The \"Vault\" candidate doesn't exist."
-        )
+        contentVisibleSwitch.assertExistence()
         
-        vaultCandidateButton.tap()
+        fromElementLabel.assertExistence()
         
-        XCTAssertTrue(
-            newAssociationText.waitForExistence(timeout: 5),
-            "The New Association header text doesn't exist."
-        )
+        toElementValueLabel.assertExistence()
         
-        XCTAssertTrue(
-            associationTypeLabel.waitForExistence(timeout: 5),
-            "The association type label doesn't exist."
-        )
+        toElementLabel.assertExistence()
         
-        XCTAssertTrue(
-            containmentLabel.waitForExistence(timeout: 5),
-            "The association type value doesn't exist."
-        )
+        electricDistributionJunctionLabel.assertExistence()
         
-        XCTAssertTrue(
-            contentVisibleSwitch.waitForExistence(timeout: 5),
-            "The content visibility switch doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            fromElementLabel.waitForExistence(timeout: 5),
-            "The from element label doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            toElementValueLabel.waitForExistence(timeout: 5),
-            "The from element value doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            toElementLabel.waitForExistence(timeout: 5),
-            "The to element label doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            electricDistributionJunctionLabel.waitForExistence(timeout: 5),
-            "The to element value doesn't exist."
-        )
-        
-        XCTAssertTrue(
-            addButton.waitForExistence(timeout: 5),
-            "The add button doesn't exist."
-        )
+        addButton.assertExistence()
         
         contentVisibleSwitch.tap()
         
         addButton.tap()
         
-        XCTAssertTrue(
-            structureJunction2.waitForExistence(timeout: 5),
-            "The added structure junction doesn't exist."
-        )
+        structureJunction2.assertExistence()
         
-        XCTAssertTrue(
-            saveButton.waitForExistence(timeout: 5),
-            "The save button doesn't exist."
-        )
+        saveButton.assertExistence()
         
-        XCTAssertTrue(
-            discardButton.waitForExistence(timeout: 5),
-            "The discard button doesn't exist."
-        )
+        discardButton.assertExistence()
     }
     
     func testCase_13_4() throws {

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1797,6 +1797,8 @@ final class FeatureFormViewTests: XCTestCase {
         
         lowVoltageSinglePhaseLineEnd.assertExistenceAndTap()
         
+        lineEndCandidates.firstMatch.assertExistence()
+        
         XCTAssertEqual(lineEndCandidates.count, 2)
         
         filterButton.assertExistenceAndTap()
@@ -1904,6 +1906,8 @@ final class FeatureFormViewTests: XCTestCase {
         
         municipalButton.assertExistenceAndTap()
         
+        streetLightCandidates.firstMatch.assertExistence()
+        
         XCTAssertTrue(streetLightCandidates.count > 3)
         
         filterButton.assertExistenceAndTap()
@@ -1951,7 +1955,7 @@ final class FeatureFormViewTests: XCTestCase {
     
     func testCase_13_6() throws {
         try skipIf(macCatalyst: true, visionOS: true)
-
+        
         let app = XCUIApplication()
         let addAssociationButton = app.staticTexts["Add Association"]
         let addButton = app.buttons["Add"]
@@ -1980,6 +1984,8 @@ final class FeatureFormViewTests: XCTestCase {
         electricDistributionDeviceDataSourceButton.assertExistenceAndTap()
         
         municipalButton.assertExistenceAndTap()
+        
+        streetLightCandidates.firstMatch.assertExistence()
         
         XCTAssertTrue(streetLightCandidates.count > 3)
         

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -84,7 +84,8 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_1_1() throws {
         let app = XCUIApplication()
         let characterIndicator = app.staticTexts["Single Line No Value, Placeholder or Description Character Indicator"]
-        let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
+        let fieldTitle = "Single Line No Value, Placeholder or Description"
+        let fieldLabel = app.staticTexts[fieldTitle]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
@@ -92,7 +93,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldTitle.assertExistence()
+        app.filterElements(fieldTitle)
+        
+        fieldLabel.assertExistence()
         
 #if !targetEnvironment(macCatalyst)
         XCTAssertFalse(
@@ -109,7 +112,7 @@ final class FeatureFormViewTests: XCTestCase {
         // Give focus to the target text field.
         textField.tap()
         
-        fieldTitle.assertExistence()
+        fieldLabel.assertExistence()
         
         footer.assertExistence()
         
@@ -131,7 +134,8 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let characterIndicator = app.staticTexts["Single Line No Value, Placeholder or Description Character Indicator"]
         let clearButton = app.buttons["Single Line No Value, Placeholder or Description Clear Button"]
-        let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
+        let fieldTitle = "Single Line No Value, Placeholder or Description"
+        let fieldLabel = app.staticTexts[fieldTitle]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
@@ -139,11 +143,13 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(fieldTitle)
+        
         textField.assertExistenceAndTap()
         
         app.typeText("Sample text")
         
-        fieldTitle.assertExistence()
+        fieldLabel.assertExistence()
         
         footer.assertExistence()
         
@@ -161,7 +167,7 @@ final class FeatureFormViewTests: XCTestCase {
         app.typeText("\r")
         
         XCTAssertTrue(
-            fieldTitle.isHittable,
+            fieldLabel.isHittable,
             "The title isn't hittable."
         )
         
@@ -188,17 +194,20 @@ final class FeatureFormViewTests: XCTestCase {
         let clearButton = app.buttons["Single Line No Value, Placeholder or Description Clear Button"]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
-        let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
+        let fieldTitle = "Single Line No Value, Placeholder or Description"
+        let fieldLabel = app.staticTexts[fieldTitle]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(fieldTitle)
+        
         textField.tap()
         
         app.typeText(.loremIpsum257)
         
-        fieldTitle.assertExistence()
+        fieldLabel.assertExistence()
         
         footer.assertExistence()
         
@@ -215,7 +224,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.typeText("\r")
         
-        fieldTitle.assertExistence()
+        fieldLabel.assertExistence()
         
         footer.assertExistence()
         
@@ -286,16 +295,19 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 2.1: Unfocused and focused state, no value, date required
     func testCase_2_1() throws {
         let app = XCUIApplication()
-        let calendarImage = app.images["Required Date Calendar Image"]
-        let clearButton = app.buttons["Required Date Clear Button"]
-        let datePicker = app.datePickers["Required Date Date Picker"]
-        let fieldValue = app.staticTexts["Required Date Value"]
-        let footer = app.staticTexts["Required Date Footer"]
+        let fieldTitle = "Required Date"
+        let calendarImage = app.images["\(fieldTitle) Calendar Image"]
+        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
+        let datePicker = app.datePickers["\(fieldTitle) Date Picker"]
+        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
+        let footer = app.staticTexts["\(fieldTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["Required Date Now Button"]
+        let nowButton = app.buttons["\(fieldTitle) Now Button"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
+        
+        app.filterElements(fieldTitle)
         
         if fieldValue.label != "No Value" {
             clearButton.tap()
@@ -338,22 +350,22 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 2.2: Focused and unfocused state, with value (populated)
     func testCase_2_2() {
         let app = XCUIApplication()
-        let datePicker = app.datePickers["Launch Date and Time for Apollo 11 Date Picker"]
-        let fieldTitle = app.staticTexts["Launch Date and Time for Apollo 11"]
-        let fieldValue = app.staticTexts["Launch Date and Time for Apollo 11 Value"]
-        let footer = app.staticTexts["Launch Date and Time for Apollo 11 Footer"]
+        let fieldTitle = "Launch Date and Time for Apollo 11"
+        let datePicker = app.datePickers["\(fieldTitle) Date Picker"]
+        let fieldLabel = app.staticTexts[fieldTitle]
+        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
+        let footer = app.staticTexts["\(fieldTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["Launch Date and Time for Apollo 11 Now Button"]
+        let nowButton = app.buttons["\(fieldTitle) Now Button"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(fieldTitle)
+        
         fieldValue.tap()
         
-        XCTAssertTrue(
-            fieldTitle.isHittable,
-            "The field title isn't hittable."
-        )
+        fieldLabel.assertExistence()
         
         let localDate = Calendar.current.date(
             from: DateComponents(
@@ -445,14 +457,17 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 2.4: Maximum date
     func testCase_2_4() {
         let app = XCUIApplication()
-        let clearButton = app.buttons["Launch Date Time End Clear Button"]
-        let fieldValue = app.staticTexts["Launch Date Time End Value"]
-        let footer = app.staticTexts["Launch Date Time End Footer"]
+        let fieldTitle = "Launch Date Time End"
+        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
+        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
+        let footer = app.staticTexts["\(fieldTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["Launch Date Time End Now Button"]
+        let nowButton = app.buttons["\(fieldTitle) Now Button"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
+        
+        app.filterElements(fieldTitle)
         
         if fieldValue.label != "No Value" {
             clearButton.tap()
@@ -498,18 +513,21 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 2.5: Minimum date
     func testCase_2_5() {
         let app = XCUIApplication()
-        let datePicker = app.datePickers["start and end date time Date Picker"]
-        let fieldValue = app.staticTexts["start and end date time Value"]
-        let footer = app.staticTexts["start and end date time Footer"]
+        let fieldTitle = "start and end date time"
+        let datePicker = app.datePickers["\(fieldTitle) Date Picker"]
+        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
+        let footer = app.staticTexts["\(fieldTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["start and end date time Now Button"]
+        let nowButton = app.buttons["\(fieldTitle) Now Button"]
         let previousMonthButton = datePicker.buttons["Previous Month"]
         let julyFirstButton = datePicker.collectionViews.staticTexts["1"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldValue.tap()
+        app.filterElements(fieldTitle)
+        
+        fieldValue.assertExistenceAndTap()
         
         // Swipe up to reveal the entire date picker.
         app.scrollViews.firstMatch.swipeUp()
@@ -582,17 +600,20 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.1: Pre-existing value, description, clear button, no value label
     func testCase_3_1() {
         let app = XCUIApplication()
-        let clearButton = app.buttons["Combo String Clear Button"]
-        let fieldTitle = app.staticTexts["Combo String"]
-        let fieldValue = app.staticTexts["Combo String Combo Box Value"]
+        let fieldTitle = "Combo String"
+        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
+        let fieldLabel = app.staticTexts[fieldTitle]
+        let fieldValue = app.staticTexts["\(fieldTitle) Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
-        let footer = app.staticTexts["Combo String Footer"]
+        let footer = app.staticTexts["\(fieldTitle) Footer"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(fieldTitle)
+        
         XCTAssertTrue(
-            fieldTitle.isHittable,
+            fieldLabel.isHittable,
             "The field title isn't hittable."
         )
         
@@ -618,10 +639,7 @@ final class FeatureFormViewTests: XCTestCase {
             "No value"
         )
         
-        XCTAssertTrue(
-            footer.isHittable,
-            "The footer isn't hittable."
-        )
+        footer.assertExistence()
         
         XCTAssertEqual(
             footer.label,
@@ -761,10 +779,11 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.5: Required Value
     func testCase_3_5() {
         let app = XCUIApplication()
-        let clearButton = app.buttons["Required Combo Box Clear Button"]
-        let fieldTitle = app.staticTexts["Required Combo Box *"]
-        let fieldValue = app.staticTexts["Required Combo Box Combo Box Value"]
-        let footer = app.staticTexts["Required Combo Box Footer"]
+        let fieldTitle = "Required Combo Box"
+        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
+        let fieldLabel = app.staticTexts["\(fieldTitle) *"]
+        let fieldValue = app.staticTexts["\(fieldTitle) Combo Box Value"]
+        let footer = app.staticTexts["\(fieldTitle) Footer"]
         let formTitle = app.staticTexts["comboBox"]
         let oakButton = app.buttons["Oak"]
         
@@ -777,7 +796,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldTitle.assertExistence()
+        app.filterElements(fieldTitle)
+        
+        fieldLabel.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -855,16 +876,19 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.7: Unsupported value
     func testCase_3_7() throws {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["Unsupported Value"]
-        let fieldValue = app.staticTexts["Unsupported Value Combo Box Value"]
+        let fieldTitle = "Unsupported Value"
+        let fieldLabel = app.staticTexts[fieldTitle]
+        let fieldValue = app.staticTexts["\(fieldTitle) Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
-        let unsupportedValueSectionHeader = app.staticTexts["Unsupported Value Unsupported Value Section"]
+        let unsupportedValueSectionHeader = app.staticTexts["\(fieldTitle) Unsupported Value Section"]
         let unsupportedValue = app.buttons["0"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldTitle.assertExistence()
+        app.filterElements(fieldTitle)
+        
+        fieldLabel.assertExistence()
         
         XCTAssertEqual(
             fieldValue.label,
@@ -886,75 +910,63 @@ final class FeatureFormViewTests: XCTestCase {
     
     /// Test case 4.1: Test regular selection
     func testCase_4_1() throws {
-        try skipIf(visionOS: true)
-        
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["Radio Button Text *"]
+        let birdOption = app.buttons["bird"]
+        let dogOption = app.buttons["dog"]
+        let fieldTitle = "Radio Button Text"
+        let fieldLabel = app.staticTexts["\(fieldTitle) *"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let radioButtonTextPicker = app.pickers["Radio Button Text"].pickerWheels.firstMatch
+        let noValueOption = app.buttons["No Value"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldTitle.assertExistence()
+        app.filterElements(fieldTitle)
         
-        XCTAssertEqual(
-            radioButtonTextPicker.stringValue,
-            "bird"
-        )
+        fieldLabel.assertExistence()
+        noValueOption.assertExistence()
+        birdOption.assertExistence()
+        dogOption.assertExistence()
         
-        XCTAssertNotEqual(
-            radioButtonTextPicker.stringValue,
-            "dog"
-        )
+        XCTAssertTrue(birdOption.isSelected)
+        XCTAssertFalse(dogOption.isSelected)
         
-#if !os(visionOS)
-        radioButtonTextPicker.adjust(toPickerWheelValue: "dog")
-#endif
+        app.buttons["dog"].tap()
         
-        XCTAssertEqual(
-            radioButtonTextPicker.stringValue,
-            "dog"
-        )
-        
-        XCTAssertNotEqual(
-            radioButtonTextPicker.stringValue,
-            "bird"
-        )
-        
-        // The following assertion is skipped because all possible values in a
-        // picker cannot be programmatically checked.
-//        XCTAssertTrue(
-//            noValueOption.exists,
-//            "The no value option doesn't exist."
-//        )
+        XCTAssertTrue(dogOption.isSelected)
+        XCTAssertFalse(birdOption.isSelected)
     }
     
     /// Test case 4.2: Test radio button fallback to combo box
     func testCase_4_2() {
         let app = XCUIApplication()
-        let field1 = app.staticTexts["Fallback 1 Combo Box Value"]
+        let comboBoxOption = app.buttons["Fallback 1 Combo Box Value-Fallback 1 Options Button"]
+        let field1Title = "Fallback 1"
+        let field2Title = "No Value Enabled"
+        let field3Title = "No Value Disabled"
+        let field1 = app.staticTexts["\(field1Title) Combo Box Value"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let noValueDisabledPicker = app.pickers["No Value Disabled"].pickerWheels.firstMatch
-        let noValueEnabledPicker = app.pickers["No Value Enabled"].pickerWheels.firstMatch
+        let naOption = app.buttons["N/A"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(field1Title)
+        
         // Verify the Radio Button fallback to Combo Box was successful.
         field1.assertExistence()
+        comboBoxOption.assertExistence()
+        
+        app.filterElements(field2Title)
         
         // Verify the radio buttons are shown even when the no value option is enabled.
-        XCTAssertEqual(
-            noValueEnabledPicker.stringValue,
-            "N/A"
-        )
+        naOption.assertExistence()
+        XCTAssertTrue(naOption.isSelected)
+        
+        app.filterElements(field3Title)
         
         // Verify the radio buttons are still shown even when the no value option is disabled.
-        XCTAssertEqual(
-            noValueDisabledPicker.stringValue,
-            "One"
-        )
+        app.buttons["One"].assertExistence()
     }
     
     // - MARK: Test case 5: Switch input type
@@ -962,21 +974,36 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 5.1: Test switch on
     func testCase_5_1() {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["switch integer"]
+        let fieldTitle = "switch integer"
+        let fieldLabel = app.staticTexts[fieldTitle]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let switchView = app.switches["switch integer Switch"]
+        
+#if targetEnvironment(macCatalyst)
+        let switchView = app.checkBoxes["\(fieldTitle) Switch"]
+#else
+        let switchView = app.switches["\(fieldTitle) Switch"]
+        let control = switchView.switches.firstMatch
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldTitle.assertExistence()
+        app.filterElements(fieldTitle)
+        
+        fieldLabel.assertExistence()
         
         XCTAssertEqual(
             switchView.label,
             "2"
         )
-        
+      
+#if targetEnvironment(macCatalyst)
         switchView.assertExistenceAndTap()
+#elseif os(visionOS)
+        switchView.assertExistenceAndTap()
+#else
+        control.assertExistenceAndTap()
+#endif
         
         XCTAssertEqual(
             switchView.label,
@@ -987,15 +1014,24 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 5.2: Test switch off
     func testCase_5_2() {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["switch string"]
+        let fieldTitle = "switch string"
+        let fieldLabel = app.staticTexts[fieldTitle]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
-        let switchView = app.switches["switch string Switch"]
+        
+#if targetEnvironment(macCatalyst)
+        let switchView = app.checkBoxes["\(fieldTitle) Switch"]
+#else
+        let switchView = app.switches["\(fieldTitle) Switch"]
+        let control = switchView.switches.firstMatch
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(fieldTitle)
+        
         XCTAssertTrue(
-            fieldTitle.isHittable,
+            fieldLabel.isHittable,
             "The field title isn't hittable."
         )
         
@@ -1009,7 +1045,13 @@ final class FeatureFormViewTests: XCTestCase {
             "The switch isn't hittable."
         )
         
-        switchView.tap()
+#if targetEnvironment(macCatalyst)
+        switchView.assertExistenceAndTap()
+#elseif os(visionOS)
+        switchView.assertExistenceAndTap()
+#else
+        control.assertExistenceAndTap()
+#endif
         
         XCTAssertEqual(
             switchView.label,
@@ -1693,6 +1735,7 @@ final class FeatureFormViewTests: XCTestCase {
         let fromElementLabel = app.staticTexts["From Element"]
         let newAssociationText = app.staticTexts["New Association"]
         let saveButton = app.buttons["Save"]
+        let searchField = app.textFields["Search"]
         let structureJunction2 = app.buttons["Structure Junction, 2"]
         let structureJunctionDataSourceButton = app.buttons["Structure Junction"]
         let toElementValueLabel = app.staticTexts["Vault"]
@@ -1711,6 +1754,8 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements("Associations")
+        
         elementTitle.assertExistence()
         
         containerFilterTitle.assertExistenceAndTap()
@@ -1718,6 +1763,10 @@ final class FeatureFormViewTests: XCTestCase {
         addAssociationButton.assertExistenceAndTap()
         
         structureJunctionDataSourceButton.assertExistenceAndTap()
+        
+        searchField.assertExistenceAndTap()
+        
+        searchField.typeText("Vault")
         
         vaultAssetTypeButton.assertExistenceAndTap()
         
@@ -2020,9 +2069,39 @@ private extension String {
 }
 
 private extension XCUIApplication {
+    /// The element filter field.
+    var filterElementsField: XCUIElement {
+        searchFields["Filter Elements"]
+    }
+    
     /// The "No value" combo box option.
     var noValueComboBoxOption: XCUIElement {
         buttons["No value Combo Box Option"]
+    }
+    
+    
+    func filterElements(_ text: String) {
+        func focusFilter() {
+#if targetEnvironment(macCatalyst)
+            let searchButton = buttons["Search"]
+            if searchButton.waitForExistence(timeout: 5.0) {
+                searchButton.tap()
+            } else {
+                filterElementsField.assertExistenceAndTap()
+            }
+#else
+            filterElementsField.assertExistenceAndTap()
+#endif
+        }
+        
+        focusFilter()
+        
+        if buttons["Clear text"].exists {
+            buttons["Clear text"].tap()
+            focusFilter()
+        }
+        
+        filterElementsField.typeText(text)
     }
 }
 

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -2212,11 +2212,9 @@ final class FeatureFormViewTests: XCTestCase {
 #if targetEnvironment(macCatalyst)
         let addAssociationButton = app.buttons["Add Association"]
         let contentVisibleSwitch = app.checkBoxes["Content Visible"]
-        let fromNetworkDataSourceButton = app.menuItems["From Network Data Source"]
 #else
         let addAssociationButton = app.staticTexts["Add Association"]
         let contentVisibleSwitch = app.switches["Content Visible"].switches.firstMatch
-        let fromNetworkDataSourceButton = app.buttons["From Network Data Source"]
 #endif
         
         openTestCase()
@@ -2229,7 +2227,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         XCTAssertTrue(
             containerFilterTitle.waitForExistence(timeout: 5),
-            "The filter result \"Connected\" doesn't exist."
+            "The filter result \"Container\" doesn't exist."
         )
         
         containerFilterTitle.tap()

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -134,7 +134,6 @@ final class FeatureFormViewTests: XCTestCase {
         let fieldTitle = app.staticTexts["Single Line No Value, Placeholder or Description"]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
-        let returnButton = app.buttons["Return"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
         
         openTestCase()
@@ -155,18 +154,11 @@ final class FeatureFormViewTests: XCTestCase {
         
         characterIndicator.assertExistence()
         
-        XCTAssertEqual(
-            characterIndicator.label,
-            "11"
-        )
+        characterIndicator.assertLabel("11")
         
         clearButton.assertExistence()
         
-#if targetEnvironment(macCatalyst)
         app.typeText("\r")
-#else
-        returnButton.tap()
-#endif
         
         XCTAssertTrue(
             fieldTitle.isHittable,

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -269,11 +269,7 @@ final class FeatureFormViewTests: XCTestCase {
         textField.typeText(XCUIKeyboardKey.delete.rawValue)
         textField.typeText("3")
         
-        expectation(
-            for: NSPredicate(format: "label == \"Range domain 2-5\""),
-            evaluatedWith: footer
-        )
-        waitForExpectations(timeout: 10, handler: nil)
+        footer.assertLabel("Range domain 2-5")
         
         // Replace the current value with 6
         textField.typeText(XCUIKeyboardKey.delete.rawValue)

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1009,13 +1009,12 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 7.1: Test read only elements
     func testCase_7_1() throws {
         let app = XCUIApplication()
-        let formTitle = app.staticTexts["Test Case 7.1 - Read only elements"]
-        
         let comboBoxReadOnlyInput = app.staticTexts["Combo box Read Only Input"]
         let comboBox = app.staticTexts["Combo box Combo Box Value"]
         let dateElementTitle = "Date"
         let dateReadOnlyInput = app.staticTexts["\(dateElementTitle) Read Only Input"]
         let dateInput = app.buttons["\(dateElementTitle) Value"]
+        let formTitle = app.staticTexts["Test Case 7.1 - Read only elements"]
         let groupElementTitle = "Group"
         let longTextFieldTitle = "Long text"
         let longTextReadOnlyInput = app.staticTexts["\(longTextFieldTitle) Read Only Input"]
@@ -2033,6 +2032,7 @@ private extension String {
 }
 
 private extension XCUIApplication {
+    /// The app's "Done"/checkmark button.
     var doneButton: XCUIElement {
 #if os(visionOS)
         buttons["Confirm"]
@@ -2059,24 +2059,17 @@ private extension XCUIApplication {
     /// Filters the elements in the form.
     /// - Parameter text: The title of the form element to filter with.
     func filterElements(_ text: String) {
-        func focusFilter() {
+        filterElementsField.assertExistenceAndTap()
+        
 #if targetEnvironment(macCatalyst)
-            let searchButton = buttons["Search"]
-            if searchButton.waitForExistence(timeout: 5.0) {
-                searchButton.tap()
-            } else {
-                filterElementsField.assertExistenceAndTap()
-            }
+        let hasCurrentValue = !(filterElementsField.stringValue?.isEmpty ?? true)
 #else
-            filterElementsField.assertExistenceAndTap()
+        let hasCurrentValue = filterElementsField.stringValue != filterElementsField.placeholderValue
 #endif
-        }
         
-        focusFilter()
-        
-        if !(filterElementsField.stringValue?.isEmpty ?? true) {
+        if hasCurrentValue {
             clearElementFilter()
-            focusFilter()
+            filterElementsField.assertExistenceAndTap()
         }
         
         filterElementsField.typeText(text)

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -44,6 +44,7 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let activityIndicator = app.activityIndicators.firstMatch
         let attachmentLabel = app.staticTexts["EsriHQ.jpeg"]
+        let elementTitle = "Attachments"
         let formTitle = app.staticTexts["Esri Location"]
         let nameField = app.textFields["New name"]
         let okButton = app.buttons["OK"]
@@ -57,7 +58,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements("Attachments")
+        app.filterElements(elementTitle)
         
         activityIndicator.assertNonExistence()
         
@@ -86,8 +87,8 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_1_1() throws {
         let app = XCUIApplication()
         let characterIndicator = app.staticTexts["Single Line No Value, Placeholder or Description Character Indicator"]
-        let fieldTitle = "Single Line No Value, Placeholder or Description"
-        let fieldLabel = app.staticTexts[fieldTitle]
+        let elementTitle = "Single Line No Value, Placeholder or Description"
+        let elementValue = app.staticTexts[elementTitle]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
@@ -95,9 +96,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldLabel.assertExistence()
+        elementValue.assertExistence()
         
 #if !targetEnvironment(macCatalyst)
         XCTAssertFalse(
@@ -114,7 +115,7 @@ final class FeatureFormViewTests: XCTestCase {
         // Give focus to the target text field.
         textField.tap()
         
-        fieldLabel.assertExistence()
+        elementValue.assertExistence()
         
         footer.assertExistence()
         
@@ -136,8 +137,8 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let characterIndicator = app.staticTexts["Single Line No Value, Placeholder or Description Character Indicator"]
         let clearButton = app.buttons["Single Line No Value, Placeholder or Description Clear Button"]
-        let fieldTitle = "Single Line No Value, Placeholder or Description"
-        let fieldLabel = app.staticTexts[fieldTitle]
+        let elementTitle = "Single Line No Value, Placeholder or Description"
+        let elementLabel = app.staticTexts[elementTitle]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
@@ -145,13 +146,13 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
         textField.assertExistenceAndTap()
         
         app.typeText("Sample text")
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
         footer.assertExistence()
         
@@ -168,25 +169,16 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.typeText("\r")
         
-        XCTAssertTrue(
-            fieldLabel.isHittable,
-            "The title isn't hittable."
-        )
+        elementLabel.assertHittable()
         
         XCTAssertFalse(
             footer.isHittable,
             "The footer is hittable."
         )
         
-        XCTAssertTrue(
-            clearButton.isHittable,
-            "The clear button isn't hittable."
-        )
+        clearButton.assertHittable()
         
-        XCTAssertTrue(
-            textField.isHittable,
-            "The text field isn't hittable."
-        )
+        textField.assertHittable()
     }
     
     /// Test case 1.3: unfocused and focused state, with error value (> 256 chars)
@@ -196,20 +188,20 @@ final class FeatureFormViewTests: XCTestCase {
         let clearButton = app.buttons["Single Line No Value, Placeholder or Description Clear Button"]
         let footer = app.staticTexts["Single Line No Value, Placeholder or Description Footer"]
         let formTitle = app.staticTexts["InputValidation"]
-        let fieldTitle = "Single Line No Value, Placeholder or Description"
-        let fieldLabel = app.staticTexts[fieldTitle]
+        let elementTitle = "Single Line No Value, Placeholder or Description"
+        let elementLabel = app.staticTexts[elementTitle]
         let textField = app.textFields["Single Line No Value, Placeholder or Description Text Input"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
         textField.tap()
         
         app.typeText(.loremIpsum257)
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
         footer.assertExistence()
         
@@ -226,7 +218,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.typeText("\r")
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
         footer.assertExistence()
         
@@ -237,15 +229,9 @@ final class FeatureFormViewTests: XCTestCase {
         
         characterIndicator.assertNonExistence()
         
-        XCTAssertTrue(
-            clearButton.isHittable,
-            "The clear button isn't hittable."
-        )
+        clearButton.assertHittable()
         
-        XCTAssertTrue(
-            textField.isHittable,
-            "The text field isn't hittable."
-        )
+        textField.assertHittable()
     }
     
     func testCase_1_4() {
@@ -257,10 +243,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertEqual(
-            textField.value as? String,
-            ""
-        )
+        XCTAssertTrue(textField.stringValue?.isEmpty ?? false)
         
         XCTAssertEqual(
             footer.label,
@@ -297,26 +280,26 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 2.1: Unfocused and focused state, no value, date required
     func testCase_2_1() throws {
         let app = XCUIApplication()
-        let fieldTitle = "Required Date"
-        let calendarImage = app.images["\(fieldTitle) Calendar Image"]
-        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
-        let datePicker = app.datePickers["\(fieldTitle) Date Picker"]
-        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
-        let footer = app.staticTexts["\(fieldTitle) Footer"]
+        let elementTitle = "Required Date"
+        let calendarImage = app.images["\(elementTitle) Calendar Image"]
+        let clearButton = app.buttons["\(elementTitle) Clear Button"]
+        let datePicker = app.datePickers["\(elementTitle) Date Picker"]
+        let elementValue = app.staticTexts["\(elementTitle) Value"]
+        let footer = app.staticTexts["\(elementTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["\(fieldTitle) Now Button"]
+        let nowButton = app.buttons["\(elementTitle) Now Button"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        if fieldValue.label != "No Value" {
+        if elementValue.label != "No Value" {
             clearButton.tap()
         }
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "No Value"
         )
         
@@ -329,21 +312,18 @@ final class FeatureFormViewTests: XCTestCase {
         
         calendarImage.assertExistence()
         
-        fieldValue.tap()
+        elementValue.tap()
         
         datePicker.assertExistence()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             Date.now.formatted()
         )
         
-        XCTAssertTrue(
-            nowButton.isHittable,
-            "The now button isn't hittable."
-        )
+        nowButton.assertHittable()
         
-        fieldValue.tap()
+        elementValue.tap()
         
         XCTAssertEqual(
             footer.label,
@@ -354,27 +334,27 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 2.2: Focused and unfocused state, with value (populated)
     func testCase_2_2() {
         let app = XCUIApplication()
-        let fieldTitle = "Launch Date and Time for Apollo 11"
-        let datePicker = app.datePickers["\(fieldTitle) Date Picker"]
-        let fieldLabel = app.staticTexts[fieldTitle]
-        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
-        let footer = app.staticTexts["\(fieldTitle) Footer"]
+        let elementTitle = "Launch Date and Time for Apollo 11"
+        let datePicker = app.datePickers["\(elementTitle) Date Picker"]
+        let elementLabel = app.staticTexts[elementTitle]
+        let elementValue = app.staticTexts["\(elementTitle) Value"]
+        let footer = app.staticTexts["\(elementTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["\(fieldTitle) Now Button"]
+        let nowButton = app.buttons["\(elementTitle) Now Button"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
         XCTAssertEqual(
             footer.label,
             "Enter the launch date and time (July 16, 1969 13:32 UTC)"
         )
         
-        fieldValue.tap()
+        elementValue.tap()
         
         datePicker.assertExistence()
         
@@ -385,21 +365,15 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             localDate?.formatted()
         )
         
-        XCTAssertTrue(
-            nowButton.isHittable,
-            "The now button isn't hittable."
-        )
+        nowButton.assertHittable()
         
-        fieldValue.tap()
+        elementValue.tap()
         
-        XCTAssertTrue(
-            fieldValue.isHittable,
-            "The label isn't hittable."
-        )
+        elementValue.assertHittable()
         
         XCTAssertFalse(
             datePicker.isHittable,
@@ -411,7 +385,7 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_2_3() {
         let app = XCUIApplication()
         let datePicker = app.datePickers["Launch Date for Apollo 11 Date Picker"]
-        let fieldValue = app.staticTexts["Launch Date for Apollo 11 Value"]
+        let elementValue = app.staticTexts["Launch Date for Apollo 11 Value"]
         let footer = app.staticTexts["Launch Date for Apollo 11 Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
         let todayButton = app.buttons["Launch Date for Apollo 11 Today Button"]
@@ -421,17 +395,14 @@ final class FeatureFormViewTests: XCTestCase {
         
         footer.assertExistence()
         
-        fieldValue.tap()
+        elementValue.tap()
         
         XCTAssertEqual(
             footer.label,
             "Enter the Date for the Apollo 11 launch"
         )
         
-        XCTAssertTrue(
-            fieldValue.isHittable,
-            "The field value isn't hittable."
-        )
+        elementValue.assertHittable()
         
         let localDate = Calendar.current.date(
             from: DateComponents(
@@ -440,59 +411,41 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             localDate?.formatted(.dateTime.day().month().year())
         )
         
-        XCTAssertTrue(
-            datePicker.isHittable,
-            "The date picker isn't hittable."
-        )
+        datePicker.assertHittable()
         
-        XCTAssertTrue(
-            todayButton.isHittable,
-            "The today button isn't hittable."
-        )
+        todayButton.assertHittable()
     }
     
     /// Test case 2.4: Maximum date
     func testCase_2_4() {
         let app = XCUIApplication()
-        let fieldTitle = "Launch Date Time End"
-        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
-        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
-        let footer = app.staticTexts["\(fieldTitle) Footer"]
+        let elementTitle = "Launch Date Time End"
+        let clearButton = app.buttons["\(elementTitle) Clear Button"]
+        let elementValue = app.staticTexts["\(elementTitle) Value"]
+        let footer = app.staticTexts["\(elementTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["\(fieldTitle) Now Button"]
+        let nowButton = app.buttons["\(elementTitle) Now Button"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        if fieldValue.label != "No Value" {
+        if elementValue.label != "No Value" {
             clearButton.tap()
         }
         
         footer.assertExistence()
         
-        fieldValue.tap()
+        elementValue.tap()
         
-        nowButton.assertExistence()
+        nowButton.assertExistenceAndTap()
         
-        XCTAssertTrue(
-            nowButton.isHittable,
-            "The Now button wasn't hittable."
-        )
-        
-        nowButton.tap()
-        
-        XCTAssertTrue(
-            fieldValue.isHittable,
-            "The field wasn't hittable."
-        )
-        
-        fieldValue.tap()
+        elementValue.assertExistenceAndTap()
         
         XCTAssertEqual(
             footer.label,
@@ -506,7 +459,7 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             localDate?.formatted()
         )
     }
@@ -514,25 +467,25 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 2.5: Minimum date
     func testCase_2_5() {
         let app = XCUIApplication()
-        let fieldTitle = "start and end date time"
-        let datePicker = app.datePickers["\(fieldTitle) Date Picker"]
-        let fieldValue = app.staticTexts["\(fieldTitle) Value"]
-        let footer = app.staticTexts["\(fieldTitle) Footer"]
+        let elementTitle = "start and end date time"
+        let datePicker = app.datePickers["\(elementTitle) Date Picker"]
+        let elementValue = app.staticTexts["\(elementTitle) Value"]
+        let footer = app.staticTexts["\(elementTitle) Footer"]
         let formTitle = app.staticTexts["DateTimePoint"]
-        let nowButton = app.buttons["\(fieldTitle) Now Button"]
+        let nowButton = app.buttons["\(elementTitle) Now Button"]
         let previousMonthButton = datePicker.buttons["Previous Month"]
         let julyFirstButton = datePicker.collectionViews.staticTexts["1"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldValue.assertExistence()
+        elementValue.assertExistence()
         
         footer.assertExistence()
         
-        fieldValue.tap()
+        elementValue.tap()
         
         XCTAssertEqual(
             footer.label,
@@ -555,7 +508,7 @@ final class FeatureFormViewTests: XCTestCase {
             )
         )
         
-        fieldValue.assertLabel(localDate!.formatted())
+        elementValue.assertLabel(localDate!.formatted())
         
         XCTAssertFalse(
             previousMonthButton.isEnabled,
@@ -567,27 +520,19 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_2_6() {
         let app = XCUIApplication()
         let clearButton = app.buttons["Launch Date and Time for Apollo 11 Clear Button"]
-        let fieldTitle = app.staticTexts["Launch Date and Time for Apollo 11"]
-        let fieldValue = app.staticTexts["Launch Date and Time for Apollo 11 Value"]
+        let elementLabel = app.staticTexts["Launch Date and Time for Apollo 11"]
+        let elementValue = app.staticTexts["Launch Date and Time for Apollo 11 Value"]
         let formTitle = app.staticTexts["DateTimePoint"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.isHittable,
-            "The field title isn't hittable."
-        )
+        elementLabel.assertHittable()
         
-        XCTAssertTrue(
-            clearButton.isHittable,
-            "The clear button isn't hittable."
-        )
-        
-        clearButton.tap()
+        clearButton.assertExistenceAndTap()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "No Value"
         )
     }
@@ -597,41 +542,30 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.1: Pre-existing value, description, clear button, no value label
     func testCase_3_1() {
         let app = XCUIApplication()
-        let fieldTitle = "Combo String"
-        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
-        let fieldLabel = app.staticTexts[fieldTitle]
-        let fieldValue = app.staticTexts["\(fieldTitle) Combo Box Value"]
+        let elementTitle = "Combo String"
+        let clearButton = app.buttons["\(elementTitle) Clear Button"]
+        let elementLabel = app.staticTexts[elementTitle]
+        let elementValue = app.staticTexts["\(elementTitle) Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
-        let footer = app.staticTexts["\(fieldTitle) Footer"]
+        let footer = app.staticTexts["\(elementTitle) Footer"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        XCTAssertTrue(
-            fieldLabel.isHittable,
-            "The field title isn't hittable."
-        )
+        elementLabel.assertHittable()
         
-        XCTAssertTrue(
-            fieldValue.isHittable,
-            "The field value isn't hittable."
-        )
+        elementValue.assertHittable()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "String 3"
         )
         
-        XCTAssertTrue(
-            clearButton.isHittable,
-            "The clear button isn't hittable."
-        )
+        clearButton.assertExistenceAndTap()
         
-        clearButton.tap()
-        
-        fieldValue.assertLabel("No value")
+        elementValue.assertLabel("No value")
         
         footer.assertExistence()
         
@@ -644,79 +578,54 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.2: No pre-existing value, no value label, options button
     func testCase_3_2() {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["Combo Integer"]
-        let fieldValue = app.staticTexts["Combo Integer Combo Box Value"]
+        let elementLabel = app.staticTexts["Combo Integer"]
+        let elementValue = app.staticTexts["Combo Integer Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
         let optionsButton = app.images["Combo Integer Options Button"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.isHittable,
-            "The field title isn't hittable."
-        )
+        elementLabel.assertHittable()
         
-        XCTAssertTrue(
-            fieldValue.isHittable,
-            "The field value isn't hittable."
-        )
+        elementValue.assertHittable()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "No value"
         )
         
-        XCTAssertTrue(
-            optionsButton.isHittable,
-            "The options button isn't hittable."
-        )
+        optionsButton.assertHittable()
     }
     
     /// Test case 3.3: Pick a value
     func testCase_3_3() {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["Combo String"]
-        let fieldValue = app.staticTexts["Combo String Combo Box Value"]
+        let elementLabel = app.staticTexts["Combo String"]
+        let elementValue = app.staticTexts["Combo String Combo Box Value"]
         let firstOptionButton = app.buttons["String 1"]
         let formTitle = app.staticTexts["comboBox"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.isHittable,
-            "The field title isn't hittable."
-        )
+        elementLabel.assertHittable()
         
-        XCTAssertTrue(
-            fieldValue.isHittable,
-            "The field value isn't hittable."
-        )
+        elementValue.assertHittable()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "String 3"
         )
         
-        fieldValue.tap()
+        elementValue.tap()
         
-        XCTAssertTrue(
-            firstOptionButton.isHittable,
-            "The first option (String 1) isn't hittable."
-        )
+        firstOptionButton.assertExistenceAndTap()
         
-        firstOptionButton.tap()
-        
-        XCTAssertTrue(
-            app.doneButton.isHittable,
-            "The done button isn't hittable."
-        )
-        
-        app.doneButton.tap()
+        app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "String 1"
         )
     }
@@ -724,24 +633,21 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.4: Picker with a noValueLabel row
     func testCase_3_4() {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["Combo String"]
-        let fieldValue = app.staticTexts["Combo String Combo Box Value"]
+        let elementLabel = app.staticTexts["Combo String"]
+        let elementValue = app.staticTexts["Combo String Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        XCTAssertTrue(
-            fieldTitle.isHittable,
-            "The field title isn't hittable."
-        )
+        elementLabel.assertHittable()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "String 3"
         )
         
-        fieldValue.tap()
+        elementValue.tap()
         
         XCTAssertTrue(
             app.noValueComboBoxOption.waitForExistence(timeout: 1),
@@ -753,7 +659,7 @@ final class FeatureFormViewTests: XCTestCase {
         app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "No value"
         )
     }
@@ -761,23 +667,23 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.5: Required Value
     func testCase_3_5() {
         let app = XCUIApplication()
-        let fieldTitle = "Required Combo Box"
-        let clearButton = app.buttons["\(fieldTitle) Clear Button"]
-        let fieldLabel = app.staticTexts["\(fieldTitle) *"]
-        let fieldValue = app.staticTexts["\(fieldTitle) Combo Box Value"]
-        let footer = app.staticTexts["\(fieldTitle) Footer"]
+        let elementTitle = "Required Combo Box"
+        let clearButton = app.buttons["\(elementTitle) Clear Button"]
+        let elementLabel = app.staticTexts["\(elementTitle) *"]
+        let elementValue = app.staticTexts["\(elementTitle) Combo Box Value"]
+        let footer = app.staticTexts["\(elementTitle) Footer"]
         let formTitle = app.staticTexts["comboBox"]
         let oakButton = app.buttons["Oak"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "Pine"
         )
         
@@ -788,7 +694,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         footer.assertExistence()
         
-        fieldValue.tap()
+        elementValue.tap()
         
         app.noValueComboBoxOption.assertNonExistence()
         
@@ -797,7 +703,7 @@ final class FeatureFormViewTests: XCTestCase {
         app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "Oak"
         )
     }
@@ -805,9 +711,9 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.6: noValueOption is 'Hide'
     func testCase_3_6() throws {
         let app = XCUIApplication()
-        let fieldTitle = "Combo No Value False"
-        let fieldLabel = app.staticTexts[fieldTitle]
-        let fieldValue = app.staticTexts["Combo No Value False Combo Box Value"]
+        let elementTitle = "Combo No Value False"
+        let elementLabel = app.staticTexts[elementTitle]
+        let elementValue = app.staticTexts["Combo No Value False Combo Box Value"]
         let firstOption = app.buttons["First"]
         let formTitle = app.staticTexts["comboBox"]
         let noValueButton = app.buttons["No Value"]
@@ -816,11 +722,11 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
-        XCTAssertTrue(fieldValue.label.isEmpty)
+        XCTAssertTrue(elementValue.label.isEmpty)
         
         optionsButton.assertExistenceAndTap()
         
@@ -828,17 +734,12 @@ final class FeatureFormViewTests: XCTestCase {
         
         noValueButton.assertNonExistence()
         
-        XCTAssertTrue(
-            firstOption.isHittable,
-            "The First option isn't hittable."
-        )
-        
-        firstOption.tap()
+        firstOption.assertExistenceAndTap()
         
         app.doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "First"
         )
     }
@@ -846,26 +747,26 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.7: Unsupported value
     func testCase_3_7() throws {
         let app = XCUIApplication()
-        let fieldTitle = "Unsupported Value"
-        let fieldLabel = app.staticTexts[fieldTitle]
-        let fieldValue = app.staticTexts["\(fieldTitle) Combo Box Value"]
+        let elementTitle = "Unsupported Value"
+        let elementLabel = app.staticTexts[elementTitle]
+        let elementValue = app.staticTexts["\(elementTitle) Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
-        let unsupportedValueSectionHeader = app.staticTexts["\(fieldTitle) Unsupported Value Section"]
+        let unsupportedValueSectionHeader = app.staticTexts["\(elementTitle) Unsupported Value Section"]
         let unsupportedValue = app.buttons["0"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "0"
         )
         
-        fieldValue.tap()
+        elementValue.tap()
         
         unsupportedValueSectionHeader.assertExistence()
         
@@ -883,17 +784,17 @@ final class FeatureFormViewTests: XCTestCase {
         let app = XCUIApplication()
         let birdOption = app.buttons["bird"]
         let dogOption = app.buttons["dog"]
-        let fieldTitle = "Radio Button Text"
-        let fieldLabel = app.staticTexts["\(fieldTitle) *"]
+        let elementTitle = "Radio Button Text"
+        let elementLabel = app.staticTexts["\(elementTitle) *"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
         let noValueOption = app.buttons["No Value"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         noValueOption.assertExistence()
         birdOption.assertExistence()
         dogOption.assertExistence()
@@ -911,29 +812,29 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_4_2() {
         let app = XCUIApplication()
         let comboBoxOption = app.buttons["Fallback 1 Combo Box Value-Fallback 1 Options Button"]
-        let field1Title = "Fallback 1"
-        let field2Title = "No Value Enabled"
-        let field3Title = "No Value Disabled"
-        let field1 = app.staticTexts["\(field1Title) Combo Box Value"]
+        let element1Title = "Fallback 1"
+        let element1Value = app.staticTexts["\(element1Title) Combo Box Value"]
+        let element2Title = "No Value Enabled"
+        let element3Title = "No Value Disabled"
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
         let naOption = app.buttons["N/A"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(field1Title)
+        app.filterElements(element1Title)
         
         // Verify the Radio Button fallback to Combo Box was successful.
-        field1.assertExistence()
+        element1Value.assertExistence()
         comboBoxOption.assertExistence()
         
-        app.filterElements(field2Title)
+        app.filterElements(element2Title)
         
         // Verify the radio buttons are shown even when the no value option is enabled.
         naOption.assertExistence()
         XCTAssertTrue(naOption.isSelected)
         
-        app.filterElements(field3Title)
+        app.filterElements(element3Title)
         
         // Verify the radio buttons are still shown even when the no value option is disabled.
         app.buttons["One"].assertExistence()
@@ -944,22 +845,22 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 5.1: Test switch on
     func testCase_5_1() {
         let app = XCUIApplication()
-        let fieldTitle = "switch integer"
-        let fieldLabel = app.staticTexts[fieldTitle]
+        let elementTitle = "switch integer"
+        let elementLabel = app.staticTexts[elementTitle]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
         
 #if targetEnvironment(macCatalyst)
-        let switchView = app.checkBoxes["\(fieldTitle) Switch"]
+        let switchView = app.checkBoxes["\(elementTitle) Switch"]
 #else
-        let switchView = app.switches["\(fieldTitle) Switch"]
+        let switchView = app.switches["\(elementTitle) Switch"]
 #endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        fieldLabel.assertExistence()
+        elementLabel.assertExistence()
         
         XCTAssertEqual(
             switchView.label,
@@ -972,43 +873,32 @@ final class FeatureFormViewTests: XCTestCase {
         switchView.switches.firstMatch.assertExistenceAndTap()
 #endif
         
-        XCTAssertEqual(
-            switchView.label,
-            "1"
-        )
+        switchView.assertLabel("1")
     }
     
     /// Test case 5.2: Test switch off
     func testCase_5_2() {
         let app = XCUIApplication()
-        let fieldTitle = "switch string"
-        let fieldLabel = app.staticTexts[fieldTitle]
+        let elementTitle = "switch string"
+        let elementLabel = app.staticTexts[elementTitle]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
         
 #if targetEnvironment(macCatalyst)
-        let switchView = app.checkBoxes["\(fieldTitle) Switch"]
+        let switchView = app.checkBoxes["\(elementTitle) Switch"]
 #else
-        let switchView = app.switches["\(fieldTitle) Switch"]
+        let switchView = app.switches["\(elementTitle) Switch"]
 #endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(fieldTitle)
+        app.filterElements(elementTitle)
         
-        XCTAssertTrue(
-            fieldLabel.isHittable,
-            "The field title isn't hittable."
-        )
+        elementLabel.assertHittable()
         
         XCTAssertEqual(
             switchView.label,
             "1"
-        )
-        
-        XCTAssertTrue(
-            switchView.isHittable,
-            "The switch isn't hittable."
         )
         
 #if targetEnvironment(macCatalyst) || os(visionOS)
@@ -1023,16 +913,16 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 5.3: Test switch with no value
     func testCase_5_3() {
         let app = XCUIApplication()
-        let fieldTitle = app.staticTexts["switch double"]
-        let fieldValue = app.staticTexts["switch double Combo Box Value"]
+        let elementLabel = app.staticTexts["switch double"]
+        let elementValue = app.staticTexts["switch double Combo Box Value"]
         let formTitle = app.staticTexts["mainobservation_ExportFeatures"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        fieldTitle.assertExistence()
+        elementLabel.assertExistence()
         
-        fieldValue.assertExistence()
+        elementValue.assertExistence()
     }
     
     /// Test case 6.1: Test initially expanded and collapsed
@@ -1073,11 +963,12 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 6.2: Test visibility of empty group
     func testCase_6_2() throws {
         let app = XCUIApplication()
-        let elementTitle = "Group with children that are visible dependent"
+        let group1ElementTitle = "Group with children that are visible dependent"
+        let group1TextElementLabel = app.staticTexts["single line text 3"]
+        let group2ElementTitle = "Group with Multiple Form Elements"
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
-        let groupElement = app.staticTexts["single line text 3"]
-        let hiddenElementsGroup = app.staticTexts["Group with children that are visible dependent"]
-        let hiddenElementsGroupDescription = app.staticTexts["Group with children that are visible dependent Description"]
+        let hiddenElementsGroup = app.staticTexts[group1ElementTitle]
+        let hiddenElementsGroupDescription = app.staticTexts["\(group1ElementTitle) Description"]
         let radioOptionA = app.buttons["No value"]
         let radioOptionB = app.buttons["Everything is working great"]
         let radioOptionC = app.buttons["show invisible form element"]
@@ -1085,7 +976,7 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements(elementTitle)
+        app.filterElements(group1ElementTitle)
         
         hiddenElementsGroup.assertExistence()
         
@@ -1097,22 +988,22 @@ final class FeatureFormViewTests: XCTestCase {
         )
         
         // Confirm the first element of the conditional group doesn't exist.
-        groupElement.assertNonExistence()
+        group1TextElementLabel.assertNonExistence()
         
-        app.filterElements("Group with Multiple Form Elements")
+        app.filterElements(group2ElementTitle)
         
-        // Show the invisible elements.
 #if targetEnvironment(macCatalyst)
         radioOptionA.swipeUp()
 #endif
         
+        // Show the invisible elements.
         radioOptionB.assertExistenceAndTap()
         radioOptionC.assertExistenceAndTap()
         
-        app.filterElements(elementTitle)
+        app.filterElements(group1ElementTitle)
         
         // Confirm the first element of the conditional group exists.
-        groupElement.assertExistence()
+        group1TextElementLabel.assertExistence()
     }
     
     /// Test case 7.1: Test read only elements
@@ -1122,19 +1013,19 @@ final class FeatureFormViewTests: XCTestCase {
         
         let comboBoxReadOnlyInput = app.staticTexts["Combo box Read Only Input"]
         let comboBox = app.staticTexts["Combo box Combo Box Value"]
-        let dateFieldTitle = "Date"
-        let dateReadOnlyInput = app.staticTexts["\(dateFieldTitle) Read Only Input"]
-        let dateInput = app.buttons["\(dateFieldTitle) Value"]
+        let dateElementTitle = "Date"
+        let dateReadOnlyInput = app.staticTexts["\(dateElementTitle) Read Only Input"]
+        let dateInput = app.buttons["\(dateElementTitle) Value"]
         let groupElementTitle = "Group"
         let longTextFieldTitle = "Long text"
         let longTextReadOnlyInput = app.staticTexts["\(longTextFieldTitle) Read Only Input"]
         let longTextTextInputPreview = app.staticTexts["\(longTextFieldTitle) Text Input Preview"]
-        let radioButtonsFieldTitle = "Radio buttons"
+        let radioButtonsElementTitle = "Radio buttons"
         let radioButtonsOption0 = app.buttons["0"]
-        let radioButtonsReadOnlyInput = app.staticTexts["\(radioButtonsFieldTitle) Read Only Input"]
-        let shortTextFieldTitle = "Short text"
-        let shortTextReadOnlyInput = app.staticTexts["\(shortTextFieldTitle) Read Only Input"]
-        let shortTextTextInput = app.textFields["\(shortTextFieldTitle) Text Input"]
+        let radioButtonsReadOnlyInput = app.staticTexts["\(radioButtonsElementTitle) Read Only Input"]
+        let shortTextElementTitle = "Short text"
+        let shortTextReadOnlyInput = app.staticTexts["\(shortTextElementTitle) Read Only Input"]
+        let shortTextTextInput = app.textFields["\(shortTextElementTitle) Text Input"]
         let switch1FieldTitle = "Elements are editable"
         let switch2FieldTitle = "Element in the group is editable"
         let switchReadOnlyInput = app.staticTexts["\(switch2FieldTitle) Read Only Input"]
@@ -1154,15 +1045,15 @@ final class FeatureFormViewTests: XCTestCase {
         
         comboBoxReadOnlyInput.assertExistence()
         
-        app.filterElements(radioButtonsFieldTitle)
+        app.filterElements(radioButtonsElementTitle)
         
         radioButtonsReadOnlyInput.assertExistence()
         
-        app.filterElements(dateFieldTitle)
+        app.filterElements(dateElementTitle)
         
         dateReadOnlyInput.assertExistence()
         
-        app.filterElements(shortTextFieldTitle)
+        app.filterElements(shortTextElementTitle)
         
         shortTextReadOnlyInput.assertExistence()
         
@@ -1182,17 +1073,17 @@ final class FeatureFormViewTests: XCTestCase {
         
         comboBox.assertExistence()
         
-        app.filterElements(radioButtonsFieldTitle)
+        app.filterElements(radioButtonsElementTitle)
         
         radioButtonsOption0.assertExistence()
         
         XCTAssertTrue(radioButtonsOption0.isSelected)
         
-        app.filterElements(dateFieldTitle)
+        app.filterElements(dateElementTitle)
         
         dateInput.assertExistence()
         
-        app.filterElements(shortTextFieldTitle)
+        app.filterElements(shortTextElementTitle)
         
         shortTextTextInput.assertExistence()
         
@@ -1275,11 +1166,11 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 11.1: Barcode Scan and Clear buttons
     func testCase_11_1() {
         let app = XCUIApplication()
+        let barcodeValidationString = app.staticTexts["Barcode Footer"]
+        let clearButton = app.buttons["Barcode Clear Button"]
+        let elementValue = app.textFields["Barcode Text Input"]
         let formTitle = app.staticTexts["Test case 11.1 Layer"]
         let scanButton = app.buttons["Barcode Scan Button"]
-        let clearButton = app.buttons["Barcode Clear Button"]
-        let barcodeValidationString = app.staticTexts["Barcode Footer"]
-        let fieldValue = app.textFields["Barcode Text Input"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -1289,8 +1180,8 @@ final class FeatureFormViewTests: XCTestCase {
 #endif
         clearButton.assertNonExistence()
         
-        fieldValue.assertExistenceAndTap()
-        fieldValue.typeText("https://esri.com/this_is_a_string_longer_than_50_count_on_it")
+        elementValue.assertExistenceAndTap()
+        elementValue.typeText("https://esri.com/this_is_a_string_longer_than_50_count_on_it")
         
 #if !os(visionOS)
         scanButton.assertExistence()
@@ -1303,7 +1194,7 @@ final class FeatureFormViewTests: XCTestCase {
         let assetGroup = app.staticTexts["Asset group"]
         let elementTitle = "Associations"
         let elementLabel = app.staticTexts[elementTitle]
-        let fieldValue = app.staticTexts["Asset group Read Only Input"]
+        let elementValue = app.staticTexts["Asset group Read Only Input"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let filterResults1 = app.staticTexts["Connected"]
         let filterResults2 = app.staticTexts["Structure"]
@@ -1351,7 +1242,7 @@ final class FeatureFormViewTests: XCTestCase {
         assetGroup.assertExistence()
         
         XCTAssertEqual(
-            fieldValue.label,
+            elementValue.label,
             "Fuse"
         )
     }
@@ -1424,7 +1315,7 @@ final class FeatureFormViewTests: XCTestCase {
         let backButton = app.buttons["Back"]
         let elementTitle = "Associations"
         let elementLabel = app.staticTexts[elementTitle]
-        let fieldValue = app.staticTexts["Asset type Combo Box Value"]
+        let elementValue = app.staticTexts["Asset type Combo Box Value"]
         let filterResults = app.staticTexts["Connected"]
         let firstOptionButton = app.buttons["Unknown Combo Box Option"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
@@ -1456,21 +1347,11 @@ final class FeatureFormViewTests: XCTestCase {
         
         assetType.assertExistence()
         
-        fieldValue.tap()
+        elementValue.tap()
         
-        XCTAssertTrue(
-            firstOptionButton.isHittable,
-            "The first option \"Unknown\" isn't hittable."
-        )
+        firstOptionButton.assertExistenceAndTap()
         
-        firstOptionButton.tap()
-        
-        XCTAssertTrue(
-            app.doneButton.isHittable,
-            "The done button isn't hittable."
-        )
-        
-        app.doneButton.tap()
+        app.doneButton.assertExistenceAndTap()
         
         // Tap the "Back" button
         backButton.tap()
@@ -1757,7 +1638,8 @@ final class FeatureFormViewTests: XCTestCase {
         let containmentLabel = app.staticTexts["Containment"]
         let discardButton = app.buttons["Discard"]
         let electricDistributionJunctionLabel = app.staticTexts["Electric Distribution Junction"]
-        let elementTitle = app.staticTexts["Associations"]
+        let elementTitle = "Associations"
+        let elementLabel = app.staticTexts[elementTitle]
         let formTitle = app.staticTexts["Electric Distribution Junction"]
         let fromElementLabel = app.staticTexts["From Element"]
         let newAssociationText = app.staticTexts["New Association"]
@@ -1781,9 +1663,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElements("Associations")
+        app.filterElements(elementTitle)
         
-        elementTitle.assertExistence()
+        elementLabel.assertExistence()
         
         containerFilterTitle.assertExistenceAndTap()
         
@@ -2169,10 +2051,13 @@ private extension XCUIApplication {
         buttons["No value Combo Box Option"]
     }
     
+    /// Clears the element filter in the form.
     func clearElementFilter() {
         buttons["Clear text"].assertExistenceAndTap()
     }
     
+    /// Filters the elements in the form.
+    /// - Parameter text: The title of the form element to filter with.
     func filterElements(_ text: String) {
         func focusFilter() {
 #if targetEnvironment(macCatalyst)

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -2220,9 +2220,6 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
-        app.filterElementsField.tap()
-        app.filterElementsField.typeText("Associations")
-        
         XCTAssertTrue(
             elementTitle.waitForExistence(timeout: 5),
             "The element \"Associations\" doesn't exist."
@@ -2590,11 +2587,6 @@ private extension String {
 }
 
 private extension XCUIApplication {
-    /// The element filter field.
-    var filterElementsField: XCUIElement {
-        searchFields["Filter Elements"]
-    }
-    
     /// The "No value" combo box option.
     var noValueComboBoxOption: XCUIElement {
         buttons["No value Combo Box Option"]

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -2220,6 +2220,9 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElementsField.tap()
+        app.filterElementsField.typeText("Associations")
+        
         XCTAssertTrue(
             elementTitle.waitForExistence(timeout: 5),
             "The element \"Associations\" doesn't exist."
@@ -2341,6 +2344,11 @@ private extension String {
 }
 
 private extension XCUIApplication {
+    /// The element filter field.
+    var filterElementsField: XCUIElement {
+        searchFields["Filter Elements"]
+    }
+    
     /// The "No value" combo box option.
     var noValueComboBoxOption: XCUIElement {
         buttons["No value Combo Box Option"]

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1078,33 +1078,30 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_6_1() {
         let app = XCUIApplication()
         let collapsedGroupFirstElement = app.staticTexts["Single Line Text"]
+        let collapsedGroupTitle = "Group with Multiple Form Elements 2"
+        let expandedGroupTitle = "Group with Multiple Form Elements"
         let expandedGroupFirstElement = app.staticTexts["MultiLine Text"]
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
         
 #if targetEnvironment(macCatalyst)
-        let collapsedGroup = app.disclosureTriangles["Group with Multiple Form Elements 2"]
-        let expandedGroup = app.disclosureTriangles["Group with Multiple Form Elements"]
-        let expandedGroupDescription = app.disclosureTriangles["Group with Multiple Form Elements Description"]
+        let collapsedGroup = app.buttons["\(collapsedGroupTitle), This group is not expanded for initial state"]
+        let expandedGroup = app.buttons["\(expandedGroupTitle), This Group is 'Expand initial state'\nThis group is Visible"]
 #else
-        let collapsedGroup = app.staticTexts["Group with Multiple Form Elements 2"]
-        let expandedGroup = app.staticTexts["Group with Multiple Form Elements"]
-        let expandedGroupDescription = app.staticTexts["Group with Multiple Form Elements Description"]
+        let collapsedGroup = app.staticTexts[collapsedGroupTitle]
+        let expandedGroup = app.staticTexts[expandedGroupTitle]
 #endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(expandedGroupTitle)
+        
         expandedGroup.assertExistence()
-        
-        expandedGroupDescription.assertExistence()
-        
-        XCTAssertEqual(
-            expandedGroupDescription.label,
-            "This Group is 'Expand initial state'\nThis group is Visible"
-        )
         
         // Confirm the first element of the expanded group exists.
         expandedGroupFirstElement.assertExistence()
+        
+        app.filterElements(collapsedGroupTitle)
         
         collapsedGroup.assertExistence()
         
@@ -1117,6 +1114,7 @@ final class FeatureFormViewTests: XCTestCase {
         try skipIf(visionOS: true)
         
         let app = XCUIApplication()
+        let elementTitle = "Group with children that are visible dependent"
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
         let groupElement = app.staticTexts["single line text 3"]
         let radioButtonPicker = app.pickers["Radio Button"].pickerWheels.firstMatch
@@ -1132,6 +1130,8 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements(elementTitle)
+        
         hiddenElementsGroup.assertExistence()
         
         hiddenElementsGroupDescription.assertExistence()
@@ -1144,6 +1144,8 @@ final class FeatureFormViewTests: XCTestCase {
         // Confirm the first element of the conditional group doesn't exist.
         groupElement.assertNonExistence()
         
+        app.filterElements("Group with Multiple Form Elements")
+        
         // Confirm the option to show the elements exists.
         radioButtonPicker.assertExistence()
         
@@ -1154,6 +1156,8 @@ final class FeatureFormViewTests: XCTestCase {
         radioButtonPicker.adjust(toPickerWheelValue: "Show Group Visible Dependent")
         radioButtonPicker.adjust(toPickerWheelValue: "show invisible form element")
 #endif
+        
+        app.filterElements(elementTitle)
         
         // Confirm the first element of the conditional group exists.
         groupElement.assertExistence()

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -668,11 +668,16 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.3: Pick a value
     func testCase_3_3() {
         let app = XCUIApplication()
-        let doneButton = app.buttons["Done"]
         let fieldTitle = app.staticTexts["Combo String"]
         let fieldValue = app.staticTexts["Combo String Combo Box Value"]
         let firstOptionButton = app.buttons["String 1"]
         let formTitle = app.staticTexts["comboBox"]
+        
+#if os(visionOS)
+        let doneButton = app.buttons["Confirm"]
+#else
+        let doneButton = app.buttons["Done"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -717,10 +722,15 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.4: Picker with a noValueLabel row
     func testCase_3_4() {
         let app = XCUIApplication()
-        let doneButton = app.buttons["Done"]
         let fieldTitle = app.staticTexts["Combo String"]
         let fieldValue = app.staticTexts["Combo String Combo Box Value"]
         let formTitle = app.staticTexts["comboBox"]
+        
+#if os(visionOS)
+        let doneButton = app.buttons["Confirm"]
+#else
+        let doneButton = app.buttons["Done"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -756,12 +766,17 @@ final class FeatureFormViewTests: XCTestCase {
     func testCase_3_5() {
         let app = XCUIApplication()
         let clearButton = app.buttons["Required Combo Box Clear Button"]
-        let doneButton = app.buttons["Done"]
         let fieldTitle = app.staticTexts["Required Combo Box *"]
         let fieldValue = app.staticTexts["Required Combo Box Combo Box Value"]
         let footer = app.staticTexts["Required Combo Box Footer"]
         let formTitle = app.staticTexts["comboBox"]
         let oakButton = app.buttons["Oak"]
+        
+#if os(visionOS)
+        let doneButton = app.buttons["Confirm"]
+#else
+        let doneButton = app.buttons["Done"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -797,13 +812,18 @@ final class FeatureFormViewTests: XCTestCase {
     /// Test case 3.6: noValueOption is 'Hide'
     func testCase_3_6() throws {
         let app = XCUIApplication()
-        let doneButton = app.buttons["Done"]
         let fieldTitle = app.staticTexts["Combo No Value False"]
         let fieldValue = app.staticTexts["Combo No Value False Combo Box Value"]
         let firstOption = app.buttons["First"]
         let formTitle = app.staticTexts["comboBox"]
         let noValueButton = app.buttons["No Value"]
         let optionsButton = app.images["Combo No Value False Options Button"]
+        
+#if os(visionOS)
+        let doneButton = app.buttons["Confirm"]
+#else
+        let doneButton = app.buttons["Done"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -828,7 +848,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         firstOption.tap()
         
-        doneButton.assertExistence()
+        doneButton.assertExistenceAndTap()
         
         XCTAssertEqual(
             fieldValue.label,

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -57,6 +57,8 @@ final class FeatureFormViewTests: XCTestCase {
         openTestCase()
         assertFormOpened(titleElement: formTitle)
         
+        app.filterElements("Attachments")
+        
         activityIndicator.assertNonExistence()
         
         attachmentLabel.assertExistence()
@@ -553,10 +555,7 @@ final class FeatureFormViewTests: XCTestCase {
             )
         )
         
-        XCTAssertEqual(
-            fieldValue.label,
-            localDate?.formatted()
-        )
+        fieldValue.assertLabel(localDate!.formatted())
         
         XCTAssertFalse(
             previousMonthButton.isEnabled,
@@ -632,10 +631,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         clearButton.tap()
         
-        XCTAssertEqual(
-            fieldValue.label,
-            "No value"
-        )
+        fieldValue.assertLabel("No value")
         
         footer.assertExistence()
         
@@ -1021,10 +1017,7 @@ final class FeatureFormViewTests: XCTestCase {
         switchView.switches.firstMatch.assertExistenceAndTap()
 #endif
         
-        XCTAssertEqual(
-            switchView.label,
-            "2"
-        )
+        switchView.assertLabel("2")
     }
     
     /// Test case 5.3: Test switch with no value
@@ -1083,16 +1076,11 @@ final class FeatureFormViewTests: XCTestCase {
         let elementTitle = "Group with children that are visible dependent"
         let formTitle = app.staticTexts["group_formelement_UI_not_editable"]
         let groupElement = app.staticTexts["single line text 3"]
-        let radioOptionA = app.buttons["Everything is working great"]
-        let radioOptionB = app.buttons["show invisible form element"]
-        
-#if targetEnvironment(macCatalyst)
-        let hiddenElementsGroup = app.disclosureTriangles["Group with children that are visible dependent"]
-        let hiddenElementsGroupDescription = app.disclosureTriangles["Group with children that are visible dependent Description"]
-#else
         let hiddenElementsGroup = app.staticTexts["Group with children that are visible dependent"]
         let hiddenElementsGroupDescription = app.staticTexts["Group with children that are visible dependent Description"]
-#endif
+        let radioOptionA = app.buttons["No value"]
+        let radioOptionB = app.buttons["Everything is working great"]
+        let radioOptionC = app.buttons["show invisible form element"]
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -1114,8 +1102,12 @@ final class FeatureFormViewTests: XCTestCase {
         app.filterElements("Group with Multiple Form Elements")
         
         // Show the invisible elements.
-        radioOptionA.assertExistenceAndTap()
+#if targetEnvironment(macCatalyst)
+        radioOptionA.swipeUp()
+#endif
+        
         radioOptionB.assertExistenceAndTap()
+        radioOptionC.assertExistenceAndTap()
         
         app.filterElements(elementTitle)
         
@@ -1318,9 +1310,15 @@ final class FeatureFormViewTests: XCTestCase {
         let filterResults3 = app.staticTexts["Container"]
         let networkSourceGroup1 = app.staticTexts["Electric Distribution Junction"]
         let networkSourceGroup2Button = app.buttons["Electric Distribution Device, 2"]
+        
+#if targetEnvironment(macCatalyst)
+        let fuses = app.staticTexts.matching(identifier: "Fuse, Single Terminal")
+#else
         let fuses = app.buttons.matching(identifier: "Fuse, Single Terminal")
-        let utilityElement1Button = fuses.element(boundBy: 0)
-        let utilityElement2Button = fuses.element(boundBy: 1)
+#endif
+        
+        let fuseOption1 = fuses.element(boundBy: 0)
+        let fuseOption2 = fuses.element(boundBy: 1)
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -1341,11 +1339,11 @@ final class FeatureFormViewTests: XCTestCase {
         
         networkSourceGroup2Button.assertExistenceAndTap()
         
-        utilityElement1Button.assertExistence()
+        fuseOption1.assertExistence()
         
-        utilityElement2Button.assertExistence()
+        fuseOption2.assertExistence()
         
-        utilityElement1Button.tap()
+        fuseOption1.tap()
         
         // Open new form
         assertFormOpened(titleElement: formTitle)
@@ -1369,7 +1367,12 @@ final class FeatureFormViewTests: XCTestCase {
         let filterResults = app.staticTexts["Content"]
         let formTitle = app.staticTexts["Structure Boundary"]
         let networkSourceGroupButton = app.buttons["Electric Distribution Device, 1"]
-        let utilityElementButton = app.buttons["Circuit Breaker, Visible: false"]
+        
+#if targetEnvironment(macCatalyst)
+        let circuitBreakerButton = app.staticTexts["Circuit Breaker, Visible: false"]
+#else
+        let circuitBreakerButton = app.buttons["Circuit Breaker, Visible: false"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -1382,8 +1385,8 @@ final class FeatureFormViewTests: XCTestCase {
         
         networkSourceGroupButton.assertExistenceAndTap()
         
-        // Expectation: a list of one utility elements with "Content"
-        utilityElementButton.assertExistence()
+        // Expectation: a list of one utility element with label "Circuit Breaker"
+        circuitBreakerButton.assertExistence()
     }
     
     func testCase_12_4() {
@@ -1393,7 +1396,12 @@ final class FeatureFormViewTests: XCTestCase {
         let filterResults = app.staticTexts["Container"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let networkSourceGroup = app.staticTexts["Structure Boundary"]
-        let utilityElementButton = app.buttons["Substation"]
+        
+#if targetEnvironment(macCatalyst)
+        let substationButton = app.staticTexts["Substation"]
+#else
+        let substationButton = app.buttons["Substation"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -1407,14 +1415,13 @@ final class FeatureFormViewTests: XCTestCase {
         networkSourceGroup.assertExistenceAndTap()
         
         // Expectation: a list of one utility element with no "Containment Visible" label
-        utilityElementButton.assertExistence()
+        substationButton.assertExistence()
     }
     
     func testCase_12_5() {
         let app = XCUIApplication()
         let assetType = app.staticTexts["Asset type *"]
         let backButton = app.buttons["Back"]
-        let discardEditsButton = app.buttons["Discard Edits"]
         let elementTitle = "Associations"
         let elementLabel = app.staticTexts[elementTitle]
         let fieldValue = app.staticTexts["Asset type Combo Box Value"]
@@ -1423,7 +1430,14 @@ final class FeatureFormViewTests: XCTestCase {
         let formTitle = app.staticTexts["Electric Distribution Device"]
         let formTitle2 = app.staticTexts["Electric Distribution Device"]
         let networkSourceGroupButton = app.buttons["Electric Distribution Device, 1"]
-        let utilityElementButton = app.buttons["Transformer, High"]
+        
+#if targetEnvironment(macCatalyst)
+        let discardEditsButton = app.buttons["Discard Edits"].firstMatch
+        let transformerButton = app.staticTexts["Transformer, High"]
+#else
+        let discardEditsButton = app.buttons["Discard Edits"]
+        let transformerButton = app.buttons["Transformer, High"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)
@@ -1436,7 +1450,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         networkSourceGroupButton.assertExistenceAndTap()
         
-        utilityElementButton.assertExistenceAndTap()
+        transformerButton.assertExistenceAndTap()
         
         assertFormOpened(titleElement: formTitle2)
         
@@ -1467,7 +1481,7 @@ final class FeatureFormViewTests: XCTestCase {
         // Access the new `FeatureForm`
         // Expectation: the form title should be "Electric Distribution Junction"
         // Expectation: a list of one utility elements entitled "Transformer - 2552"
-        utilityElementButton.assertExistence()
+        transformerButton.assertExistence()
     }
     
     func testCase_12_6() {
@@ -1815,37 +1829,47 @@ final class FeatureFormViewTests: XCTestCase {
     }
     
     func testCase_13_4() throws {
-        try skipIf(macCatalyst: true)
-        
         let app = XCUIApplication()
         let addAssociationButton = app.staticTexts["Add Association"]
         let addConditionButton = app.buttons["Add Condition"]
         let cancelButton = app.buttons["Cancel"]
-        let condition1Options = app.buttons["Condition 1 Options"]
         let conditionEqualsButton = app.buttons["Condition, ="]
         let connectedFilterTitle = app.staticTexts["Connected"]
-        let deleteButton = app.buttons["Delete"]
-        let discardEditsButton = app.buttons["Discard Edits"]
         let electricDistributionJunctionDataSourceButton = app.buttons["Electric Distribution Junction"]
         let elementTitle = "Associations"
         let elementLabel = app.staticTexts[elementTitle]
-        let equalOption = app.buttons["="]
         let filterButton = app.buttons["Filter Candidates"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
-        let isBlankOption = app.buttons["is blank"]
         let lineEndCandidates = app.buttons.matching(identifier: "Line End")
         let lowVoltageSinglePhaseLineEnd = app.buttons["Low Voltage Single Phase Line End"]
-        let optionAButton = app.buttons["A"]
-        let phasesCurrentState = app.buttons["Phases Current State"]
-        let unsavedChangesAlert = app.alerts["Filters have not been applied"]
         let valueButton = app.buttons["Value"]
         
-#if os(visionOS)
+#if os(visionOS) || targetEnvironment(macCatalyst)
         let isBlankLabel = app.buttons["Condition, is blank"]
         let objectIDField = app.buttons["Field, Object ID"]
 #else
         let isBlankLabel = app.staticTexts["is blank"]
         let objectIDField = app.staticTexts["Object ID"]
+#endif
+        
+#if targetEnvironment(macCatalyst)
+        let condition1Options = app.popUpButtons.firstMatch
+        let deleteButton = app.menuItems["delete"].firstMatch
+        let discardEditsButton = app.buttons["Discard Edits"].firstMatch
+        let equalOption = app.menuItems["="]
+        let isBlankOption = app.menuItems["is_blank"]
+        let optionAButton = app.menuItems["A"]
+        let phasesCurrentState = app.menuItems["phases_current_state"]
+        let unsavedChangesAlert = app.staticTexts["Filters have not been applied"]
+#else
+        let condition1Options = app.buttons["Condition 1 Options"]
+        let deleteButton = app.buttons["Delete"]
+        let discardEditsButton = app.buttons["Discard Edits"]
+        let equalOption = app.buttons["="]
+        let isBlankOption = app.buttons["is blank"]
+        let optionAButton = app.buttons["A"]
+        let phasesCurrentState = app.buttons["Phases Current State"]
+        let unsavedChangesAlert = app.alerts["Filters have not been applied"]
 #endif
         
         openTestCase()
@@ -1914,7 +1938,7 @@ final class FeatureFormViewTests: XCTestCase {
         
         app.doneButton.assertExistenceAndTap()
         
-        XCTAssertEqual(lineEndCandidates.count, 0)
+        lineEndCandidates.firstMatch.assertNonExistence()
         
         filterButton.assertExistenceAndTap()
         
@@ -1934,34 +1958,28 @@ final class FeatureFormViewTests: XCTestCase {
     }
     
     func testCase_13_5() throws {
-        try skipIf(macCatalyst: true)
-        
         let app = XCUIApplication()
         let addAssociationButton = app.staticTexts["Add Association"]
         let addConditionButton = app.buttons["Add Condition"]
-        let condition1Options = app.buttons["Condition 1 Options"]
         let connectedFilterTitle = app.staticTexts["Connected"]
         let currentMonthYear = Date.now.formatted(.dateTime.month(.wide).year())
         let currentMonthYearLabel = app.staticTexts[currentMonthYear]
-        let dateInstalledButton = app.buttons["Date Installed"]
         let datePickers = XCUIApplication().datePickers
         let datePicker1 = datePickers.firstMatch
         let datePicker2 = datePickers.element(boundBy: 1)
         let dismissPopover = app.buttons["PopoverDismissRegion"]
-        let duplicateButton = app.buttons["Duplicate"]
         let electricDistributionDeviceDataSourceButton = app.buttons["Electric Distribution Device"]
         let elementTitle = "Associations"
         let elementLabel = app.staticTexts[elementTitle]
         let filterButton = app.buttons["Filter Candidates"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
-        let greaterThanButton = app.buttons[">"]
         let greaterThanLabels = app.staticTexts.matching(identifier: ">")
         let jan2014Label = app.staticTexts["January 2014"]
         let lessThanButton = app.buttons["<"]
         let municipalButton = app.buttons["Municipal"]
         let streetLightCandidates = app.buttons.matching(identifier: "Street Light")
         
-#if os(visionOS)
+#if os(visionOS) || targetEnvironment(macCatalyst)
         let currentMonthYearOption = app.buttons[currentMonthYear]
         let equalsCondition = app.buttons["Condition, ="]
         let objectIDField = app.buttons["Field, Object ID"]
@@ -1969,6 +1987,18 @@ final class FeatureFormViewTests: XCTestCase {
         let currentMonthYearOption = app.staticTexts[currentMonthYear]
         let equalsCondition = app.staticTexts["="]
         let objectIDField = app.staticTexts["Object ID"]
+#endif
+        
+#if targetEnvironment(macCatalyst)
+        let condition1Options = app.popUpButtons["Condition 1 Options"]
+        let dateInstalledButton = app.menuItems["date_installed"]
+        let duplicateButton = app.menuItems["duplicate"]
+        let greaterThanButton = app.menuItems[">"]
+#else
+        let condition1Options = app.buttons["Condition 1 Options"]
+        let dateInstalledButton = app.buttons["Date Installed"]
+        let duplicateButton = app.buttons["Duplicate"]
+        let greaterThanButton = app.buttons[">"]
 #endif
         
         openTestCase()
@@ -2006,19 +2036,30 @@ final class FeatureFormViewTests: XCTestCase {
         
 #if os(visionOS)
         XCTExpectFailure("Opening the date picker's month & year picker doesn't work as expected on visionOS.")
-#endif
-        
         currentMonthYearLabel.assertExistenceAndTap()
-        
+#elseif targetEnvironment(macCatalyst)
+        datePicker1.typeKey(.leftArrow, modifierFlags: .function)
+        datePicker1.typeKey(.leftArrow, modifierFlags: .function)
+        datePicker1.typeText("1")
+        datePicker1.typeKey(.rightArrow, modifierFlags: .function)
+        datePicker1.typeText("1")
+        datePicker1.typeKey(.rightArrow, modifierFlags: .function)
+        datePicker1.typeText("2014")
+        datePicker1.typeKey(.return, modifierFlags: .function)
+#else
+        currentMonthYearLabel.assertExistenceAndTap()
         datePicker1.adjustPickerWheelElement(boundBy: 0, to: "January")
-        
         datePicker1.adjustPickerWheelElement(boundBy: 1, to: "2014")
-        
         dismissPopover.firstMatch.assertExistenceAndTap()
+#endif
         
         condition1Options.assertExistenceAndTap()
         
         duplicateButton.assertExistenceAndTap()
+        
+#if targetEnvironment(macCatalyst)
+        XCTExpectFailure("The condition doesn't duplicate correctly on Mac Catalyst. The selected field is not preserved.")
+#endif
         
         greaterThanLabels.element(boundBy: 1).assertExistenceAndTap()
         

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -2038,8 +2038,6 @@ final class FeatureFormViewTests: XCTestCase {
     }
     
     func testCase_13_6() throws {
-        try skipIf(macCatalyst: true)
-        
         let app = XCUIApplication()
         let addAssociationButton = app.staticTexts["Add Association"]
         let addButton = app.buttons["Add"]

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1363,7 +1363,6 @@ final class FeatureFormViewTests: XCTestCase {
         let assetType = app.staticTexts["Asset type *"]
         let backButton = app.buttons["Back"]
         let discardEditsButton = app.buttons["Discard Edits"]
-        let doneButton = app.buttons["Done"]
         let elementTitle = app.staticTexts["Associations"]
         let fieldValue = app.staticTexts["Asset type Combo Box Value"]
         let filterResults = app.staticTexts["Connected"]
@@ -1372,6 +1371,12 @@ final class FeatureFormViewTests: XCTestCase {
         let formTitle2 = app.staticTexts["Electric Distribution Device"]
         let networkSourceGroupButton = app.buttons["Electric Distribution Device, 1"]
         let utilityElementButton = app.buttons["Transformer, High"]
+        
+#if os(visionOS)
+        let doneButton = app.buttons["Confirm"]
+#else
+        let doneButton = app.buttons["Done"]
+#endif
         
         openTestCase()
         assertFormOpened(titleElement: formTitle)


### PR DESCRIPTION
- Refactors `RangeDomain.displayableNumericMinAndMax` as [suggested](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1176#discussion_r2183926569) by @yo1995.
- Adds a common `Button.delete` to use across various components.
- Marks a few view model classes as `final`.
- Overhauls `FeatureFormView` UI tests.
  - Uses recently added `XCUIElement` methods and adds a few more.
  - Restores _nearly all_ cases to passing on all supported platforms (save for a couple expected failures).
  - Synchornizes variable naming patterns across all cases.
- Various small improvements.