### PR TITLE
Bracket attachment url access between `url.startAccessingSecurityScop…

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -168,12 +168,14 @@ struct AttachmentImportMenu: View {
             }
             
             var newAttachment: FeatureAttachment? = nil
-            if let url = newAttachmentImportData.filePath {
+            if let url = newAttachmentImportData.filePath,
+               url.startAccessingSecurityScopedResource() {
                 newAttachment = try? await element.addAttachment(
                     named: fileName,
                     contentType: newAttachmentImportData.contentType,
                     fileURL: url
                 )
+                url.stopAccessingSecurityScopedResource()
             } else if let data = newAttachmentImportData.data {
                 newAttachment = element.addAttachment(
                     name: fileName,


### PR DESCRIPTION
Apollo 1648

When accessing an attachment url from the "Add From File" functionality, always wrap the url in a `url.startAccessingSecurityScopedResource`/`url.stopAccessingSecurityScopedResource` block. In this case, when adding an attachment to an element.

This fixes a crash when adding an attachment from file.