### PR TITLE
doc: Adjust phrasing and paragraph structure for the Offline tutorial

### DIFF
--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/OfflineMapAreasViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/OfflineMapAreasViewTutorial.tutorial
@@ -81,10 +81,13 @@
             }
             
             @Step {
-                The job manager and the offline manager requires the following keys in the application's Information Property List to support background downloads and to support iOS 26 `BGContinuedProcessingTask`.
+                The job manager and the offline manager requires the following keys in the application's 
+                Information Property List to support background downloads and to support iOS 26 `BGContinuedProcessingTask`.
                 
-                For the job manager, add “com.esri.ArcGISToolkit.jobManager.offlineManager.statusCheck” 
-                to Permitted Background Task Scheduler Identifiers. For the offline manager, add “$(PRODUCT_BUNDLE_IDENTIFIER).cpt.jobs.\*” to Permitted Background Task Scheduler Identifiers. Then add "App downloads content from the network" to Required Background Modes.
+                For the job manager, add “com.esri.ArcGISToolkit.jobManager.offlineManager.statusCheck”
+                to Permitted Background Task Scheduler Identifiers. For the offline manager,
+                add “$(PRODUCT_BUNDLE_IDENTIFIER).cpt.jobs.\*” to Permitted Background Task Scheduler Identifiers.
+                Then add "App downloads content from the network" to Required Background Modes.
                 
                 @Image(source: InformationPropertyList, alt: "An image of the required keys in the Information Property List.")
             }

--- a/Sources/ArcGISToolkit/Documentation.docc/Tutorials/OfflineMapAreasViewTutorial.tutorial
+++ b/Sources/ArcGISToolkit/Documentation.docc/Tutorials/OfflineMapAreasViewTutorial.tutorial
@@ -48,9 +48,7 @@
                 The `OfflineMapAreasView` requires additional setup to use the job manager.
                 
                 Apply the view modifier `.offlineManager(configuration:onJobCompletion:)` at the entry point of
-                the application.
-                
-                Set the `preferredBackgroundStatusCheckSchedule` to `.regularInterval(interval: 30)`
+                the application. Set the `preferredBackgroundStatusCheckSchedule` to `.regularInterval(interval: 30)`
                 on the specified configuration to check the status of the download job in the
                 background every 30 seconds. Note that whether the system actually allows the job
                 to be checked at the preferred interval is at the discretion of the operating system.
@@ -83,18 +81,11 @@
             }
             
             @Step {
-                The job manager requires the following keys in the application's Information Property List 
-                to support background downloads.
+                The job manager and the offline manager requires the following keys in the application's Information Property List to support background downloads and to support iOS 26 `BGContinuedProcessingTask`.
                 
-                Add “com.esri.ArcGISToolkit.jobManager.offlineManager.statusCheck” 
-                to Permitted Background Task Scheduler Identifiers.
+                For the job manager, add “com.esri.ArcGISToolkit.jobManager.offlineManager.statusCheck” 
+                to Permitted Background Task Scheduler Identifiers. For the offline manager, add “$(PRODUCT_BUNDLE_IDENTIFIER).cpt.jobs.\*” to Permitted Background Task Scheduler Identifiers. Then add "App downloads content from the network" to Required Background Modes.
                 
-                The offline manager requires the following keys in the application's Information Property List 
-                to support iOS 26 `BGContinuedProcessingTask`.
-                
-                Add “$(PRODUCT_BUNDLE_IDENTIFIER).cpt.jobs.*” to Permitted Background Task Scheduler Identifiers.
-                    
-                Then add "App downloads content from the network" to Required Background Modes. 
                 @Image(source: InformationPropertyList, alt: "An image of the required keys in the Information Property List.")
             }
         }


### PR DESCRIPTION
Close #1387 

Restructure the paragraphs, so no content get truncated

|Before|After|
|:-:|:-:|
|<img width="1169" height="427" alt="Screenshot 2026-03-19 at 9 56 36 AM" src="https://github.com/user-attachments/assets/f5a504b6-2ea5-484b-9da2-16db21d0bffd" />|<img width="1180" height="525" alt="Screenshot 2026-03-19 at 9 49 43 AM" src="https://github.com/user-attachments/assets/39f046c4-ad5f-4720-a95e-602bc36fd30b" />|
|<img width="1118" height="288" alt="Screenshot 2026-03-19 at 9 56 46 AM" src="https://github.com/user-attachments/assets/9f17f765-506d-450e-a844-de602833ba1f" />|<img width="1130" height="446" alt="Screenshot 2026-03-19 at 9 49 15 AM" src="https://github.com/user-attachments/assets/1d1a9de8-44b3-4e3c-aff7-b0b9138ae45f" />|
