### PR TITLE
`FeatureFormView` - Test case 13.6 iOS patch

### DIFF
--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1989,6 +1989,7 @@ final class FeatureFormViewTests: XCTestCase {
         let filterButton = app.buttons["Filter Candidates"]
         let formTitle = app.staticTexts["Structure Junction"]
         let municipalButton = app.buttons["Municipal, Street Light"]
+        let popoverDismissRegion = app.otherElements["PopoverDismissRegion"].firstMatch
         let streetLightButton = app.buttons["Street Light"]
         let streetLightCandidates = app.buttons.matching(identifier: "Street Light")
         
@@ -2018,6 +2019,10 @@ final class FeatureFormViewTests: XCTestCase {
         textField.assertExistenceAndTap()
         
         textField.typeText("449")
+        
+        if popoverDismissRegion.exists {
+            popoverDismissRegion.tap()
+        }
         
         app.doneButton.assertExistenceAndTap()
         


### PR DESCRIPTION
iOS 26 hardware devices have a fun little numeric keypad that appears in different spots and sometimes blocks the done button.

<img width="724" height="554" alt="IMG_0200" src="https://github.com/user-attachments/assets/b5bc8a9a-cb85-40b1-ae51-ab885dc94943" />
<img width="511" height="317" alt="Screenshot 2026-03-20 at 10 27 31" src="https://github.com/user-attachments/assets/cc0de45b-a8da-435b-8711-851e6c4fc7b4" />
