### PR TITLE
Alphabetically sort the sublayers in `BuildingExplorer`

### DIFF
--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerForm.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerForm.swift
@@ -112,7 +112,7 @@ struct BuildingExplorerForm: View {
                 // is visible.
                 if showFullModel && layerIsVisible {
                     Section {
-                        ForEach(groupSublayers) { sublayer in
+                        ForEach(groupSublayers.sorted { $0.name < $1.name }) { sublayer in
                             BuildingGroupSublayerToggleView(groupSublayer: sublayer)
                         }
                     } header: {

--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingGroupSublayerToggleView.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingGroupSublayerToggleView.swift
@@ -26,7 +26,7 @@ struct BuildingGroupSublayerToggleView: View {
     
     var body: some View {
         DisclosureGroup {
-            ForEach(groupSublayer.sublayers) { sublayer in
+            ForEach(groupSublayer.sublayers.sorted { $0.name < $1.name }) { sublayer in
                 BuildingSublayerToggleView(sublayer: sublayer)
                     // If the group sublayer isn't visible then the toggles
                     // for its sublayers should be disabled.


### PR DESCRIPTION
When I was making changes to the common design, I noticed I missed this change so fixing that now.