### PR TITLE
fix preplanned map model test

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OfflineManager.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineManager.swift
@@ -100,7 +100,7 @@ public class OfflineManager: ObservableObject {
     
     /// The configuration settings for the offline manager.
     /// - Since 300.0
-    public fileprivate(set) var configuration = OfflineManagerConfiguration()
+    public internal(set) var configuration = OfflineManagerConfiguration()
     
     /// Storage for jobs when we are not making use of the job manager.
     private var selfManagedJobs: [any JobProtocol] = []

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
@@ -199,6 +199,7 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     /// when it's done, updates the status, removes the job from the job manager,
     /// and fires a user notification.
     private func observeJob(_ job: DownloadPreplannedOfflineMapJob) {
+        Logger.offlineManager.info("Observing DownloadPreplannedOfflineMapJob.")
         self.job = job
         status = .downloading
         Task { [weak self, job] in

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -189,12 +189,23 @@ class PreplannedMapModelTests: XCTestCase {
                 directoryHint: .isDirectory
             )
         
+#if os(iOS) && !targetEnvironment(macCatalyst)
+        if #available(iOS 26.0, *) {
+            // Make sure to specify to use the job manager so that the job can
+            // be found.
+            OfflineManager.shared.configuration = .init(useBGContinuedProcessingTasks: false)
+        }
+#endif
+        
         defer {
             // Clean up JobManager.
             OfflineManager.shared.jobManager.jobs.removeAll()
             
             // Clean up folder.
             try? FileManager.default.removeItem(at: mmpkDirectory)
+            
+            // Clean up OfflineManager
+            try? OfflineManager.shared.removeAllDownloads()
         }
         
         // Add a job to the job manager so that when creating the model it finds it.


### PR DESCRIPTION
Fixes the preplanned map model failure. Need to specify in the OfflineManager to use the job manager instead of continued processing tasks.