### PR TITLE
Improve `BuildingExplorer` example on iPhone

### DIFF
--- a/Examples/Examples/BuildingExplorerExampleView.swift
+++ b/Examples/Examples/BuildingExplorerExampleView.swift
@@ -43,9 +43,9 @@ struct BuildingExplorerExampleView: View {
                             selection: $selection
                         )
                         .frame(idealWidth: 400, idealHeight: 500)
-                        .presentationDetents([.medium, .large])
                         .presentationBackgroundInteraction(.enabled)
                         .presentationContentInteraction(.scrolls)
+                        .presentationDetents([.medium, .large])
                     }
                 }
             }

--- a/Examples/Examples/BuildingExplorerExampleView.swift
+++ b/Examples/Examples/BuildingExplorerExampleView.swift
@@ -43,7 +43,9 @@ struct BuildingExplorerExampleView: View {
                             selection: $selection
                         )
                         .frame(idealWidth: 400, idealHeight: 500)
-                        .presentationCompactAdaptation(.popover)
+                        .presentationDetents([.medium, .large])
+                        .presentationBackgroundInteraction(.enabled)
+                        .presentationContentInteraction(.scrolls)
                     }
                 }
             }


### PR DESCRIPTION
Adding these modifiers makes the BE on iPhone much more usable, where you can make changes in the BE and see the changes take place in the view.

Before:

https://github.com/user-attachments/assets/f589f5f6-3fb3-466b-a5af-595ea19a43bb



After:

https://github.com/user-attachments/assets/fba48f0a-d084-4a08-9266-150299020ee4

