### PR TITLE
Use custom flag to to determine how to get the bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,9 +40,6 @@ let package = Package(
             dependencies: [
                 .product(name: "ArcGIS", package: "arcgis-maps-sdk-swift"),
                 .product(name: "Markdown", package: "swift-markdown")
-            ],
-            swiftSettings: [
-                .define("USE_BUNDLE_MACRO")
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,9 @@ let package = Package(
             dependencies: [
                 .product(name: "ArcGIS", package: "arcgis-maps-sdk-swift"),
                 .product(name: "Markdown", package: "swift-markdown")
+            ],
+            swiftSettings: [
+                .define("USE_BUNDLE_MACRO")
             ]
         ),
         .testTarget(

--- a/Sources/ArcGISToolkit/Extensions/Foundation/Bundle.swift
+++ b/Sources/ArcGISToolkit/Extensions/Foundation/Bundle.swift
@@ -20,5 +20,15 @@ extension Bundle {
     
     /// The toolkit module, which is either the resource bundle or the
     /// ArcGISToolkit framework, depending on how the toolkit was built.
-    static let toolkitModule = Bundle(identifier: toolkitIdentifier) ?? .module
+    static let toolkitModule: Bundle = {
+#if USE_BUNDLE_MACRO
+        #bundle
+#else
+        // Only create the bundle using the ID if the toolkit
+        // is being used as a built framework. Otherwise time-consuming
+        // heuristics will be used to locate the bundle and that
+        // can block the main thread.
+        Bundle(identifier: toolkitIdentifier)!
+#endif
+    }()
 }

--- a/Sources/ArcGISToolkit/Extensions/Foundation/Bundle.swift
+++ b/Sources/ArcGISToolkit/Extensions/Foundation/Bundle.swift
@@ -21,14 +21,14 @@ extension Bundle {
     /// The toolkit module, which is either the resource bundle or the
     /// ArcGISToolkit framework, depending on how the toolkit was built.
     static let toolkitModule: Bundle = {
-#if USE_BUNDLE_MACRO
-        #bundle
-#else
+#if USE_BUNDLE_IDENTIFIER
         // Only create the bundle using the ID if the toolkit
         // is being used as a built framework. Otherwise time-consuming
         // heuristics will be used to locate the bundle and that
         // can block the main thread.
         Bundle(identifier: toolkitIdentifier)!
+#else
+        #bundle
 #endif
     }()
 }


### PR DESCRIPTION
Fixes #1397
cc: @rolson @mhdostal  

The [pitch](https://forums.swift.org/t/pitch-introduce-bundle-macro/79288) for the bundle macro actually discusses the problem we were seeing:

> Or worse yet, they lookup the bundle using its bundle identifier, which while tempting is actually rather inefficient.

So us looking up the bundle by its bundle identifier when using the source code would take a while, hence the problem we were seeing.

In the Bundle [doc](https://developer.apple.com/documentation/foundation/bundle), Apple recommends using this macro:

> In Swift, use the [bundle()](https://developer.apple.com/documentation/foundation/bundle()) macro to insert a bundle instance appropriate to the current execution context, whether an app, app extension, framework, or Swift package.

So we are using that when the source code is used. That macro doesn't work when using the xcframework. The only solution I ended up on was adding a custom flag that we set to false when creating the xcframework and that works. This will require a separate PR in the Swift SDK that I will put up when this is approved.

Before:

https://github.com/user-attachments/assets/89cb7150-3014-46b1-9092-3fe5828c3e2e



After:

https://github.com/user-attachments/assets/d2e6754d-1b99-429a-b434-bb908cc12075

