### PR TITLE
Mhd/filter duplicate

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
@@ -52,7 +52,7 @@ final class FilterViewModel {
         let whereClause = whereClause(filters: fieldFilters)
         return originalWhereClause != whereClause
     }
-    
+
     /// Sets the fields to filter on.
     ///
     /// Use this to customize the filterable fields. Alternatively, set `featureTable` to auto-populate
@@ -120,7 +120,7 @@ class FieldFilter {
             }
             
             if oldValue.type != field.type {
-                codedValue = nil
+                codedValue = (field.domain as? CodedValueDomain)?.codedValues.first
                 dateValue = .now
             }
         }
@@ -153,33 +153,47 @@ class FieldFilter {
         }
     }
     
+    /// A Boolean value indicating whether the filter view is presented.
+    var selectedFieldName: String// {
+//        didSet {
+//            guard let field = model.field(named: selectedFieldName) else { return }
+//            self.field = field
+//        }
+//    }
+
     /// The value to filter on.
     var value = ""
     
     /// Creates a `FieldFilter`.
     /// - Parameter field: The `Field` being filtered on.
     init(field: Field) {
+        self.codedValue = (field.domain as? CodedValueDomain)?.codedValues.first
         self.dateValue = .now
         self.field = field
+        self.selectedFieldName = field.name
         self.condition = firstCondition()
+        self.value = codedValue?.name ?? ""
     }
     
     /// Creates a `FieldFilter`.
     /// - Parameters:
     ///   - field: The `Field` being filtered on.
+    ///   - codedValue: The codedValue used by the filter, if any.
     ///   - condition: The `FilterOperator` used on the `Field`.
+    ///   - dateValue: The dateValue used by the filter.
     ///   - value: The string value used in the filter.
     init(
         field: Field,
-        condition: FilterOperator,
         codedValue: CodedValue?,
+        condition: FilterOperator,
         dateValue: Date,
         value: String = ""
     ) {
-        self.field = field
-        self.condition = condition
         self.codedValue = codedValue
+        self.condition = condition
         self.dateValue = dateValue
+        self.field = field
+        self.selectedFieldName = field.name
         self.value = value
     }
     
@@ -244,8 +258,8 @@ extension FieldFilter {
     func copy() -> FieldFilter {
         FieldFilter(
             field: self.field,
-            condition: self.condition,
             codedValue: self.codedValue,
+            condition: self.condition,
             dateValue: self.dateValue,
             value: self.value
         )

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
@@ -166,6 +166,7 @@ class FieldFilter {
         self.dateValue = .now
         self.field = field
         self.selectedFieldName = field.name
+        // Calculating the first condition requires that the field be set.
         self.condition = firstCondition()
         self.value = codedValue?.name ?? ""
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
@@ -52,7 +52,7 @@ final class FilterViewModel {
         let whereClause = whereClause(filters: fieldFilters)
         return originalWhereClause != whereClause
     }
-
+    
     /// Sets the fields to filter on.
     ///
     /// Use this to customize the filterable fields. Alternatively, set `featureTable` to auto-populate
@@ -154,13 +154,8 @@ class FieldFilter {
     }
     
     /// A Boolean value indicating whether the filter view is presented.
-    var selectedFieldName: String// {
-//        didSet {
-//            guard let field = model.field(named: selectedFieldName) else { return }
-//            self.field = field
-//        }
-//    }
-
+    var selectedFieldName: String
+    
     /// The value to filter on.
     var value = ""
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FilterViewModel.swift
@@ -153,7 +153,7 @@ class FieldFilter {
         }
     }
     
-    /// A Boolean value indicating whether the filter view is presented.
+    /// The name of the selected field.
     var selectedFieldName: String
     
     /// The value to filter on.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -209,7 +209,7 @@ struct FilterView: View {
     let model = FilterViewModel()
     
     FilterView(model: model)
-        .onAppear() {
+        .onAppear {
             model.setFields(fields)
         }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -107,7 +107,7 @@ struct FilterView: View {
                         if oldValue.count < newValue.count,
                            let lastFieldFilter = model.fieldFilters.last {
                             withAnimation {
-                                proxy.scrollTo(lastFieldFilter.id, anchor: .bottom)
+                                proxy.scrollTo(lastFieldFilter.id, anchor: .top)
                             }
                         }
                     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -199,11 +199,12 @@ struct FilterView: View {
         }
     }
 }
+
 #Preview {
     let fields: [Field] = [
-        Field(type: .int32, name: "fieldOne", alias: "One", length: 30, domain: nil, isEditable: true, isNullable: false),
-        Field(type: .int32, name: "fieldTwo", alias: "Two", length: 30, domain: nil, isEditable: true, isNullable: false),
-        Field(type: .int32, name: "fieldThree", alias: "Three", length: 30, domain: nil, isEditable: true, isNullable: false)
+        Field(type: .int32, name: "fieldOne", alias: "One", length: 30, isNullable: false),
+        Field(type: .int32, name: "fieldTwo", alias: "Two", length: 30, isNullable: false),
+        Field(type: .int32, name: "fieldThree", alias: "Three", length: 30, isNullable: false)
     ]
     let model = FilterViewModel()
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -209,7 +209,7 @@ struct FilterView: View {
     let model = FilterViewModel()
     
     FilterView(model: model)
-        .task() {
+        .onAppear() {
             model.setFields(fields)
         }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -199,6 +199,19 @@ struct FilterView: View {
         }
     }
 }
+#Preview {
+    let fields: [Field] = [
+        Field(type: .int32, name: "fieldOne", alias: "One", length: 30, domain: nil, isEditable: true, isNullable: false),
+        Field(type: .int32, name: "fieldTwo", alias: "Two", length: 30, domain: nil, isEditable: true, isNullable: false),
+        Field(type: .int32, name: "fieldThree", alias: "Three", length: 30, domain: nil, isEditable: true, isNullable: false)
+    ]
+    let model = FilterViewModel()
+    
+    FilterView(model: model)
+        .task() {
+            model.setFields(fields)
+        }
+}
 
 /// A button that adds a `FieldFilter` to the current  list of `FieldFilter` objects.
 private struct AddButton: View {
@@ -266,9 +279,6 @@ private struct FieldView: View {
     /// The list of conditions/operations the user is allowed to choose from.
     @State private var conditions = [FilterOperator]()
     
-    /// The name of the selected field.
-    @State private var selectedFieldName = ""
-    
     init(fieldFilter: FieldFilter) {
         self.fieldFilter = fieldFilter
     }
@@ -284,7 +294,7 @@ private struct FieldView: View {
                 }
             } else {
                 HStack {
-                    Picker(selection: $selectedFieldName) {
+                    Picker(selection: $fieldFilter.selectedFieldName) {
                         ForEach(model.fields, id: \.name) { field in
                             Text(field.title)
                         }
@@ -293,11 +303,8 @@ private struct FieldView: View {
                     }
                     .pickerStyle(.menu)
                     .tint(.primary)
-                    .onAppear {
-                        selectedFieldName = fieldFilter.field.name
-                    }
-                    .onChange(of: selectedFieldName) {
-                        guard let field = model.field(named: selectedFieldName) else { return }
+                    .onChange(of: fieldFilter.selectedFieldName) {
+                        guard let field = model.field(named: fieldFilter.selectedFieldName) else { return }
                         fieldFilter.field = field
                         conditions = fieldFilter.supportedConditions
                     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationFeatureCandidatesView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/UtilityAssociationsFormElement/UtilityAssociationFeatureCandidatesView.swift
@@ -81,7 +81,6 @@ extension FeatureFormView {
             }
             .sheet(isPresented: $filterViewModel.filterViewIsPresented) {
                 FilterView(model: filterViewModel) {
-                    candidates.removeAll()
                     whereClause = filterViewModel.whereClause()
                 }
                 .interactiveDismissDisabled()

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1950,6 +1950,7 @@ final class FeatureFormViewTests: XCTestCase {
         condition1Options.assertExistenceAndTap()
         
         duplicateButton.assertExistenceAndTap()
+        
         greaterThanLabels.element(boundBy: 1).assertExistenceAndTap()
         
         lessThanButton.assertExistenceAndTap()
@@ -1981,6 +1982,7 @@ final class FeatureFormViewTests: XCTestCase {
 #endif
         
         app.doneButton.assertExistenceAndTap()
+        
         // This is needed for Mac Catalyst to allow the list to update,
         // but it causes no problems on iOS.
         streetLightCandidates.firstMatch.assertExistence()

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -882,7 +882,7 @@ final class FeatureFormViewTests: XCTestCase {
             switchView.label,
             "2"
         )
-      
+        
 #if targetEnvironment(macCatalyst) || os(visionOS)
         switchView.assertExistenceAndTap()
 #else
@@ -1949,11 +1949,6 @@ final class FeatureFormViewTests: XCTestCase {
         condition1Options.assertExistenceAndTap()
         
         duplicateButton.assertExistenceAndTap()
-        
-#if targetEnvironment(macCatalyst)
-        XCTExpectFailure("The condition doesn't duplicate correctly on Mac Catalyst. The selected field is not preserved.")
-#endif
-        
         greaterThanLabels.element(boundBy: 1).assertExistenceAndTap()
         
         lessThanButton.assertExistenceAndTap()

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1866,9 +1866,8 @@ final class FeatureFormViewTests: XCTestCase {
         let elementLabel = app.staticTexts[elementTitle]
         let filterButton = app.buttons["Filter Candidates"]
         let formTitle = app.staticTexts["Electric Distribution Device"]
-        let greaterThanLabels = app.staticTexts.matching(identifier: ">")
-        let jan2014Label = app.staticTexts["January 2014"]
-        let lessThanButton = app.buttons["<"]
+        // Using app.buttons allows this to work on both Mac Catalyst and iOS
+        let greaterThanLabels = app.buttons.matching(identifier: "Condition, >")
         let municipalButton = app.buttons["Municipal, Street Light"]
         let streetLightCandidates = app.buttons.matching(identifier: "Street Light")
         
@@ -1887,11 +1886,13 @@ final class FeatureFormViewTests: XCTestCase {
         let dateInstalledButton = app.menuItems["date_installed"]
         let duplicateButton = app.menuItems["duplicate"]
         let greaterThanButton = app.menuItems[">"]
+        let lessThanButton = app.menuItems["<"]
 #else
         let condition1Options = app.buttons["Condition 1 Options"]
         let dateInstalledButton = app.buttons["Date Installed"]
         let duplicateButton = app.buttons["Duplicate"]
         let greaterThanButton = app.buttons[">"]
+        let lessThanButton = app.buttons["<"]
 #endif
         
         openTestCase()
@@ -1954,15 +1955,36 @@ final class FeatureFormViewTests: XCTestCase {
         lessThanButton.assertExistenceAndTap()
         
         datePicker2.assertExistenceAndTap()
-        
-        jan2014Label.assertExistenceAndTap()
-        
+
+#if os(visionOS)
+        XCTExpectFailure("Opening the date picker's month & year picker doesn't work as expected on visionOS.")
+        currentMonthYearLabel.assertExistenceAndTap()
+#elseif targetEnvironment(macCatalyst)
+        datePicker2.typeKey(.leftArrow, modifierFlags: .function)
+        datePicker2.typeKey(.leftArrow, modifierFlags: .function)
+        datePicker2.typeText("3")
+        datePicker2.typeKey(.return, modifierFlags: .function)
+#else
+        // Need to create the date set above so we can find it 
+        var components = DateComponents()
+        components.year = 2014
+        components.month = 1
+        components.day = 1
+
+        let calendar = Calendar.current
+        let newDate = try XCTUnwrap(calendar.date(from: components))
+        let monthYear2014 = newDate.formatted(.dateTime.month(.wide).year())
+        let monthYearLabel = app.staticTexts[monthYear2014]
+        monthYearLabel.assertExistenceAndTap()
         datePicker2.adjustPickerWheelElement(boundBy: 0, to: "March")
-        
         dismissPopover.firstMatch.assertExistenceAndTap()
+#endif
         
         app.doneButton.assertExistenceAndTap()
-        
+        // This is needed for Mac Catalyst to allow the list to update,
+        // but it causes no problems on iOS.
+        streetLightCandidates.firstMatch.assertExistence()
+
         XCTAssertEqual(streetLightCandidates.count, 1)
     }
     

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1868,6 +1868,7 @@ final class FeatureFormViewTests: XCTestCase {
         let formTitle = app.staticTexts["Electric Distribution Device"]
         // Using app.buttons allows this to work on both Mac Catalyst and iOS
         let greaterThanLabels = app.buttons.matching(identifier: "Condition, >")
+        let jan2014Label = app.staticTexts["January 2014"]
         let municipalButton = app.buttons["Municipal, Street Light"]
         let streetLightCandidates = app.buttons.matching(identifier: "Street Light")
         
@@ -1956,35 +1957,20 @@ final class FeatureFormViewTests: XCTestCase {
         lessThanButton.assertExistenceAndTap()
         
         datePicker2.assertExistenceAndTap()
-
-#if os(visionOS)
-        XCTExpectFailure("Opening the date picker's month & year picker doesn't work as expected on visionOS.")
-        currentMonthYearLabel.assertExistenceAndTap()
-#elseif targetEnvironment(macCatalyst)
+        
+#if targetEnvironment(macCatalyst)
         datePicker2.typeKey(.leftArrow, modifierFlags: .function)
         datePicker2.typeKey(.leftArrow, modifierFlags: .function)
         datePicker2.typeText("3")
         datePicker2.typeKey(.return, modifierFlags: .function)
 #else
-        // Need to create the date set above so we can find it 
-        var components = DateComponents()
-        components.year = 2014
-        components.month = 1
-        components.day = 1
-
-        let calendar = Calendar.current
-        let newDate = try XCTUnwrap(calendar.date(from: components))
-        let monthYear2014 = newDate.formatted(.dateTime.month(.wide).year())
-        let monthYearLabel = app.staticTexts[monthYear2014]
-        monthYearLabel.assertExistenceAndTap()
+        jan2014Label.assertExistenceAndTap()
         datePicker2.adjustPickerWheelElement(boundBy: 0, to: "March")
         dismissPopover.firstMatch.assertExistenceAndTap()
 #endif
         
         app.doneButton.assertExistenceAndTap()
         
-        // This is needed for Mac Catalyst to allow the list to update,
-        // but it causes no problems on iOS.
         streetLightCandidates.firstMatch.assertExistence()
 
         XCTAssertEqual(streetLightCandidates.count, 1)


### PR DESCRIPTION
Apollo 1660 - Filter conditions don't duplicate properly on Mac Catalyst.

I have eliminated all of the runtime warnings. Everything works fine with one exception:

When running on Mac Catalyst and the "Mac Catalyst Interface" option for the Target is set to "Optimize for Mac", changing the selected field (and when the selected field has a different list of "conditions" associated with it), the Picker selection is incorrect. It doesn't update when the new field is selected. Clicking on the picker shows the correct selection in the list and DOES show the correct selected condition.

It updates correctly on the "Scale to match iPad" option and on  iOS. There are no more runtime warnings and nothing I've tried has caused it to switch correctly, so I'm assuming this is simply a SwiftUI issue with the "Optimize for Mac" option.