### PR TITLE
Fix construction phase bug in `BuildingExplorer`

### DIFF
--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerForm.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerForm.swift
@@ -52,9 +52,9 @@ struct BuildingExplorerForm: View {
     // MARK: Phase picker properties.
     
     /// The selected phase in the phase picker.
-    @State private var selectedPhase = ""
+    @State private var selectedPhase: Int?
     /// The available phase in the phase picker.
-    @State private var availablePhases: [String] = []
+    @State private var availablePhases: [Int] = []
     
     @State private var phasePickerStyle: (any PickerStyle) = .automatic
     
@@ -238,7 +238,8 @@ struct BuildingExplorerForm: View {
     private var phasePicker: some View {
         Picker(selection: $selectedPhase) {
             ForEach(availablePhases, id: \.self) { phase in
-                Text(verbatim: phase)
+                Text(verbatim: "\(phase)")
+                    .tag(phase)
             }
             .onChange(of: selectedPhase) {
                 if selection.phase != selectedPhase {
@@ -263,14 +264,14 @@ struct BuildingExplorerForm: View {
     private var levelAndPhaseFilter: BuildingFilter? {
         // If no level or phase is selected then we need show everything
         // so return 'nil' for the filter.
-        guard selectedLevel != .allLabel || !selectedPhase.isEmpty else { return nil }
+        guard selectedLevel != .allLabel || selectedPhase != nil else { return nil }
         
         // Construct the where clauses based on the selection state.
         
         var solidWhereClause = ""
         var xRayWhereClause = ""
         
-        if !selectedPhase.isEmpty {
+        if let selectedPhase {
             solidWhereClause = "\(String.phaseFieldKey) <= \(selectedPhase)"
         }
         
@@ -351,7 +352,9 @@ struct BuildingExplorerForm: View {
         // Gets all the levels and phases and sort them.
         
         availableLevels = levelStatistics.mostFrequentValues.sorted { Int($0) ?? .zero > Int($1) ?? .zero } + [.allLabel]
-        availablePhases = phaseStatistics.mostFrequentValues.sorted { Int($0) ?? .zero > Int($1) ?? .zero }
+        availablePhases = phaseStatistics.mostFrequentValues
+            .compactMap { Int($0) } // Make sure all phases are integers.
+            .sorted { $0 > $1 }
         
         // Restore last selected level and phase if there was one.
         // If not, give a default.
@@ -362,10 +365,10 @@ struct BuildingExplorerForm: View {
             selection.level
         }
         
-        selectedPhase = if selection.phase.isEmpty {
-            availablePhases.first ?? ""
+        selectedPhase = if let phase = selection.phase {
+            phase
         } else {
-            selection.phase
+            availablePhases.first
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerForm.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerForm.swift
@@ -238,7 +238,7 @@ struct BuildingExplorerForm: View {
     private var phasePicker: some View {
         Picker(selection: $selectedPhase) {
             ForEach(availablePhases, id: \.self) { phase in
-                Text(verbatim: "\(phase)")
+                Text(phase, format: .number)
                     .tag(phase)
             }
             .onChange(of: selectedPhase) {

--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerItem.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerItem.swift
@@ -25,7 +25,7 @@ public final class BuildingExplorerItem {
     /// The level that is selected for this item.
     public internal(set) var level = ""
     /// The phase that is selected for this item.
-    public internal(set) var phase = ""
+    public internal(set) var phase: Int?
     
     init(layer: BuildingSceneLayer) { self.layer = layer }
 }


### PR DESCRIPTION
I was testing a web scene (that I will send to the reviewers on Slack) and I was using the explorer with it. When I changed the level, I realized the filters weren't behaving as I expected. 

After some debugging, it looks like the problem came down to that there was a single construction phase present and it wasn't a number which threw off the filters being applied. I would consider this an edge case because I've never seen a phase that wasn't a number. But we should still fix the behavior and this PR does that by requiring the construction phase to be a number. The web scene viewer has similar behavior.