### PR TITLE
`BuildingExplorer` - Remove empty string entry

### DIFF
--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorer.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorer.swift
@@ -103,7 +103,6 @@ public struct BuildingExplorer: View {
                     failure.localizedDescription,
                     systemImage: "exclamationmark.triangle"
                 )
-                EmptyView()
             case nil:
                 ProgressView()
             }

--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorer.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorer.swift
@@ -99,7 +99,11 @@ public struct BuildingExplorer: View {
                     localSceneViewProxy: localSceneViewProxy
                 )
             case .failure(let failure):
-                ContentUnavailableView("\(failure.localizedDescription)", systemImage: "exclamationmark.triangle")
+                ContentUnavailableView(
+                    failure.localizedDescription,
+                    systemImage: "exclamationmark.triangle"
+                )
+                EmptyView()
             case nil:
                 ProgressView()
             }


### PR DESCRIPTION
The current usage of `ContentUnavailableView` generates an empty entry in the strings file.