### PR TITLE
use hasPrefix instead of starts(with:) from RegexBuilder

### DIFF
--- a/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/FieldsPopupElementView.swift
@@ -72,7 +72,7 @@ struct FieldsPopupElementView: View {
         let formattedValue: String
         
         var body: some View {
-            if formattedValue.lowercased().starts(with: "http"),
+            if formattedValue.lowercased().hasPrefix("http"),
                let url = URL(string: formattedValue) {
                 Link(destination: url) {
                     Text(


### PR DESCRIPTION
The `starts(with:)` method is part of `RegexBuilder`, which is not imported in this file. In this case, using the simpler `hasPrefix` method is sufficient.