### PR TITLE
`BuildingExplorer` - add Mac Catalyst padding

### DIFF
--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingGroupSublayerToggleView.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingGroupSublayerToggleView.swift
@@ -37,6 +37,9 @@ struct BuildingGroupSublayerToggleView: View {
                 .onChange(of: isVisible) {
                     groupSublayer.isVisible = isVisible
                 }
+#if targetEnvironment(macCatalyst)
+                .padding(.leading, 4)
+#endif
         }
         .onAppear {
             // Sets the value of the toggle to the

--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingGroupSublayerToggleView.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingGroupSublayerToggleView.swift
@@ -37,9 +37,7 @@ struct BuildingGroupSublayerToggleView: View {
                 .onChange(of: isVisible) {
                     groupSublayer.isVisible = isVisible
                 }
-#if targetEnvironment(macCatalyst)
-                .padding(.leading, 4)
-#endif
+                .catalystPadding(4)
         }
         .onAppear {
             // Sets the value of the toggle to the


### PR DESCRIPTION
Adds padding to the DisclosureGroup Toggle in the `BuildingGroupSublayerToggleView` on Mac Catalyst.

Before padding:

<img width="419" height="258" alt="Screenshot 2026-04-06 at 12 59 45 PM" src="https://github.com/user-attachments/assets/9b68cb80-63b4-47e1-bd28-0c3d20cf1ec0" />

After padding: 

<img width="384" height="237" alt="Screenshot 2026-04-06 at 3 24 10 PM" src="https://github.com/user-attachments/assets/42860a00-ea65-4daf-8541-9f492e4577c6" />
