### PR TITLE
`FloorFilter` - use plain button style for Mac Catalyst

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -135,6 +135,9 @@ private struct SiteList: View {
                 .fixedSize(horizontal: true, vertical: false)
 #endif
         }
+#if targetEnvironment(macCatalyst)
+        .buttonStyle(.plain)
+#endif
     }
 }
 


### PR DESCRIPTION
Uses a plain button style for Mac Catalyst to remove the gray background on the "All Sites" Navigation Link Text.

Before/After:

<img width="375" height="512" alt="Screenshot 2026-04-07 at 11 49 30 AM" src="https://github.com/user-attachments/assets/3169d6a4-08d7-49f9-b8ef-631f18d0497e" /> <img width="375" height="512" alt="plain button fix" src="https://github.com/user-attachments/assets/5f8d86cc-be87-4b9e-99d5-ee73eb7fd9c8" />
