### PR TITLE
`LocationButton` - update button style for Mac Catalyst

### DIFF
--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -104,7 +104,7 @@ public struct LocationButton: View {
         .task(id: ObjectIdentifier(locationDisplay)) { await observeAutoPanMode() }
         .animation(.default, value: autoPanMode)
 #if targetEnvironment(macCatalyst)
-        .buttonStyle(.plain)
+        .buttonStyle(.borderless)
 #endif
     }
     

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -103,6 +103,9 @@ public struct LocationButton: View {
         .task(id: ObjectIdentifier(locationDisplay)) { await observeStatus() }
         .task(id: ObjectIdentifier(locationDisplay)) { await observeAutoPanMode() }
         .animation(.default, value: autoPanMode)
+#if targetEnvironment(macCatalyst)
+        .buttonStyle(.plain)
+#endif
     }
     
     /// The accessibility label of the button.


### PR DESCRIPTION
Uses a borderless button style for the LocationButton to remove the gray background. This issue is only present on Mac Catalyst.

Before/After:
<img width="205" alt="Screenshot 2026-04-07 at 2 39 17 PM" src="https://github.com/user-attachments/assets/a049ea83-c527-42be-8ab5-eb585f8de556" /> <img width="205" alt="Screenshot 2026-04-08 at 1 14 41 PM" src="https://github.com/user-attachments/assets/17bccabe-f4e1-42c5-be0e-08cb6d890cde" />

