### PR TITLE
Update `swift-tools-version` to 6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,3 @@
-// swift-tools-version: 6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 // Copyright 2021 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// swift-tools-version: 6.2
 
 import PackageDescription
 


### PR DESCRIPTION
The [Swift tools version](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/settingswifttoolsversion/) declares "the minimum version of the Swift compiler required to use the package." Since our declared minimum Xcode version is now 26.0, which shipped with tools version 6.2, increasing our declared tools version to 6.2 makes sense. Doing so will prevent the SDK and toolkit from being used as dependencies of packages that have a swift tools version lower than 6.2, but if we don't change it, we are saying that the package can be used as a dependency of a package built using Swift compiler 6.0 (Xcode 16–16.2) and 6.1 (Xcode 16.3–16.4), which we do not claim to support nor do we build/test with.

Note that starting with Swift 6.0, the tools version no longer needs to be on the first line of the package manifest, so I have moved it to below the preamble.