### PR TITLE
Improve `FloorFilter` on visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -242,6 +242,7 @@ private struct FloorFilterBody: View {
                 .frame(height: FloorFilterBody.buttonSize)
                 .font(.system(size: FloorFilterBody.fontSize))
                 .contentShape(FloorFilterBody.buttonShape)
+                .hoverEffect()
         }
         .accessibilityIdentifier("FloorFilter.siteSelectorButton")
         .buttonStyle(.plain)
@@ -289,6 +290,7 @@ private struct LevelSelector: View {
                     .font(.system(size: FloorFilterBody.fontSize))
                     .foregroundStyle(.secondary)
                     .contentShape(FloorFilterBody.buttonShape)
+                    .hoverEffect()
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier("FloorFilter.collapseButton")
@@ -395,6 +397,7 @@ private struct LevelButton: View {
                     }
                 }
                 .contentShape(FloorFilterBody.buttonShape)
+                .hoverEffect()
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("FloorFilter.levelButton.\(level.shortName)")

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -105,7 +105,9 @@ private struct SiteList: View {
                     placement: .navigationBarDrawer(displayMode: .always),
                     prompt: String.filterSites
                 )
+#if !os(visionOS)
                 .listStyle(.plain)
+#endif
             }
         }
         .navigationTitle(String.sites)
@@ -192,14 +194,18 @@ private struct FacilityList: View {
                             .contentShape(.rect)
                             .lineLimit(1)
                         }
+#if !os(visionOS)
                         .buttonStyle(.plain)
+#endif
                     }
                     .searchable(
                         text: $searchText,
                         placement: .navigationBarDrawer(displayMode: .always),
                         prompt: String.filterFacilities
                     )
+#if !os(visionOS)
                     .listStyle(.plain)
+#endif
                     .onChange(of: model.selection) {
                         guard let floorFacility = model.selection?.facility else {
                             return


### PR DESCRIPTION
`swift/8084`

It looks like some PRs went in that had some unintended changes on this component in visionOS so this PR fixes that and brings this component more in line with what is expected in visionOS.

Facility selector before:

https://github.com/user-attachments/assets/20248d46-c969-4bc2-9cfe-8c7f1d7f9bc5


Facility selector after:

https://github.com/user-attachments/assets/d5f09e7e-6b15-461c-9fd0-cd35518672e7

Level selector before:

https://github.com/user-attachments/assets/d3f64777-ed15-4597-b1d1-ee76ad74df02


Level selector after:

https://github.com/user-attachments/assets/75650958-b59b-423b-926a-523b66061e27