### PR TITLE
Fix hover effect for multi-line text input

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -96,24 +96,25 @@ private extension TextInput {
         HStack {
             Group {
                 if element.isMultiline {
-                    Text(text)
-                        .accessibilityIdentifier("\(element.label) Text Input Preview")
-                        .fixedSize(horizontal: false, vertical: true)
-                        .lineLimit(5)
-                        .truncationMode(.tail)
-                        .sheet(isPresented: $fullScreenTextInputIsPresented) {
-                            FullScreenTextInput(text: $text, element: element, embeddedFeatureFormViewModel: embeddedFeatureFormViewModel)
-                                .padding()
+                    Button {
+                        fullScreenTextInputIsPresented = true
+                    } label: {
+                        Text(text)
+                            .lineLimit(5)
+                            .truncationMode(.tail)
+                            .frame(maxWidth: .infinity, minHeight: 100, alignment: .topLeading)
+                    }
+                    .foregroundStyle(.primary)
+                    .accessibilityIdentifier("\(element.label) Text Input Preview")
+                    .fixedSize(horizontal: false, vertical: true)
+                    .sheet(isPresented: $fullScreenTextInputIsPresented) {
+                        FullScreenTextInput(text: $text, element: element, embeddedFeatureFormViewModel: embeddedFeatureFormViewModel)
+                            .padding()
 #if targetEnvironment(macCatalyst)
-                                .environment(embeddedFeatureFormViewModel)
-                                .environment(featureFormViewModel)
+                            .environment(embeddedFeatureFormViewModel)
+                            .environment(featureFormViewModel)
 #endif
-                        }
-                        .frame(maxWidth: .infinity, minHeight: 100, alignment: .topLeading)
-                        .contentShape(.rect)
-                        .onTapGesture {
-                            fullScreenTextInputIsPresented = true
-                        }
+                    }
                 } else {
                     TextField(
                         element.label,

--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -1040,7 +1040,7 @@ final class FeatureFormViewTests: XCTestCase {
         let groupElementTitle = "Group"
         let longTextFieldTitle = "Long text"
         let longTextReadOnlyInput = app.staticTexts["\(longTextFieldTitle) Read Only Input"]
-        let longTextTextInputPreview = app.staticTexts["\(longTextFieldTitle) Text Input Preview"]
+        let longTextTextInputPreview = app.buttons["\(longTextFieldTitle) Text Input Preview"]
         let radioButtonsElementTitle = "Radio buttons"
         let radioButtonsOption0 = app.buttons["0"]
         let radioButtonsReadOnlyInput = app.staticTexts["\(radioButtonsElementTitle) Read Only Input"]


### PR DESCRIPTION
`swift/8091`

I tried adding hover effects to the `Text` view to fix this but no solution would look as I would expect. This could be due to some default styling being done by `Form`. So by using a `Button` instead of `Text` we get default hover effects that look as expected.

Before there was no hover effects and now it looks like this:

https://github.com/user-attachments/assets/19f0d3e4-9f38-45b4-9846-2b251c0577d3



I checked the other platforms and they look good as well. But I recommend the reviewers test this locally.