### PR TITLE
Fix crash on iOS 18

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -184,7 +184,8 @@ public struct TableTopSceneView: View {
         // Disable coaching overlay when a plane is found.
         coachingOverlayIsActive = false
         
-        let anchorEntity = AnchorEntity(anchor: planeAnchor)
+        let anchorEntity = AnchorEntity()
+        anchorEntity.transform = Transform(matrix: planeAnchor.transform)
         
         let mesh = makeMesh(from: planeAnchor)
         let material = SimpleMaterial(


### PR DESCRIPTION
Closes https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/1441.

Removes use of an unavailable initializer for `AnchorEntity(anchor:)` to resolve the crash on iOS 18. Confirmed the crash was resolved on iOS 18 and 26 and tested that plane visualization still works as expected.