### PR TITLE
`Scalebar` - Nest public types

### DIFF
--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -104,7 +104,7 @@ public struct Scalebar: View {
     static let lineWidth: Double = 2.0
     
     /// Appearance settings.
-    let settings: Scalebar.Settings
+    let settings: Settings
     
     /// The render style for this `Scalebar`.
     private let style: Scalebar.Style

--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -107,7 +107,7 @@ public struct Scalebar: View {
     let settings: Settings
     
     /// The render style for this `Scalebar`.
-    private let style: Scalebar.Style
+    private let style: Style
     
     // - MARK: Public methods/vars
     

--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -104,10 +104,10 @@ public struct Scalebar: View {
     static let lineWidth: Double = 2.0
     
     /// Appearance settings.
-    let settings: ScalebarSettings
+    let settings: Scalebar.Settings
     
     /// The render style for this `Scalebar`.
-    private let style: ScalebarStyle
+    private let style: Scalebar.Style
     
     // - MARK: Public methods/vars
     
@@ -128,10 +128,10 @@ public struct Scalebar: View {
     public init(
         maxWidth: Double,
         minScale: Double = .zero,
-        settings: ScalebarSettings = ScalebarSettings(),
+        settings: Settings = Settings(),
         spatialReference: SpatialReference?,
-        style: ScalebarStyle = .alternatingBar,
-        units: ScalebarUnits = NSLocale.current.measurementSystem == .metric ? .metric : .imperial,
+        style: Style = .alternatingBar,
+        units: Units = NSLocale.current.measurementSystem == .metric ? .metric : .imperial,
         unitsPerPoint: Double?,
         useGeodeticCalculations: Bool = true,
         viewpoint: Viewpoint?

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
@@ -19,31 +19,22 @@ extension Scalebar {
     public struct Settings: Sendable {
         /// Determines if the scalebar should automatically hide/show itself.
         var autoHide: Bool
-        
         /// The time to wait in seconds before the scalebar hides itself.
         var autoHideDelay: TimeInterval
-        
         /// The corner radius used by bar style scalebar renders.
         var barCornerRadius: Double
-        
         /// The darker fill color used by the alternating bar style render.
         var fillColor1: Color
-        
         /// The lighter fill color used by the bar style renders.
         var fillColor2: Color
-        
         /// The color of the prominent scalebar line.
         var lineColor: Color
-        
         /// The shadow color used by all scalebar style renders.
         var shadowColor: Color
-        
         /// The shadow radius used by all scalebar style renders.
         var shadowRadius: Double
-        
         /// The text color used by all scalebar style renders.
         var textColor: Color
-        
         /// The text shadow color used by all scalebar style renders.
         var textShadowColor: Color
         

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
@@ -14,80 +14,85 @@
 
 import SwiftUI
 
-/// Customizes scalebar appearance and behavior.
-public struct ScalebarSettings: Sendable {
-    /// Determines if the scalebar should automatically hide/show itself.
-    var autoHide: Bool
-    
-    /// The time to wait in seconds before the scalebar hides itself.
-    var autoHideDelay: TimeInterval
-    
-    /// The corner radius used by bar style scalebar renders.
-    var barCornerRadius: Double
-    
-    /// The darker fill color used by the alternating bar style render.
-    var fillColor1: Color
-    
-    /// The lighter fill color used by the bar style renders.
-    var fillColor2: Color
-    
-    /// The color of the prominent scalebar line.
-    var lineColor: Color
-    
-    /// The shadow color used by all scalebar style renders.
-    var shadowColor: Color
-    
-    /// The shadow radius used by all scalebar style renders.
-    var shadowRadius: Double
-    
-    /// The text color used by all scalebar style renders.
-    var textColor: Color
-    
-    /// The text shadow color used by all scalebar style renders.
-    var textShadowColor: Color
-    
-    /// - Parameters:
-    ///   - autoHide: Determines if the scalebar should automatically hide/show itself.
-    ///   - autoHideDelay: The time to wait in seconds before the scalebar hides itself.
-    ///   - barCornerRadius: The corner radius used by bar style scalebar renders.
-    ///   - fillColor1: The darker fill color used by the alternating bar style render.
-    ///   - fillColor2: The lighter fill color used by the bar style renders.
-    ///   - lineColor: The color of the prominent scalebar line.
-    ///   - shadowColor: The shadow color used by all scalebar style renders.
-    ///   - shadowRadius: The shadow radius used by all scalebar style renders.
-    ///   - textColor: The text color used by all scalebar style renders.
-    ///   - textShadowColor: The text shadow color used by all scalebar style renders.
-    public init(
-        autoHide: Bool = false,
-        autoHideDelay: TimeInterval = 1.75,
-        barCornerRadius: Double = 2.5,
-        fillColor1: Color = .black,
-        fillColor2: Color = Color(uiColor: .lightGray).opacity(0.5),
-        lineColor: Color = .white,
-        shadowColor: Color = Color(uiColor: .black).opacity(0.65),
-        shadowRadius: Double = 1.0,
-        textColor: Color = .primary,
-        textShadowColor: Color = .white
-    ) {
-        self.autoHide = autoHide
-        self.autoHideDelay = autoHideDelay
-        self.barCornerRadius = barCornerRadius
-        self.fillColor1 = fillColor1
-        self.fillColor2 = fillColor2
-        self.lineColor = lineColor
-        self.shadowColor = shadowColor
-        self.shadowRadius = shadowRadius
-        self.textColor = textColor
-        self.textShadowColor = textShadowColor
+extension Scalebar {
+    /// Customizes scalebar appearance and behavior.
+    public struct Settings: Sendable {
+        /// Determines if the scalebar should automatically hide/show itself.
+        var autoHide: Bool
+        
+        /// The time to wait in seconds before the scalebar hides itself.
+        var autoHideDelay: TimeInterval
+        
+        /// The corner radius used by bar style scalebar renders.
+        var barCornerRadius: Double
+        
+        /// The darker fill color used by the alternating bar style render.
+        var fillColor1: Color
+        
+        /// The lighter fill color used by the bar style renders.
+        var fillColor2: Color
+        
+        /// The color of the prominent scalebar line.
+        var lineColor: Color
+        
+        /// The shadow color used by all scalebar style renders.
+        var shadowColor: Color
+        
+        /// The shadow radius used by all scalebar style renders.
+        var shadowRadius: Double
+        
+        /// The text color used by all scalebar style renders.
+        var textColor: Color
+        
+        /// The text shadow color used by all scalebar style renders.
+        var textShadowColor: Color
+        
+        /// - Parameters:
+        ///   - autoHide: Determines if the scalebar should automatically hide/show itself.
+        ///   - autoHideDelay: The time to wait in seconds before the scalebar hides itself.
+        ///   - barCornerRadius: The corner radius used by bar style scalebar renders.
+        ///   - fillColor1: The darker fill color used by the alternating bar style render.
+        ///   - fillColor2: The lighter fill color used by the bar style renders.
+        ///   - lineColor: The color of the prominent scalebar line.
+        ///   - shadowColor: The shadow color used by all scalebar style renders.
+        ///   - shadowRadius: The shadow radius used by all scalebar style renders.
+        ///   - textColor: The text color used by all scalebar style renders.
+        ///   - textShadowColor: The text shadow color used by all scalebar style renders.
+        public init(
+            autoHide: Bool = false,
+            autoHideDelay: TimeInterval = 1.75,
+            barCornerRadius: Double = 2.5,
+            fillColor1: Color = .black,
+            fillColor2: Color = Color(uiColor: .lightGray).opacity(0.5),
+            lineColor: Color = .white,
+            shadowColor: Color = Color(uiColor: .black).opacity(0.65),
+            shadowRadius: Double = 1.0,
+            textColor: Color = .primary,
+            textShadowColor: Color = .white
+        ) {
+            self.autoHide = autoHide
+            self.autoHideDelay = autoHideDelay
+            self.barCornerRadius = barCornerRadius
+            self.fillColor1 = fillColor1
+            self.fillColor2 = fillColor2
+            self.lineColor = lineColor
+            self.shadowColor = shadowColor
+            self.shadowRadius = shadowRadius
+            self.textColor = textColor
+            self.textShadowColor = textShadowColor
+        }
     }
 }
 
+@available(*, deprecated, renamed: "Scalebar.Settings")
+public typealias ScalebarSettings = Scalebar.Settings
+
 struct ScalebarSettingsKey: EnvironmentKey {
-  static let defaultValue = ScalebarSettings()
+    static let defaultValue = Scalebar.Settings()
 }
 
 extension EnvironmentValues {
-    var scalebarSettings: ScalebarSettings {
+    var scalebarSettings: Scalebar.Settings {
         get { self[ScalebarSettingsKey.self] }
         set { self[ScalebarSettingsKey.self] = newValue }
     }

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
@@ -17,16 +17,12 @@ extension Scalebar {
     public enum Style: Sendable {
         /// Displays a single unit with segmented bars of alternating fill color.
         case alternatingBar
-        
         /// Displays a single unit.
         case bar
-        
         /// Displays both metric and imperial units. The primary unit is displayed on top.
         case dualUnitLine
-        
         /// Displays a single unit with tick marks.
         case graduatedLine
-        
         /// Displays a single unit with endpoint tick marks.
         case line
     }

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarStyle.swift
@@ -12,20 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Visual scalebar styles.
-public enum ScalebarStyle: Sendable {
-    /// Displays a single unit with segmented bars of alternating fill color.
-    case alternatingBar
-    
-    /// Displays a single unit.
-    case bar
-    
-    /// Displays both metric and imperial units. The primary unit is displayed on top.
-    case dualUnitLine
-    
-    /// Displays a single unit with tick marks.
-    case graduatedLine
-    
-    /// Displays a single unit with endpoint tick marks.
-    case line
+extension Scalebar {
+    /// Visual scalebar styles.
+    public enum Style: Sendable {
+        /// Displays a single unit with segmented bars of alternating fill color.
+        case alternatingBar
+        
+        /// Displays a single unit.
+        case bar
+        
+        /// Displays both metric and imperial units. The primary unit is displayed on top.
+        case dualUnitLine
+        
+        /// Displays a single unit with tick marks.
+        case graduatedLine
+        
+        /// Displays a single unit with endpoint tick marks.
+        case line
+    }
 }
+
+@available(*, deprecated, renamed: "Scalebar.Style")
+public typealias ScalebarStyle = Scalebar.Style

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
@@ -64,43 +64,25 @@ extension Scalebar {
         /// - Parameter multiplier: A distance to compute the multiplier for.
         /// - Returns: A list of segment options for a given multiplier.
         private static func segmentOptions(forMultiplier multiplier: Double) -> [Int] {
-            switch multiplier {
-            case 1:
-                return [1, 2, 4, 5]
-            case 1.2:
-                return [1, 2, 3, 4]
-            case 1.25:
-                return [1, 2]
-            case 1.5:
-                return [1, 2, 3, 5]
-            case 1.75:
-                return [1, 2]
-            case 2:
-                return [1, 2, 4, 5]
-            case 2.4:
-                return [1, 2, 3]
-            case 2.5:
-                return [1, 2, 5]
-            case 3:
-                return [1, 2, 3]
-            case 3.75:
-                return [1, 3]
-            case 4:
-                return [1, 2, 4]
-            case 5:
-                return [1, 2, 5]
-            case 6:
-                return [1, 2, 3]
-            case 7.5:
-                return [1, 2]
-            case 8:
-                return [1, 2, 4]
-            case 9:
-                return [1, 2, 3]
-            case 10:
-                return [1, 2, 5]
-            default:
-                return [1]
+            return switch multiplier {
+            case 1:     [1, 2, 4, 5]
+            case 1.2:   [1, 2, 3, 4]
+            case 1.25:  [1, 2]
+            case 1.5:   [1, 2, 3, 5]
+            case 1.75:  [1, 2]
+            case 2:     [1, 2, 4, 5]
+            case 2.4:   [1, 2, 3]
+            case 2.5:   [1, 2, 5]
+            case 3:     [1, 2, 3]
+            case 3.75:  [1, 3]
+            case 4:     [1, 2, 4]
+            case 5:     [1, 2, 5]
+            case 6:     [1, 2, 3]
+            case 7.5:   [1, 2]
+            case 8:     [1, 2, 4]
+            case 9:     [1, 2, 3]
+            case 10:    [1, 2, 5]
+            default:    [1]
             }
         }
         

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
@@ -15,152 +15,157 @@
 import ArcGIS
 import Foundation
 
-public enum ScalebarUnits: Sendable {
-    /// Imperial units (feet, miles, etc)
-    case imperial
-    
-    /// Metric units (meters, etc)
-    case metric
-    
-    /// Multiplier options.
-    /// This table must begin with 1 and end with 10.
-    private static let roundNumberMultipliers: [Double] =
-        [1, 1.2, 1.25, 1.5, 1.75, 2, 2.4, 2.5, 3, 3.75, 4, 5, 6, 7.5, 8, 9, 10]
-    
-    /// Determines an appropriate base linear unit for this scalebar unit.
-    /// - Returns: `LinearUnit.feet` or `LinearUnit.meters` depending on this unit.
-    ///
-    /// `ScalebarUnits.imperial` will return `LinearUnit.feet` as feet is the smallest linear
-    /// unit that will be displayed.
-    /// `ScalebarUnits.metric` will return `LinearUnit.meters` as meter is the smallest linear
-    /// unit that will be displayed.
-    var baseLinearUnit: LinearUnit {
-        return self == .imperial ? LinearUnit.feet : LinearUnit.meters
-    }
-    
-    /// Calculates a magnitude for a given distance.
-    /// - Parameter distance: A distance to compute the magnitude for.
-    /// - Returns: A magnitude for a given distance.
-    ///
-    /// For example:
-    /// A distance of 25 will return 10 as 10 is the highest power of 10 that will fit into 25.
-    /// A distance of 550 will return 100 as 100 is the highest power of 10 that will fit into 550.
-    /// A distance of 2,222 will return 1000 as 1000 is the highest power of 10 that will fit into 2,222.
-    private static func magnitude(forDistance distance: Double) -> Double {
-        return pow(10, floor(log10(distance)))
-    }
-    
-    /// Returns a multiplier for a given distance.
-    /// - Parameter distance: A distance to compute the multiplier for.
-    /// - Returns: A multiplier for a given distance.
-    private static func multiplier(forDistance distance: Double) -> Double {
-        let residual = distance / ScalebarUnits.magnitude(forDistance: distance)
-        let multiplier = ScalebarUnits.roundNumberMultipliers.filter { $0 <= residual }.last ?? 0
-        return multiplier
-    }
-    
-    /// Returns a list of segment options for a given multiplier.
-    /// - Parameter multiplier: A distance to compute the multiplier for.
-    /// - Returns: A list of segment options for a given multiplier.
-    private static func segmentOptions(forMultiplier multiplier: Double) -> [Int] {
-        switch multiplier {
-        case 1:
-            return [1, 2, 4, 5]
-        case 1.2:
-            return [1, 2, 3, 4]
-        case 1.25:
-            return [1, 2]
-        case 1.5:
-            return [1, 2, 3, 5]
-        case 1.75:
-            return [1, 2]
-        case 2:
-            return [1, 2, 4, 5]
-        case 2.4:
-            return [1, 2, 3]
-        case 2.5:
-            return [1, 2, 5]
-        case 3:
-            return [1, 2, 3]
-        case 3.75:
-            return [1, 3]
-        case 4:
-            return [1, 2, 4]
-        case 5:
-            return [1, 2, 5]
-        case 6:
-            return [1, 2, 3]
-        case 7.5:
-            return [1, 2]
-        case 8:
-            return [1, 2, 4]
-        case 9:
-            return [1, 2, 3]
-        case 10:
-            return [1, 2, 5]
-        default:
-            return [1]
-        }
-    }
-    
-    /// - Returns: The best number of segments so that we get relatively round numbers when the
-    /// distance is divided up.
-    static func numSegments(
-        forDistance distance: Double,
-        maxNumSegments: Int
-    ) -> Int {
-        let multiplier = multiplier(forDistance: distance)
-        let options = segmentOptions(forMultiplier: multiplier)
-        let num = options.filter { $0 <= maxNumSegments }.last ?? 1
-        return num
-    }
-    
-    /// Calculates a round number suitable for display.
-    /// - Returns: A displayable round number.
-    func closestDistanceWithoutGoingOver(
-        to distance: Double,
-        units: LinearUnit
-    ) -> Double {
-        let magnitude = ScalebarUnits.magnitude(forDistance: distance)
-        let multiplier = ScalebarUnits.multiplier(forDistance: distance)
-        let roundNumber = multiplier * magnitude
+extension Scalebar {
+    public enum Units: Sendable {
+        /// Imperial units (feet, miles, etc)
+        case imperial
         
-        // Because feet and miles are not relationally multiples of 10 with
-        // each other, we have to convert to miles if we are dealing in feet.
-        if units == .feet {
-            let displayUnits = linearUnits(forDistance: roundNumber)
-            if units != displayUnits {
-                let displayDistance = closestDistanceWithoutGoingOver(
-                    to: units.convert(
-                        to: displayUnits,
-                        value: distance
-                    ),
-                    units: displayUnits
-                )
-                return displayUnits.convert(
-                    to: units,
-                    value: displayDistance
-                )
+        /// Metric units (meters, etc)
+        case metric
+        
+        /// Multiplier options.
+        /// This table must begin with 1 and end with 10.
+        private static let roundNumberMultipliers: [Double] =
+            [1, 1.2, 1.25, 1.5, 1.75, 2, 2.4, 2.5, 3, 3.75, 4, 5, 6, 7.5, 8, 9, 10]
+        
+        /// Determines an appropriate base linear unit for this scalebar unit.
+        /// - Returns: `LinearUnit.feet` or `LinearUnit.meters` depending on this unit.
+        ///
+        /// `ScalebarUnits.imperial` will return `LinearUnit.feet` as feet is the smallest linear
+        /// unit that will be displayed.
+        /// `ScalebarUnits.metric` will return `LinearUnit.meters` as meter is the smallest linear
+        /// unit that will be displayed.
+        var baseLinearUnit: LinearUnit {
+            return self == .imperial ? LinearUnit.feet : LinearUnit.meters
+        }
+        
+        /// Calculates a magnitude for a given distance.
+        /// - Parameter distance: A distance to compute the magnitude for.
+        /// - Returns: A magnitude for a given distance.
+        ///
+        /// For example:
+        /// A distance of 25 will return 10 as 10 is the highest power of 10 that will fit into 25.
+        /// A distance of 550 will return 100 as 100 is the highest power of 10 that will fit into 550.
+        /// A distance of 2,222 will return 1000 as 1000 is the highest power of 10 that will fit into 2,222.
+        private static func magnitude(forDistance distance: Double) -> Double {
+            return pow(10, floor(log10(distance)))
+        }
+        
+        /// Returns a multiplier for a given distance.
+        /// - Parameter distance: A distance to compute the multiplier for.
+        /// - Returns: A multiplier for a given distance.
+        private static func multiplier(forDistance distance: Double) -> Double {
+            let residual = distance / Units.magnitude(forDistance: distance)
+            let multiplier = Units.roundNumberMultipliers.filter { $0 <= residual }.last ?? 0
+            return multiplier
+        }
+        
+        /// Returns a list of segment options for a given multiplier.
+        /// - Parameter multiplier: A distance to compute the multiplier for.
+        /// - Returns: A list of segment options for a given multiplier.
+        private static func segmentOptions(forMultiplier multiplier: Double) -> [Int] {
+            switch multiplier {
+            case 1:
+                return [1, 2, 4, 5]
+            case 1.2:
+                return [1, 2, 3, 4]
+            case 1.25:
+                return [1, 2]
+            case 1.5:
+                return [1, 2, 3, 5]
+            case 1.75:
+                return [1, 2]
+            case 2:
+                return [1, 2, 4, 5]
+            case 2.4:
+                return [1, 2, 3]
+            case 2.5:
+                return [1, 2, 5]
+            case 3:
+                return [1, 2, 3]
+            case 3.75:
+                return [1, 3]
+            case 4:
+                return [1, 2, 4]
+            case 5:
+                return [1, 2, 5]
+            case 6:
+                return [1, 2, 3]
+            case 7.5:
+                return [1, 2]
+            case 8:
+                return [1, 2, 4]
+            case 9:
+                return [1, 2, 3]
+            case 10:
+                return [1, 2, 5]
+            default:
+                return [1]
             }
         }
         
-        return roundNumber
-    }
-    
-    /// Determines a suitable display unit for the given distance.
-    /// - Parameter distance: The distance to be displayed.
-    /// - Returns: A suitable linear unit.
-    ///
-    /// `ScalebarUnits.imperial` will return `LinearUnit.miles` if the given distance is greater
-    /// than or equal to 1/2 mile, and `LinearUnit.feet` otherwise.
-    /// `ScalebarUnits.metric` will return `LinearUnit.kilometers` if the given distance is
-    /// greater than or equal to 1 kilometer, and `LinearUnit.meters` otherwise.
-    func linearUnits(forDistance distance: Double) -> LinearUnit {
-        switch self {
-        case .imperial:
-            return distance >= 2640 ? .miles : .feet
-        case .metric:
-            return distance >= 1000 ? .kilometers : .meters
+        /// - Returns: The best number of segments so that we get relatively round numbers when the
+        /// distance is divided up.
+        static func numSegments(
+            forDistance distance: Double,
+            maxNumSegments: Int
+        ) -> Int {
+            let multiplier = multiplier(forDistance: distance)
+            let options = segmentOptions(forMultiplier: multiplier)
+            let num = options.filter { $0 <= maxNumSegments }.last ?? 1
+            return num
+        }
+        
+        /// Calculates a round number suitable for display.
+        /// - Returns: A displayable round number.
+        func closestDistanceWithoutGoingOver(
+            to distance: Double,
+            units: LinearUnit
+        ) -> Double {
+            let magnitude = Units.magnitude(forDistance: distance)
+            let multiplier = Units.multiplier(forDistance: distance)
+            let roundNumber = multiplier * magnitude
+            
+            // Because feet and miles are not relationally multiples of 10 with
+            // each other, we have to convert to miles if we are dealing in feet.
+            if units == .feet {
+                let displayUnits = linearUnits(forDistance: roundNumber)
+                if units != displayUnits {
+                    let displayDistance = closestDistanceWithoutGoingOver(
+                        to: units.convert(
+                            to: displayUnits,
+                            value: distance
+                        ),
+                        units: displayUnits
+                    )
+                    return displayUnits.convert(
+                        to: units,
+                        value: displayDistance
+                    )
+                }
+            }
+            
+            return roundNumber
+        }
+        
+        /// Determines a suitable display unit for the given distance.
+        /// - Parameter distance: The distance to be displayed.
+        /// - Returns: A suitable linear unit.
+        ///
+        /// `ScalebarUnits.imperial` will return `LinearUnit.miles` if the given distance is greater
+        /// than or equal to 1/2 mile, and `LinearUnit.feet` otherwise.
+        /// `ScalebarUnits.metric` will return `LinearUnit.kilometers` if the given distance is
+        /// greater than or equal to 1 kilometer, and `LinearUnit.meters` otherwise.
+        func linearUnits(forDistance distance: Double) -> LinearUnit {
+            switch self {
+            case .imperial:
+                return distance >= 2640 ? .miles : .feet
+            case .metric:
+                return distance >= 1000 ? .kilometers : .meters
+            }
         }
     }
 }
+
+@available(*, deprecated, renamed: "Scalebar.Units")
+public typealias ScalebarUnits = Scalebar.Units

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
@@ -28,7 +28,7 @@ private extension Scalebar.Units {
     /// Multiplier options.
     /// This table must begin with 1 and end with 10.
     private static let roundNumberMultipliers: [Double] =
-    [1, 1.2, 1.25, 1.5, 1.75, 2, 2.4, 2.5, 3, 3.75, 4, 5, 6, 7.5, 8, 9, 10]
+        [1, 1.2, 1.25, 1.5, 1.75, 2, 2.4, 2.5, 3, 3.75, 4, 5, 6, 7.5, 8, 9, 10]
     
     /// Determines an appropriate base linear unit for this scalebar unit.
     /// - Returns: `LinearUnit.feet` or `LinearUnit.meters` depending on this unit.

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarUnits.swift
@@ -19,132 +19,133 @@ extension Scalebar {
     public enum Units: Sendable {
         /// Imperial units (feet, miles, etc)
         case imperial
-        
         /// Metric units (meters, etc)
         case metric
-        
-        /// Multiplier options.
-        /// This table must begin with 1 and end with 10.
-        private static let roundNumberMultipliers: [Double] =
-            [1, 1.2, 1.25, 1.5, 1.75, 2, 2.4, 2.5, 3, 3.75, 4, 5, 6, 7.5, 8, 9, 10]
-        
-        /// Determines an appropriate base linear unit for this scalebar unit.
-        /// - Returns: `LinearUnit.feet` or `LinearUnit.meters` depending on this unit.
-        ///
-        /// `ScalebarUnits.imperial` will return `LinearUnit.feet` as feet is the smallest linear
-        /// unit that will be displayed.
-        /// `ScalebarUnits.metric` will return `LinearUnit.meters` as meter is the smallest linear
-        /// unit that will be displayed.
-        var baseLinearUnit: LinearUnit {
-            return self == .imperial ? LinearUnit.feet : LinearUnit.meters
+    }
+}
+
+private extension Scalebar.Units {
+    /// Multiplier options.
+    /// This table must begin with 1 and end with 10.
+    private static let roundNumberMultipliers: [Double] =
+    [1, 1.2, 1.25, 1.5, 1.75, 2, 2.4, 2.5, 3, 3.75, 4, 5, 6, 7.5, 8, 9, 10]
+    
+    /// Determines an appropriate base linear unit for this scalebar unit.
+    /// - Returns: `LinearUnit.feet` or `LinearUnit.meters` depending on this unit.
+    ///
+    /// `ScalebarUnits.imperial` will return `LinearUnit.feet` as feet is the smallest linear
+    /// unit that will be displayed.
+    /// `ScalebarUnits.metric` will return `LinearUnit.meters` as meter is the smallest linear
+    /// unit that will be displayed.
+    var baseLinearUnit: LinearUnit {
+        return self == .imperial ? LinearUnit.feet : LinearUnit.meters
+    }
+    
+    /// Calculates a magnitude for a given distance.
+    /// - Parameter distance: A distance to compute the magnitude for.
+    /// - Returns: A magnitude for a given distance.
+    ///
+    /// For example:
+    /// A distance of 25 will return 10 as 10 is the highest power of 10 that will fit into 25.
+    /// A distance of 550 will return 100 as 100 is the highest power of 10 that will fit into 550.
+    /// A distance of 2,222 will return 1000 as 1000 is the highest power of 10 that will fit into 2,222.
+    private static func magnitude(forDistance distance: Double) -> Double {
+        return pow(10, floor(log10(distance)))
+    }
+    
+    /// Returns a multiplier for a given distance.
+    /// - Parameter distance: A distance to compute the multiplier for.
+    /// - Returns: A multiplier for a given distance.
+    private static func multiplier(forDistance distance: Double) -> Double {
+        let residual = distance / magnitude(forDistance: distance)
+        let multiplier = roundNumberMultipliers.filter { $0 <= residual }.last ?? 0
+        return multiplier
+    }
+    
+    /// Returns a list of segment options for a given multiplier.
+    /// - Parameter multiplier: A distance to compute the multiplier for.
+    /// - Returns: A list of segment options for a given multiplier.
+    private static func segmentOptions(forMultiplier multiplier: Double) -> [Int] {
+        return switch multiplier {
+        case 1:     [1, 2, 4, 5]
+        case 1.2:   [1, 2, 3, 4]
+        case 1.25:  [1, 2]
+        case 1.5:   [1, 2, 3, 5]
+        case 1.75:  [1, 2]
+        case 2:     [1, 2, 4, 5]
+        case 2.4:   [1, 2, 3]
+        case 2.5:   [1, 2, 5]
+        case 3:     [1, 2, 3]
+        case 3.75:  [1, 3]
+        case 4:     [1, 2, 4]
+        case 5:     [1, 2, 5]
+        case 6:     [1, 2, 3]
+        case 7.5:   [1, 2]
+        case 8:     [1, 2, 4]
+        case 9:     [1, 2, 3]
+        case 10:    [1, 2, 5]
+        default:    [1]
         }
+    }
+    
+    /// - Returns: The best number of segments so that we get relatively round numbers when the
+    /// distance is divided up.
+    static func numSegments(
+        forDistance distance: Double,
+        maxNumSegments: Int
+    ) -> Int {
+        let multiplier = multiplier(forDistance: distance)
+        let options = segmentOptions(forMultiplier: multiplier)
+        let num = options.filter { $0 <= maxNumSegments }.last ?? 1
+        return num
+    }
+    
+    /// Calculates a round number suitable for display.
+    /// - Returns: A displayable round number.
+    func closestDistanceWithoutGoingOver(
+        to distance: Double,
+        units: LinearUnit
+    ) -> Double {
+        let magnitude = Scalebar.Units.magnitude(forDistance: distance)
+        let multiplier = Scalebar.Units.multiplier(forDistance: distance)
+        let roundNumber = multiplier * magnitude
         
-        /// Calculates a magnitude for a given distance.
-        /// - Parameter distance: A distance to compute the magnitude for.
-        /// - Returns: A magnitude for a given distance.
-        ///
-        /// For example:
-        /// A distance of 25 will return 10 as 10 is the highest power of 10 that will fit into 25.
-        /// A distance of 550 will return 100 as 100 is the highest power of 10 that will fit into 550.
-        /// A distance of 2,222 will return 1000 as 1000 is the highest power of 10 that will fit into 2,222.
-        private static func magnitude(forDistance distance: Double) -> Double {
-            return pow(10, floor(log10(distance)))
-        }
-        
-        /// Returns a multiplier for a given distance.
-        /// - Parameter distance: A distance to compute the multiplier for.
-        /// - Returns: A multiplier for a given distance.
-        private static func multiplier(forDistance distance: Double) -> Double {
-            let residual = distance / Units.magnitude(forDistance: distance)
-            let multiplier = Units.roundNumberMultipliers.filter { $0 <= residual }.last ?? 0
-            return multiplier
-        }
-        
-        /// Returns a list of segment options for a given multiplier.
-        /// - Parameter multiplier: A distance to compute the multiplier for.
-        /// - Returns: A list of segment options for a given multiplier.
-        private static func segmentOptions(forMultiplier multiplier: Double) -> [Int] {
-            return switch multiplier {
-            case 1:     [1, 2, 4, 5]
-            case 1.2:   [1, 2, 3, 4]
-            case 1.25:  [1, 2]
-            case 1.5:   [1, 2, 3, 5]
-            case 1.75:  [1, 2]
-            case 2:     [1, 2, 4, 5]
-            case 2.4:   [1, 2, 3]
-            case 2.5:   [1, 2, 5]
-            case 3:     [1, 2, 3]
-            case 3.75:  [1, 3]
-            case 4:     [1, 2, 4]
-            case 5:     [1, 2, 5]
-            case 6:     [1, 2, 3]
-            case 7.5:   [1, 2]
-            case 8:     [1, 2, 4]
-            case 9:     [1, 2, 3]
-            case 10:    [1, 2, 5]
-            default:    [1]
+        // Because feet and miles are not relationally multiples of 10 with
+        // each other, we have to convert to miles if we are dealing in feet.
+        if units == .feet {
+            let displayUnits = linearUnits(forDistance: roundNumber)
+            if units != displayUnits {
+                let displayDistance = closestDistanceWithoutGoingOver(
+                    to: units.convert(
+                        to: displayUnits,
+                        value: distance
+                    ),
+                    units: displayUnits
+                )
+                return displayUnits.convert(
+                    to: units,
+                    value: displayDistance
+                )
             }
         }
         
-        /// - Returns: The best number of segments so that we get relatively round numbers when the
-        /// distance is divided up.
-        static func numSegments(
-            forDistance distance: Double,
-            maxNumSegments: Int
-        ) -> Int {
-            let multiplier = multiplier(forDistance: distance)
-            let options = segmentOptions(forMultiplier: multiplier)
-            let num = options.filter { $0 <= maxNumSegments }.last ?? 1
-            return num
-        }
-        
-        /// Calculates a round number suitable for display.
-        /// - Returns: A displayable round number.
-        func closestDistanceWithoutGoingOver(
-            to distance: Double,
-            units: LinearUnit
-        ) -> Double {
-            let magnitude = Units.magnitude(forDistance: distance)
-            let multiplier = Units.multiplier(forDistance: distance)
-            let roundNumber = multiplier * magnitude
-            
-            // Because feet and miles are not relationally multiples of 10 with
-            // each other, we have to convert to miles if we are dealing in feet.
-            if units == .feet {
-                let displayUnits = linearUnits(forDistance: roundNumber)
-                if units != displayUnits {
-                    let displayDistance = closestDistanceWithoutGoingOver(
-                        to: units.convert(
-                            to: displayUnits,
-                            value: distance
-                        ),
-                        units: displayUnits
-                    )
-                    return displayUnits.convert(
-                        to: units,
-                        value: displayDistance
-                    )
-                }
-            }
-            
-            return roundNumber
-        }
-        
-        /// Determines a suitable display unit for the given distance.
-        /// - Parameter distance: The distance to be displayed.
-        /// - Returns: A suitable linear unit.
-        ///
-        /// `ScalebarUnits.imperial` will return `LinearUnit.miles` if the given distance is greater
-        /// than or equal to 1/2 mile, and `LinearUnit.feet` otherwise.
-        /// `ScalebarUnits.metric` will return `LinearUnit.kilometers` if the given distance is
-        /// greater than or equal to 1 kilometer, and `LinearUnit.meters` otherwise.
-        func linearUnits(forDistance distance: Double) -> LinearUnit {
-            switch self {
-            case .imperial:
-                return distance >= 2640 ? .miles : .feet
-            case .metric:
-                return distance >= 1000 ? .kilometers : .meters
-            }
+        return roundNumber
+    }
+    
+    /// Determines a suitable display unit for the given distance.
+    /// - Parameter distance: The distance to be displayed.
+    /// - Returns: A suitable linear unit.
+    ///
+    /// `ScalebarUnits.imperial` will return `LinearUnit.miles` if the given distance is greater
+    /// than or equal to 1/2 mile, and `LinearUnit.feet` otherwise.
+    /// `ScalebarUnits.metric` will return `LinearUnit.kilometers` if the given distance is
+    /// greater than or equal to 1 kilometer, and `LinearUnit.meters` otherwise.
+    func linearUnits(forDistance distance: Double) -> LinearUnit {
+        switch self {
+        case .imperial:
+            return distance >= 2640 ? .miles : .feet
+        case .metric:
+            return distance >= 1000 ? .kilometers : .meters
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarViewModel.swift
@@ -33,7 +33,7 @@ final class ScalebarViewModel: ObservableObject {
         guard let displayUnit = displayUnit else {
             return (.zero, "")
         }
-        let altUnit: ScalebarUnits = units == .imperial ? .metric : .imperial
+        let altUnit: Scalebar.Units = units == .imperial ? .metric : .imperial
         let altMapBaseLength = displayUnit.convert(
             to: altUnit.baseLinearUnit,
             value: lineMapLength
@@ -74,8 +74,8 @@ final class ScalebarViewModel: ObservableObject {
     init(
         _ maxWidth: Double,
         _ minScale: Double,
-        _ style: ScalebarStyle,
-        _ units: ScalebarUnits,
+        _ style: Scalebar.Style,
+        _ units: Scalebar.Units,
         _ useGeodeticCalculations: Bool
     ) {
         self.maxWidth = maxWidth
@@ -94,7 +94,7 @@ final class ScalebarViewModel: ObservableObject {
     private let minScale: Double
     
     /// The visual appearance of the scalebar.
-    private let style: ScalebarStyle
+    private let style: Scalebar.Style
     
     // - MARK: Private variables
     
@@ -130,7 +130,7 @@ final class ScalebarViewModel: ObservableObject {
     private var spatialReference: SpatialReference?
     
     /// Unit of measure in use.
-    private var units: ScalebarUnits
+    private var units: Scalebar.Units
     
     /// The units per point to calculate the scale with.
     private var unitsPerPoint: Double?
@@ -168,7 +168,7 @@ final class ScalebarViewModel: ObservableObject {
         // Cap segments at 4
         let maxNumSegments = min(suggestedNumSegments, 4)
         
-        let numSegments: Int = ScalebarUnits.numSegments(
+        let numSegments: Int = Scalebar.Units.numSegments(
             forDistance: lineMapLength,
             maxNumSegments: maxNumSegments
         )

--- a/Tests/ArcGISToolkitTests/ScalebarTests.swift
+++ b/Tests/ArcGISToolkitTests/ScalebarTests.swift
@@ -23,9 +23,9 @@ class ScalebarTests: XCTestCase {
         let x: Double
         let y: Double
         let spatialReference: SpatialReference = .webMercator
-        let style: ScalebarStyle
+        let style: Scalebar.Style
         let maxWidth: Double
-        let units: ScalebarUnits
+        let units: Scalebar.Units
         let scale: Double
         let unitsPerPoint: Double
         var useGeodeticCalculations: Bool = true


### PR DESCRIPTION
Closes #685 

- Nests `ScalebarSettings`, `ScalebarStyle` and `ScalebarUnits` under `Scalebar` as `Settings`,  `Style` and `Units`.
- Adds deprecated `typealias`s for `ScalebarSettings`, `ScalebarStyle` and `ScalebarUnits`.