### PR TITLE
`GeometryEditorToolbar` - Add example

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		88519D3F2C8A7967007D7015 /* LocationButtonExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88519D3E2C8A7967007D7015 /* LocationButtonExampleView.swift */; };
 		8A9419622E035F1D003C7D10 /* AppSecrets.swift.masque in Sources */ = {isa = PBXBuildFile; fileRef = 8A9419612E035F1D003C7D10 /* AppSecrets.swift.masque */; };
 		8AC666152DA865EE00F33C36 /* Examples+ListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC666142DA865DD00F33C36 /* Examples+ListItem.swift */; };
+		D72A3EDC2FB69B18005C6D1B /* GeometryEditorToolbarExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72A3EDB2FB69B18005C6D1B /* GeometryEditorToolbarExampleView.swift */; };
 		E42BFBE92672BF9500159107 /* SearchExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42BFBE82672BF9500159107 /* SearchExampleView.swift */; };
 		E4624A25278CE815000D2A38 /* FloorFilterExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4624A24278CE815000D2A38 /* FloorFilterExampleView.swift */; };
 		E47ABE442652FE0900FD2FE3 /* ExamplesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47ABE432652FE0900FD2FE3 /* ExamplesApp.swift */; };
@@ -79,6 +80,7 @@
 		88519D3E2C8A7967007D7015 /* LocationButtonExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationButtonExampleView.swift; sourceTree = "<group>"; };
 		8A9419612E035F1D003C7D10 /* AppSecrets.swift.masque */ = {isa = PBXFileReference; lastKnownFileType = text; name = AppSecrets.swift.masque; path = ../AppSecrets.swift.masque; sourceTree = "<group>"; };
 		8AC666142DA865DD00F33C36 /* Examples+ListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Examples+ListItem.swift"; sourceTree = "<group>"; };
+		D72A3EDB2FB69B18005C6D1B /* GeometryEditorToolbarExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryEditorToolbarExampleView.swift; sourceTree = "<group>"; };
 		E42BFBE82672BF9500159107 /* SearchExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchExampleView.swift; sourceTree = "<group>"; };
 		E4624A24278CE815000D2A38 /* FloorFilterExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorFilterExampleView.swift; sourceTree = "<group>"; };
 		E47ABE402652FE0900FD2FE3 /* Toolkit Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Toolkit Examples.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -118,6 +120,7 @@
 				E4AA9315276BF5ED000E6289 /* FloatingPanelExampleView.swift */,
 				E4624A24278CE815000D2A38 /* FloorFilterExampleView.swift */,
 				882899FC2AB5099300A0BDC1 /* FlyoverExampleView.swift */,
+				D72A3EDB2FB69B18005C6D1B /* GeometryEditorToolbarExampleView.swift */,
 				88519D3E2C8A7967007D7015 /* LocationButtonExampleView.swift */,
 				E4F9BC98265EFCAF001280FF /* OverviewMapExampleView.swift */,
 				4D19FCB42881C8F3002601E8 /* PopupExampleView.swift */,
@@ -327,6 +330,7 @@
 				882899FD2AB5099300A0BDC1 /* FlyoverExampleView.swift in Sources */,
 				E42BFBE92672BF9500159107 /* SearchExampleView.swift in Sources */,
 				E4C389D526B8A12C002BC255 /* BasemapGalleryExampleView.swift in Sources */,
+				D72A3EDC2FB69B18005C6D1B /* GeometryEditorToolbarExampleView.swift in Sources */,
 				75D41B2B27C6F21400624D7C /* ScalebarExampleView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/Examples/GeometryEditorToolbarExampleView.swift
+++ b/Examples/Examples/GeometryEditorToolbarExampleView.swift
@@ -12,10 +12,86 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ArcGIS
+import ArcGISToolkit
 import SwiftUI
 
 struct GeometryEditorToolbarExampleView: View {
+    /// The geometry editor used to edit geometries on the map view.
+    @State private var geometryEditor = GeometryEditor()
+    /// The graphics overlay for displaying the created graphics on the map view.
+    @State private var graphicsOverlay = GraphicsOverlay()
+    /// The map displayed in the map view.
+    @State private var map = Map(basemapStyle: .arcGISTopographic)
+    /// A Boolean value indicating whether the view is currently editing a geometry.
+    @State private var isEditing = false
+    
     var body: some View {
-        Text("Placeholder")
+        MapView(map: map, graphicsOverlays: [graphicsOverlay])
+            .geometryEditor(geometryEditor)
+            .overlay(alignment: .topTrailing) {
+                GeometryEditorToolbar(geometryEditor: geometryEditor)
+                    .padding()
+            }
+            .toolbar {
+                ToolbarItemGroup(placement: .bottomBar) {
+                    Menu("Add Graphic", systemImage: "plus") {
+                        ForEach(GeometryKind.allCases, id: \.self) { geometryKind in
+                            Button(geometryKind.label) {
+                                geometryEditor.start(withType: geometryKind.type)
+                                isEditing = true
+                            }
+                        }
+                    }
+                    .disabled(isEditing)
+                    
+                    Button("Done", systemImage: "checkmark") {
+                        addGraphic()
+                        isEditing = false
+                    }
+                    .disabled(!isEditing)
+                }
+            }
+    }
+    
+    /// Creates a graphic from the geometry editor's geometry and adds it to the graphics overlay.
+    private func addGraphic() {
+        guard let geometry = geometryEditor.stop(), !geometry.isEmpty else { return }
+        
+        let symbol = switch geometry {
+        case is Point:
+            SimpleMarkerSymbol(color: .blue)
+        case is Polyline:
+            SimpleLineSymbol(color: .black, width: 2)
+        case is ArcGIS.Polygon:
+            SimpleFillSymbol(color: .green)
+        default:
+            fatalError("Unsupported geometry type")
+        }
+        let graphic = Graphic(geometry: geometry, symbol: symbol)
+        graphicsOverlay.addGraphic(graphic)
+    }
+}
+
+/// An enumeration representing the kinds of geometries that can be created in this example.
+private enum GeometryKind: CaseIterable {
+    case point, polyline, polygon
+    
+    /// A user-friendly label for the geometry kind.
+    var label: String {
+        switch self {
+        case .point: "Point"
+        case .polyline: "Polyline"
+        case .polygon: "Polygon"
+        }
+    }
+    
+    /// The `Geometry.Type` corresponding to the geometry kind.
+    var type: Geometry.Type {
+        switch self {
+        case .point: Point.self
+        case .polyline: Polyline.self
+        case .polygon: ArcGIS.Polygon.self
+        }
     }
 }

--- a/Examples/Examples/GeometryEditorToolbarExampleView.swift
+++ b/Examples/Examples/GeometryEditorToolbarExampleView.swift
@@ -1,0 +1,21 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+struct GeometryEditorToolbarExampleView: View {
+    var body: some View {
+        Text("Placeholder")
+    }
+}

--- a/Examples/ExamplesApp/Examples.swift
+++ b/Examples/ExamplesApp/Examples.swift
@@ -84,6 +84,7 @@ struct Examples: View {
             .example("Feature Form", content: FeatureFormExampleView()),
             .example("Floating Panel", content: FloatingPanelExampleView()),
             .example("Floor Filter", content: FloorFilterExampleView()),
+            .example("Geometry Editor Toolbar", content: GeometryEditorToolbarExampleView()),
             .example("Location Button", content: LocationButtonExampleView()),
             .example("Overview Map", content: OverviewMapExampleView()),
             .example("Popup", content: PopupExampleView()),


### PR DESCRIPTION
### Description

This PR adds an example for the new `GeometryEditorToolbar` component. This is redo of https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1450, since it was recommended by Ryan and Divesh to make the example simpler; see related https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1450#issuecomment-4546969617.

Closes `swift/issues/7407`.

### How To Test

1. Tap the plus button and select a geometry type to create.
2. Use the geometry editor and the geometry editor toolbar controls to create a geometry.
3. Tap the checkmark to finish editing and add a graphic with the created geometry.

### Screenshots

<img width="276" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-26 at 15 44 56" src="https://github.com/user-attachments/assets/4c2c48ed-d9b6-4bbb-ab28-93acd4b72d94" />