### PR TITLE
AR: Update `ARSwiftUIView` and `ARCoachingOverlay`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -22,8 +22,8 @@ import RealityKit
 @available(visionOS, unavailable)
 public struct TableTopSceneView: View {
 #if os(iOS)
-    /// The proxy for the ARSwiftUIView.
-    @State private var arViewProxy = ARSwiftUIViewProxy()
+    /// The AR session provider for the ARSwiftUIView.
+    @State private var arSessionProvider = ARSessionProvider<ARView>()
 #endif
     /// The initial transformation for the scene's camera controller.
     @State private var initialTransformation: TransformationMatrix? = nil
@@ -99,7 +99,7 @@ public struct TableTopSceneView: View {
         SceneViewReader { sceneViewProxy in
             ZStack {
 #if os(iOS)
-                ARSwiftUIView(proxy: arViewProxy)
+                ARSwiftUIView(sessionProvider: arSessionProvider)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation else { return }
                         sceneViewProxy.updateCamera(
@@ -123,7 +123,7 @@ public struct TableTopSceneView: View {
                         guard !initialTransformationIsSet else { return }
                         
                         if let transformation = sceneViewProxy.initialTransformation(
-                            for: arViewProxy,
+                            for: arSessionProvider,
                             using: screenPoint
                         ) {
                             initialTransformation = transformation
@@ -133,15 +133,15 @@ public struct TableTopSceneView: View {
                         }
                     }
                     .onAppear {
-                        arViewProxy.session.run(configuration, options: .removeExistingAnchors)
+                        arSessionProvider.session.run(configuration, options: .removeExistingAnchors)
                     }
                     .onDisappear {
-                        arViewProxy.session.pause()
+                        arSessionProvider.session.pause()
                     }
                 
                 if !coachingOverlayIsHidden {
                     ARCoachingOverlay(goal: .horizontalPlane)
-                        .sessionProvider(arViewProxy)
+                        .sessionProvider(arSessionProvider)
                         .active(coachingOverlayIsActive)
                         .allowsHitTesting(false)
                         .ignoresSafeArea()
@@ -197,7 +197,7 @@ public struct TableTopSceneView: View {
         let planeEntity = ModelEntity(mesh: mesh, materials: [material])
         
         anchorEntity.addChild(planeEntity)
-        arViewProxy.scene.addAnchor(anchorEntity)
+        arSessionProvider.scene.addAnchor(anchorEntity)
         
         planeEntities[planeAnchor.identifier] = planeEntity
         
@@ -260,16 +260,16 @@ private extension SceneViewProxy {
     /// Sets the initial transformation used to offset the originCamera.  The initial transformation is based on an AR point determined
     /// via existing plane hit detection from `screenPoint`.  If an AR point cannot be determined, this method will return `false`.
     /// - Parameters:
-    ///   - arViewProxy: The AR view proxy.
+    ///   - sessionProvider: The AR session provider.
     ///   - screenPoint: The screen point to determine the `initialTransformation` from.
     /// - Returns: The `initialTransformation`.
     @MainActor
     func initialTransformation(
-        for arViewProxy: ARSwiftUIViewProxy,
+        for sessionProvider: ARSessionProvider<ARView>,
         using screenPoint: CGPoint
     ) -> TransformationMatrix? {
         // Use the `raycast` method to get the matrix of `screenPoint`.
-        guard let matrix = arViewProxy.raycast(from: screenPoint, allowing: .existingPlaneGeometry) else { return nil }
+        guard let matrix = sessionProvider.arView.raycast(from: screenPoint, allowing: .existingPlaneGeometry) else { return nil }
         
         // Set the `initialTransformation` as the TransformationMatrix.identity - raycast matrix.
         let initialTransformation = TransformationMatrix.identity.subtracting(matrix)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -142,6 +142,7 @@ public struct TableTopSceneView: View {
                 if !coachingOverlayIsHidden {
                     ARCoachingOverlay(goal: .horizontalPlane)
                         .sessionProvider(arSessionProvider)
+                        .activatesAutomatically(false)
                         .active(coachingOverlayIsActive)
                         .allowsHitTesting(false)
                         .ignoresSafeArea()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -22,7 +22,7 @@ import RealityKit
 @available(visionOS, unavailable)
 public struct TableTopSceneView: View {
 #if os(iOS)
-    /// The AR session provider for the ARSwiftUIView.
+    /// The AR session provider for the SwiftUIARView.
     @State private var arSessionProvider = ARSessionProvider<ARView>()
 #endif
     /// The initial transformation for the scene's camera controller.
@@ -99,7 +99,7 @@ public struct TableTopSceneView: View {
         SceneViewReader { sceneViewProxy in
             ZStack {
 #if os(iOS)
-                ARSwiftUIView(sessionProvider: arSessionProvider)
+                SwiftUIARView(sessionProvider: arSessionProvider)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation else { return }
                         sceneViewProxy.updateCamera(

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -113,11 +113,15 @@ public struct TableTopSceneView: View {
                             orientation: interfaceOrientation
                         )
                     }
-                    .onAddAnchor { planeAnchor in
-                        addPlane(for: planeAnchor)
+                    .onAnchorsAdded { planeAnchors in
+                        for anchor in planeAnchors {
+                            addPlane(for: anchor)
+                        }
                     }
-                    .onUpdateAnchor { planeAnchor in
-                        updatePlane(for: planeAnchor)
+                    .onAnchorsUpdated { planeAnchors in
+                        for anchor in planeAnchors {
+                            updatePlane(for: anchor)
+                        }
                     }
                     .onTapGesture { screenPoint in
                         guard !initialTransformationIsSet else { return }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
@@ -46,8 +46,7 @@ extension ARCoachingOverlay {
         return view
     }
     
-    
-    /// Controls whether the coaching overlay activates automatically.
+    /// Sets whether the coaching overlay activates automatically.
     /// - Parameter activatesAutomatically: A Boolean value that
     /// indicates if the coaching overlay activates automatically.
     func activatesAutomatically(_ activatesAutomatically: Bool) -> Self {
@@ -108,28 +107,30 @@ extension ARCoachingOverlay: UIViewRepresentable {
         uiView.goal = goal
     }
     
-    class Coordinator: NSObject, ARCoachingOverlayViewDelegate {
+    class Coordinator: NSObject {
         var coachingOverlay: ARCoachingOverlay
         
         init(coachingOverlay: ARCoachingOverlay) {
             self.coachingOverlay = coachingOverlay
         }
-        
-        func coachingOverlayViewWillActivate(_ coachingOverlayView: ARCoachingOverlayView) {
-            coachingOverlay.onCoachingOverlayActivateAction?(coachingOverlayView)
-        }
-        
-        func coachingOverlayViewDidDeactivate(_ coachingOverlayView: ARCoachingOverlayView) {
-            coachingOverlay.onCoachingOverlayDeactivateAction?(coachingOverlayView)
-        }
-        
-        func coachingOverlayViewDidRequestSessionReset(_ coachingOverlayView: ARCoachingOverlayView) {
-            coachingOverlay.onCoachingOverlayRequestSessionResetAction?(coachingOverlayView)
-        }
     }
     
     func makeCoordinator() -> Coordinator {
         return .init(coachingOverlay: self)
+    }
+}
+
+extension ARCoachingOverlay.Coordinator: ARCoachingOverlayViewDelegate {
+    func coachingOverlayViewWillActivate(_ coachingOverlayView: ARCoachingOverlayView) {
+        coachingOverlay.onCoachingOverlayActivateAction?(coachingOverlayView)
+    }
+    
+    func coachingOverlayViewDidDeactivate(_ coachingOverlayView: ARCoachingOverlayView) {
+        coachingOverlay.onCoachingOverlayDeactivateAction?(coachingOverlayView)
+    }
+    
+    func coachingOverlayViewDidRequestSessionReset(_ coachingOverlayView: ARCoachingOverlayView) {
+        coachingOverlay.onCoachingOverlayRequestSessionResetAction?(coachingOverlayView)
     }
 }
 #endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
@@ -31,9 +31,12 @@ struct ARCoachingOverlay {
     var goal: ARCoachingOverlayView.Goal
     /// A Boolean value that indicates if coaching is in progress.
     var active: Bool = false
-    
+}
+
+extension ARCoachingOverlay {
     /// Controls whether the coaching is in progress.
-    /// - Parameter active: A Boolean value indicating if coaching is in progress.
+    /// - Parameter active: A Boolean value indicating if coaching is in
+    /// progress.
     /// - Returns: The `ARCoachingOverlay`.
     func active(_ active: Bool) -> Self {
         var view = self
@@ -50,7 +53,8 @@ struct ARCoachingOverlay {
         return view
     }
     
-    /// Sets the closure to call when the coaching experience is completely deactivated.
+    /// Sets the closure to call when the coaching experience is completely
+    /// deactivated.
     func onCoachingOverlayDeactivate(
         perform action: @escaping (ARCoachingOverlayView) -> Void
     ) -> Self {
@@ -59,8 +63,8 @@ struct ARCoachingOverlay {
         return view
     }
     
-    /// Sets the closure to call when the user taps the coaching overlay view's Start Over button
-    /// while the session is relocalizing.
+    /// Sets the closure to call when the user taps the coaching overlay view's
+    /// Start Over button while the session is relocalizing.
     func onCoachingOverlayRequestSessionReset(
         perform action: @escaping (ARCoachingOverlayView) -> Void
     ) -> Self {
@@ -88,36 +92,33 @@ extension ARCoachingOverlay: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: ARCoachingOverlayView, context: Context) {
+        context.coordinator.coachingOverlay = self
         uiView.sessionProvider = sessionProvider
         uiView.goal = goal
-        uiView.setActive(active, animated: true)
-        context.coordinator.onCoachingOverlayActivateAction = onCoachingOverlayActivateAction
-        context.coordinator.onCoachingOverlayDeactivateAction = onCoachingOverlayDeactivateAction
-        context.coordinator.onCoachingOverlayRequestSessionResetAction = onCoachingOverlayRequestSessionResetAction
     }
     
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
-}
-
-extension ARCoachingOverlay {
     class Coordinator: NSObject, ARCoachingOverlayViewDelegate {
-        var onCoachingOverlayActivateAction: ((ARCoachingOverlayView) -> Void)?
-        var onCoachingOverlayDeactivateAction: ((ARCoachingOverlayView) -> Void)?
-        var onCoachingOverlayRequestSessionResetAction: ((ARCoachingOverlayView) -> Void)?
+        var coachingOverlay: ARCoachingOverlay
+        
+        init(coachingOverlay: ARCoachingOverlay) {
+            self.coachingOverlay = coachingOverlay
+        }
         
         func coachingOverlayViewWillActivate(_ coachingOverlayView: ARCoachingOverlayView) {
-            onCoachingOverlayActivateAction?(coachingOverlayView)
+            coachingOverlay.onCoachingOverlayActivateAction?(coachingOverlayView)
         }
         
         func coachingOverlayViewDidDeactivate(_ coachingOverlayView: ARCoachingOverlayView) {
-            onCoachingOverlayDeactivateAction?(coachingOverlayView)
+            coachingOverlay.onCoachingOverlayDeactivateAction?(coachingOverlayView)
         }
         
         func coachingOverlayViewDidRequestSessionReset(_ coachingOverlayView: ARCoachingOverlayView) {
-            onCoachingOverlayRequestSessionResetAction?(coachingOverlayView)
+            coachingOverlay.onCoachingOverlayRequestSessionResetAction?(coachingOverlayView)
         }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        return .init(coachingOverlay: self)
     }
 }
 #endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
@@ -31,6 +31,8 @@ struct ARCoachingOverlay {
     var goal: ARCoachingOverlayView.Goal
     /// A Boolean value that indicates if coaching is in progress.
     var active: Bool = false
+    /// A Boolean value that indicates if the coaching overlay activates automatically.
+    var activatesAutomatically: Bool = true
 }
 
 extension ARCoachingOverlay {
@@ -41,6 +43,15 @@ extension ARCoachingOverlay {
     func active(_ active: Bool) -> Self {
         var view = self
         view.active = active
+        return view
+    }
+    
+    
+    /// Controls whether the coaching overlay activates automatically.
+    /// - Parameter activatesAutomatically: A Boolean value that indicates if the coaching overlay activates automatically.
+    func activatesAutomatically(_ activatesAutomatically: Bool) -> Self {
+        var view = self
+        view.activatesAutomatically = activatesAutomatically
         return view
     }
     
@@ -87,7 +98,6 @@ extension ARCoachingOverlay: UIViewRepresentable {
     func makeUIView(context: Context) -> ARCoachingOverlayView {
         let view = ARCoachingOverlayView()
         view.delegate = context.coordinator
-        view.activatesAutomatically = true
         return view
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARCoachingOverlay.swift
@@ -48,7 +48,8 @@ extension ARCoachingOverlay {
     
     
     /// Controls whether the coaching overlay activates automatically.
-    /// - Parameter activatesAutomatically: A Boolean value that indicates if the coaching overlay activates automatically.
+    /// - Parameter activatesAutomatically: A Boolean value that
+    /// indicates if the coaching overlay activates automatically.
     func activatesAutomatically(_ activatesAutomatically: Bool) -> Self {
         var view = self
         view.activatesAutomatically = activatesAutomatically

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
@@ -18,203 +18,215 @@ import ARKit
 import RealityKit
 import SwiftUI
 
-typealias ARViewType = RealityKit.ARView
-
 /// A SwiftUI version of an AR view.
-struct ARSwiftUIView {
+public struct ARSwiftUIView {
     /// The closure to call when the session's geo-tracking state changes.
-    private(set) var onDidChangeGeoTrackingStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
+    private var onDidChangeGeoTrackingStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
     /// The closure to call when the session's camera tracking state changes.
-    private(set) var onCameraDidChangeTrackingStateAction: ((ARSession, ARCamera.TrackingState) -> Void)?
+    private var onCameraDidChangeTrackingStateAction: ((ARSession, ARCamera.TrackingState) -> Void)?
     /// The closure to call when the session's frame updates.
-    private(set) var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
+    private var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
     /// The closure to call when a new plane anchor has been added to the view.
-    private(set) var onAddAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
+    private var onAddAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
     /// The closure to call when a plane anchor has been updated.
-    private(set) var onUpdateAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
+    private var onUpdateAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
+    /// The closure to call when the session is interrupted.
+    private var onSessionWasInterruptedAction: ((ARSession) -> Void)?
+    /// The closure to call when the session interruption ends.
+    private var onSessionInterruptionEndedAction: ((ARSession) -> Void)?
+    /// The AR session provider for the AR view.
+    private let sessionProvider: ARSessionProvider<ARView>
     
-    /// The proxy.
-    private let proxy: ARSwiftUIViewProxy
-    
-    /// Creates an ARSwiftUIView.
-    /// - Parameter proxy: The provided proxy which will have it's state filled out
-    /// when available by the underlying view.
-    init(proxy: ARSwiftUIViewProxy) {
-        self.proxy = proxy
+    /// Creates an instance with the given session provider.
+    /// - Parameter sessionProvider: The session provider which will have its
+    /// view set when available.
+    public init(sessionProvider: ARSessionProvider<ARView>) {
+        self.sessionProvider = sessionProvider
     }
-    
+}
+
+public extension ARSwiftUIView {
     /// Sets the closure to call when the session's geo-tracking state changes.
     ///
     /// ARKit invokes the callback only for `ARGeoTrackingConfiguration` sessions.
     func onDidChangeGeoTrackingStatus(
         perform action: @escaping (ARSession, ARGeoTrackingStatus) -> Void
     ) -> Self {
-        var view = self
-        view.onDidChangeGeoTrackingStatusAction = action
-        return view
+        var copy = self
+        copy.onDidChangeGeoTrackingStatusAction = action
+        return copy
     }
     
     /// Sets the closure to call when session's camera tracking state changes.
     func onCameraDidChangeTrackingState(
         perform action: @escaping (ARSession, ARCamera.TrackingState) -> Void
     ) -> Self {
-        var view = self
-        view.onCameraDidChangeTrackingStateAction = action
-        return view
+        var copy = self
+        copy.onCameraDidChangeTrackingStateAction = action
+        return copy
     }
     
     /// Sets the closure to call when underlying scene renders.
     func onDidUpdateFrame(
         perform action: @escaping (ARSession, ARFrame) -> Void
     ) -> Self {
-        var view = self
-        view.onDidUpdateFrameAction = action
-        return view
+        var copy = self
+        copy.onDidUpdateFrameAction = action
+        return copy
     }
     
     /// Sets the closure to call when a new plane anchor has been added to the scene.
     func onAddAnchor(
         perform action: @escaping @MainActor (ARPlaneAnchor) -> Void
     ) -> Self {
-        var view = self
-        view.onAddAnchorAction = action
-        return view
+        var copy = self
+        copy.onAddAnchorAction = action
+        return copy
     }
     
     /// Sets the closure to call when the a plane anchor is updated.
     func onUpdateAnchor(
         perform action: @escaping @MainActor (ARPlaneAnchor) -> Void
     ) -> Self {
-        var view = self
-        view.onUpdateAnchorAction = action
-        return view
+        var copy = self
+        copy.onUpdateAnchorAction = action
+        return copy
+    }
+    
+    /// Sets the closure to call when the session is interrupted.
+    func onSessionWasInterrupted(
+        perform action: @escaping (ARSession) -> Void
+    ) -> Self {
+        var copy = self
+        copy.onSessionWasInterruptedAction = action
+        return copy
+    }
+    
+    /// Sets the closure to call when the session interruption ends.
+    func onSessionInterruptionEnded(
+        perform action: @escaping (ARSession) -> Void
+    ) -> Self {
+        var copy = self
+        copy.onSessionInterruptionEndedAction = action
+        return copy
     }
 }
 
 extension ARSwiftUIView: UIViewRepresentable {
-    func makeUIView(context: Context) -> ARViewType {
-        let arView = ARViewType()
+    public func makeUIView(context: Context) -> ARView {
+        let arView = ARView()
         arView.session.delegate = context.coordinator
-        // Set the AR view on the proxy.
-        proxy.arView = arView
+        sessionProvider.arView = arView
         return arView
     }
     
-    func updateUIView(_ uiView: ARViewType, context: Context) {}
-    
-    func makeCoordinator() -> Coordinator {
-        return .init(
-            onDidChangeGeoTrackingStatusAction: onDidChangeGeoTrackingStatusAction,
-            onCameraDidChangeTrackingStateAction: onCameraDidChangeTrackingStateAction,
-            onDidUpdateFrameAction: onDidUpdateFrameAction,
-            onAddAnchorAction: onAddAnchorAction,
-            onUpdateAnchorAction: onUpdateAnchorAction
-        )
+    public func updateUIView(_: ARView, context: Context) {
+        context.coordinator.arSwiftUIView = self
     }
     
-    class Coordinator: NSObject {
-        let onDidChangeGeoTrackingStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
-        let onCameraDidChangeTrackingStateAction: ((ARSession, ARCamera.TrackingState) -> Void)?
-        let onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
-        let onAddAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
-        let onUpdateAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
+    public class Coordinator: NSObject {
+        var arSwiftUIView: ARSwiftUIView
         
-        init(
-            onDidChangeGeoTrackingStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?,
-            onCameraDidChangeTrackingStateAction: ((ARSession, ARCamera.TrackingState) -> Void)?,
-            onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?,
-            onAddAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?,
-            onUpdateAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
-        ) {
-            self.onDidChangeGeoTrackingStatusAction = onDidChangeGeoTrackingStatusAction
-            self.onCameraDidChangeTrackingStateAction = onCameraDidChangeTrackingStateAction
-            self.onDidUpdateFrameAction = onDidUpdateFrameAction
-            self.onAddAnchorAction = onAddAnchorAction
-            self.onUpdateAnchorAction = onUpdateAnchorAction
+        init(arSwiftUIView: ARSwiftUIView) {
+            self.arSwiftUIView = arSwiftUIView
         }
+    }
+    
+    public func makeCoordinator() -> Coordinator {
+        return .init(arSwiftUIView: self)
     }
 }
 
 extension ARSwiftUIView.Coordinator: ARSessionDelegate {
-    func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
+    public func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
         // Filter new plane anchors to use for horizontal plane visualization.
         let planeAnchors = anchors.compactMap { $0 as? ARPlaneAnchor }
         for anchor in planeAnchors {
-            Task { @MainActor [onAddAnchorAction] in
+            Task { @MainActor [onAddAnchorAction = arSwiftUIView.onAddAnchorAction] in
                 onAddAnchorAction?(anchor)
             }
         }
     }
     
-    func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
+    public func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
         // Filter updated plane anchors to use for horizontal plane visualization.
         let planeAnchors = anchors.compactMap { $0 as? ARPlaneAnchor }
         for anchor in planeAnchors {
-            Task { @MainActor [onUpdateAnchorAction] in
+            Task { @MainActor [onUpdateAnchorAction = arSwiftUIView.onUpdateAnchorAction] in
                 onUpdateAnchorAction?(anchor)
             }
         }
     }
     
-    func session(_ session: ARSession, didChange geoTrackingStatus: ARGeoTrackingStatus) {
-        onDidChangeGeoTrackingStatusAction?(session, geoTrackingStatus)
+    public func session(_ session: ARSession, didChange geoTrackingStatus: ARGeoTrackingStatus) {
+        arSwiftUIView.onDidChangeGeoTrackingStatusAction?(session, geoTrackingStatus)
     }
     
-    func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
-        onCameraDidChangeTrackingStateAction?(session, camera.trackingState)
+    public func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
+        arSwiftUIView.onCameraDidChangeTrackingStateAction?(session, camera.trackingState)
     }
     
-    func session(_ session: ARSession, didUpdate frame: ARFrame) {
-        onDidUpdateFrameAction?(session, frame)
+    public func session(_ session: ARSession, didUpdate frame: ARFrame) {
+        arSwiftUIView.onDidUpdateFrameAction?(session, frame)
+    }
+    
+    public func sessionWasInterrupted(_ session: ARSession) {
+        arSwiftUIView.onSessionWasInterruptedAction?(session)
+    }
+    
+    public func sessionInterruptionEnded(_ session: ARSession) {
+        arSwiftUIView.onSessionWasInterruptedAction?(session)
+    }
+    
+    public func sessionShouldAttemptRelocalization(_ session: ARSession) -> Bool {
+        return true
     }
 }
 
-/// A proxy for the ARSwiftUIView.
+/// A class that provides an AR session from an underlying AR view.
 @MainActor
-class ARSwiftUIViewProxy: NSObject, @preconcurrency ARSessionProviding {
+public class ARSessionProvider<ARViewType: ARView>: NSObject, @preconcurrency ARSessionProviding {
     /// The underlying AR view.
-    /// This is set by the ARSwiftUIView when it is available.
-    fileprivate var arView: ARViewType!
+    public var arView: ARViewType!
     
     /// The AR session.
-    @objc dynamic var session: ARSession {
-        arView.session
-    }
+    @objc public dynamic var session: ARSession { arView.session }
     
     /// The scene.
-    var scene: RealityKit.Scene {
-        arView.scene
-    }
+    public var scene: RealityKit.Scene { arView.scene }
 }
 
-extension ARSwiftUIViewProxy {
-    /// Performs a raycast to get the transformation matrix representing the corresponding
-    /// real-world point for `screenPoint`.
+public extension ARView {
+    /// Performs a raycast to get the transformation matrix representing the
+    /// corresponding real-world point for `screenPoint`.
     ///
-    /// The method returns `nil` when the raycast query or the raycast fails. They can fail due to
-    /// certain limitations, such as reflective or irregular surfaces, poorly lit environment that
-    /// reduces the amount of visible objects, distance between the camera and the object being
-    /// too far, camera occlusion that blocks the rays, etc.
+    /// This method returns `nil` when the raycast query or the raycast fails.
+    /// They can fail due to certain limitations, such as reflective or
+    /// irregular surfaces, poorly lit environment that reduces the amount of
+    /// visible objects, distance between the camera and the object being too
+    /// far, camera occlusion that blocks the rays, etc.
     /// - Parameters:
-    ///   - screenPoint: The screen point to determine the real world transformation matrix from.
+    ///   - screenPoint: The screen point from which to determine the real world
+    ///   transformation matrix.
     ///   - target: The type of surface the raycast can interact with.
-    /// - Returns: A `TransformationMatrix` representing the real-world point corresponding to `screenPoint`.
-    @MainActor func raycast(from screenPoint: CGPoint, allowing target: ARRaycastQuery.Target) -> TransformationMatrix? {
-        // Use the `raycast` method on ARView to get the location of `screenPoint`.
-        let results = arView.raycast(
-            from: screenPoint,
-            allowing: target,
-            alignment: .any
-        )
-        // Get the worldTransform from the first result; if there's no worldTransform, return nil.
+    /// - Returns: A transformation matrix representing the real-world point
+    /// corresponding to `screenPoint`.
+    @MainActor func raycast(
+        from screenPoint: CGPoint,
+        allowing target: ARRaycastQuery.Target
+    ) -> TransformationMatrix? {
+        // Use the 'raycast' method to get the location of 'screenPoint'.
+        let results = raycast(from: screenPoint, allowing: target, alignment: .any)
+        // Get the world transform from the first result or return 'nil'.
         guard let worldTransform = results.first?.worldTransform else { return nil }
         
-        // Create our raycast matrix based on the worldTransform location.
-        // Right now we ignore the orientation of the plane that was hit to find the point
-        // since we only use horizontal planes.
-        // If we start supporting vertical planes we will have to stop suppressing the
-        // quaternion rotation to a null rotation (0,0,0,1).
-        let raycastMatrix = TransformationMatrix.normalized(
+        // Create our raycast matrix based on the 'worldTransform' location.
+        // Right now we ignore the orientation of the plane that was hit to find
+        // the point since we only use horizontal planes.
+        //
+        // If we start supporting vertical planes we will have to stop
+        // suppressing the quaternion rotation to a null rotation (0,0,0,1).
+        return .normalized(
             quaternionX: 0,
             quaternionY: 0,
             quaternionZ: 0,
@@ -223,8 +235,6 @@ extension ARSwiftUIViewProxy {
             translationY: Double(worldTransform.columns.3.y),
             translationZ: Double(worldTransform.columns.3.z)
         )
-        
-        return raycastMatrix
     }
 }
 #endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
@@ -19,7 +19,7 @@ import RealityKit
 import SwiftUI
 
 /// A SwiftUI version of an AR view.
-public struct ARSwiftUIView {
+public struct SwiftUIARView {
     /// The closure to call when the session's geo-tracking state changes.
     private var onDidChangeGeoTrackingStatusAction: ((ARSession, ARGeoTrackingStatus) -> Void)?
     /// The closure to call when the session's camera tracking state changes.
@@ -45,7 +45,7 @@ public struct ARSwiftUIView {
     }
 }
 
-public extension ARSwiftUIView {
+public extension SwiftUIARView {
     /// Sets the closure to call when the session's geo-tracking state changes.
     ///
     /// ARKit invokes the callback only for `ARGeoTrackingConfiguration` sessions.
@@ -112,7 +112,7 @@ public extension ARSwiftUIView {
     }
 }
 
-extension ARSwiftUIView: UIViewRepresentable {
+extension SwiftUIARView: UIViewRepresentable {
     public func makeUIView(context: Context) -> ARView {
         let arView = ARView()
         arView.session.delegate = context.coordinator
@@ -121,25 +121,25 @@ extension ARSwiftUIView: UIViewRepresentable {
     }
     
     public func updateUIView(_: ARView, context: Context) {
-        context.coordinator.arSwiftUIView = self
+        context.coordinator.swiftUIARView = self
     }
     
     public class Coordinator: NSObject {
-        var arSwiftUIView: ARSwiftUIView
+        var swiftUIARView: SwiftUIARView
         
-        init(arSwiftUIView: ARSwiftUIView) {
-            self.arSwiftUIView = arSwiftUIView
+        init(swiftUIARView: SwiftUIARView) {
+            self.swiftUIARView = swiftUIARView
         }
     }
     
     public func makeCoordinator() -> Coordinator {
-        return .init(arSwiftUIView: self)
+        return .init(swiftUIARView: self)
     }
 }
 
-extension ARSwiftUIView.Coordinator: ARSessionDelegate {
+extension SwiftUIARView.Coordinator: ARSessionDelegate {
     public func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
-        let onAnchorsAddedAction = arSwiftUIView.onAnchorsAddedAction
+        let onAnchorsAddedAction = swiftUIARView.onAnchorsAddedAction
         
         Task { @MainActor in
             // Filter new plane anchors to use for horizontal plane visualization.
@@ -149,7 +149,7 @@ extension ARSwiftUIView.Coordinator: ARSessionDelegate {
     }
     
     public func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
-        let onAnchorsUpdatedAction = arSwiftUIView.onAnchorsUpdatedAction
+        let onAnchorsUpdatedAction = swiftUIARView.onAnchorsUpdatedAction
         
         Task { @MainActor in
             // Filter updated plane anchors to use for horizontal plane visualization.
@@ -159,23 +159,23 @@ extension ARSwiftUIView.Coordinator: ARSessionDelegate {
     }
     
     public func session(_ session: ARSession, didChange geoTrackingStatus: ARGeoTrackingStatus) {
-        arSwiftUIView.onDidChangeGeoTrackingStatusAction?(session, geoTrackingStatus)
+        swiftUIARView.onDidChangeGeoTrackingStatusAction?(session, geoTrackingStatus)
     }
     
     public func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
-        arSwiftUIView.onCameraDidChangeTrackingStateAction?(session, camera.trackingState)
+        swiftUIARView.onCameraDidChangeTrackingStateAction?(session, camera.trackingState)
     }
     
     public func session(_ session: ARSession, didUpdate frame: ARFrame) {
-        arSwiftUIView.onDidUpdateFrameAction?(session, frame)
+        swiftUIARView.onDidUpdateFrameAction?(session, frame)
     }
     
     public func sessionWasInterrupted(_ session: ARSession) {
-        arSwiftUIView.onSessionWasInterruptedAction?(session)
+        swiftUIARView.onSessionWasInterruptedAction?(session)
     }
     
     public func sessionInterruptionEnded(_ session: ARSession) {
-        arSwiftUIView.onSessionWasInterruptedAction?(session)
+        swiftUIARView.onSessionWasInterruptedAction?(session)
     }
     
     public func sessionShouldAttemptRelocalization(_ session: ARSession) -> Bool {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
@@ -26,10 +26,10 @@ public struct ARSwiftUIView {
     private var onCameraDidChangeTrackingStateAction: ((ARSession, ARCamera.TrackingState) -> Void)?
     /// The closure to call when the session's frame updates.
     private var onDidUpdateFrameAction: ((ARSession, ARFrame) -> Void)?
-    /// The closure to call when a new plane anchor has been added to the view.
-    private var onAddAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
-    /// The closure to call when a plane anchor has been updated.
-    private var onUpdateAnchorAction: (@MainActor (ARPlaneAnchor) -> Void)?
+    /// The closure to call when new plane anchors have been added to the view.
+    private var onAnchorsAddedAction: (@MainActor ([ARPlaneAnchor]) -> Void)?
+    /// The closure to call when plane anchors have been updated.
+    private var onAnchorsUpdatedAction: (@MainActor ([ARPlaneAnchor]) -> Void)?
     /// The closure to call when the session is interrupted.
     private var onSessionWasInterruptedAction: ((ARSession) -> Void)?
     /// The closure to call when the session interruption ends.
@@ -75,21 +75,21 @@ public extension ARSwiftUIView {
         return copy
     }
     
-    /// Sets the closure to call when a new plane anchor has been added to the scene.
-    func onAddAnchor(
-        perform action: @escaping @MainActor (ARPlaneAnchor) -> Void
+    /// Sets the closure to call when new plane anchors have been added to the scene.
+    func onAnchorsAdded(
+        perform action: @escaping @MainActor ([ARPlaneAnchor]) -> Void
     ) -> Self {
         var copy = self
-        copy.onAddAnchorAction = action
+        copy.onAnchorsAddedAction = action
         return copy
     }
     
-    /// Sets the closure to call when the a plane anchor is updated.
-    func onUpdateAnchor(
-        perform action: @escaping @MainActor (ARPlaneAnchor) -> Void
+    /// Sets the closure to call when plane anchors are updated.
+    func onAnchorsUpdated(
+        perform action: @escaping @MainActor ([ARPlaneAnchor]) -> Void
     ) -> Self {
         var copy = self
-        copy.onUpdateAnchorAction = action
+        copy.onAnchorsUpdatedAction = action
         return copy
     }
     
@@ -139,22 +139,22 @@ extension ARSwiftUIView: UIViewRepresentable {
 
 extension ARSwiftUIView.Coordinator: ARSessionDelegate {
     public func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
-        for anchor in anchors {
+        let onAnchorsAddedAction = arSwiftUIView.onAnchorsAddedAction
+        
+        Task { @MainActor in
             // Filter new plane anchors to use for horizontal plane visualization.
-            guard let planeAnchor = anchor as? ARPlaneAnchor else { continue }
-            Task { @MainActor [onAddAnchorAction = arSwiftUIView.onAddAnchorAction] in
-                onAddAnchorAction?(planeAnchor)
-            }
+            let planeAnchors = anchors.compactMap { $0 as? ARPlaneAnchor }
+            onAnchorsAddedAction?(planeAnchors)
         }
     }
     
     public func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
-        for anchor in anchors {
+        let onAnchorsUpdatedAction = arSwiftUIView.onAnchorsUpdatedAction
+        
+        Task { @MainActor in
             // Filter updated plane anchors to use for horizontal plane visualization.
-            guard let planeAnchor = anchor as? ARPlaneAnchor else { continue }
-            Task { @MainActor [onUpdateAnchorAction = arSwiftUIView.onUpdateAnchorAction] in
-                onUpdateAnchorAction?(planeAnchor)
-            }
+            let planeAnchors = anchors.compactMap { $0 as? ARPlaneAnchor }
+            onAnchorsUpdatedAction?(planeAnchors)
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/ARSwiftUIView.swift
@@ -139,21 +139,21 @@ extension ARSwiftUIView: UIViewRepresentable {
 
 extension ARSwiftUIView.Coordinator: ARSessionDelegate {
     public func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
-        // Filter new plane anchors to use for horizontal plane visualization.
-        let planeAnchors = anchors.compactMap { $0 as? ARPlaneAnchor }
-        for anchor in planeAnchors {
+        for anchor in anchors {
+            // Filter new plane anchors to use for horizontal plane visualization.
+            guard let planeAnchor = anchor as? ARPlaneAnchor else { continue }
             Task { @MainActor [onAddAnchorAction = arSwiftUIView.onAddAnchorAction] in
-                onAddAnchorAction?(anchor)
+                onAddAnchorAction?(planeAnchor)
             }
         }
     }
     
     public func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
-        // Filter updated plane anchors to use for horizontal plane visualization.
-        let planeAnchors = anchors.compactMap { $0 as? ARPlaneAnchor }
-        for anchor in planeAnchors {
+        for anchor in anchors {
+            // Filter updated plane anchors to use for horizontal plane visualization.
+            guard let planeAnchor = anchor as? ARPlaneAnchor else { continue }
             Task { @MainActor [onUpdateAnchorAction = arSwiftUIView.onUpdateAnchorAction] in
-                onUpdateAnchorAction?(anchor)
+                onUpdateAnchorAction?(planeAnchor)
             }
         }
     }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -35,7 +35,7 @@ public struct GeoTrackingSceneView: View {
     /// The closure that builds the scene view.
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
 #if os(iOS)
-    /// The proxy for the ARSwiftUIView.
+    /// The proxy for the SwiftUIARView.
     private let arViewProxy: ARSessionProvider<ARView>
 #endif
     /// The camera controller that will be set on the scene view.
@@ -56,7 +56,7 @@ public struct GeoTrackingSceneView: View {
     
     /// Creates a world scale geo-tracking scene view.
     /// - Parameters:
-    ///   - arViewProxy: The proxy for the ARSwiftUIView.
+    ///   - arViewProxy: The proxy for the SwiftUIARView.
     ///   - cameraController: The camera controller that will be set on the scene view.
     ///   - calibrationViewModel: The view model for accessing the calibration values.
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
@@ -92,7 +92,7 @@ public struct GeoTrackingSceneView: View {
         SceneViewReader { sceneViewProxy in
             ZStack {
 #if os(iOS)
-                ARSwiftUIView(sessionProvider: arViewProxy)
+                SwiftUIARView(sessionProvider: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation, initialCameraIsSet else { return }
                         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -15,6 +15,7 @@
 import ARKit
 import SwiftUI
 import ArcGIS
+import RealityKit
 
 /// A scene view that provides an augmented reality world scale experience using geo-tracking.
 @available(visionOS, unavailable)
@@ -35,7 +36,7 @@ public struct GeoTrackingSceneView: View {
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
 #if os(iOS)
     /// The proxy for the ARSwiftUIView.
-    private let arViewProxy: ARSwiftUIViewProxy
+    private let arViewProxy: ARSessionProvider<ARView>
 #endif
     /// The camera controller that will be set on the scene view.
     private let cameraController: TransformationMatrixCameraController
@@ -66,7 +67,7 @@ public struct GeoTrackingSceneView: View {
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
     ///   augmented reality video feed.
     init(
-        arViewProxy: ARSwiftUIViewProxy,
+        arViewProxy: ARSessionProvider<ARView>,
         cameraController: TransformationMatrixCameraController,
         calibrationViewModel: WorldScaleCalibrationViewModel,
         clippingDistance: Double?,
@@ -91,7 +92,7 @@ public struct GeoTrackingSceneView: View {
         SceneViewReader { sceneViewProxy in
             ZStack {
 #if os(iOS)
-                ARSwiftUIView(proxy: arViewProxy)
+                ARSwiftUIView(sessionProvider: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation, initialCameraIsSet else { return }
                         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/SwiftUIARView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/SwiftUIARView.swift
@@ -121,25 +121,25 @@ extension SwiftUIARView: UIViewRepresentable {
     }
     
     public func updateUIView(_: ARView, context: Context) {
-        context.coordinator.swiftUIARView = self
+        context.coordinator.view = self
     }
     
     public class Coordinator: NSObject {
-        var swiftUIARView: SwiftUIARView
+        var view: SwiftUIARView
         
-        init(swiftUIARView: SwiftUIARView) {
-            self.swiftUIARView = swiftUIARView
+        init(view: SwiftUIARView) {
+            self.view = view
         }
     }
     
     public func makeCoordinator() -> Coordinator {
-        return .init(swiftUIARView: self)
+        return .init(view: self)
     }
 }
 
 extension SwiftUIARView.Coordinator: ARSessionDelegate {
     public func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
-        let onAnchorsAddedAction = swiftUIARView.onAnchorsAddedAction
+        let onAnchorsAddedAction = view.onAnchorsAddedAction
         
         Task { @MainActor in
             // Filter new plane anchors to use for horizontal plane visualization.
@@ -149,7 +149,7 @@ extension SwiftUIARView.Coordinator: ARSessionDelegate {
     }
     
     public func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
-        let onAnchorsUpdatedAction = swiftUIARView.onAnchorsUpdatedAction
+        let onAnchorsUpdatedAction = view.onAnchorsUpdatedAction
         
         Task { @MainActor in
             // Filter updated plane anchors to use for horizontal plane visualization.
@@ -159,23 +159,23 @@ extension SwiftUIARView.Coordinator: ARSessionDelegate {
     }
     
     public func session(_ session: ARSession, didChange geoTrackingStatus: ARGeoTrackingStatus) {
-        swiftUIARView.onDidChangeGeoTrackingStatusAction?(session, geoTrackingStatus)
+        view.onDidChangeGeoTrackingStatusAction?(session, geoTrackingStatus)
     }
     
     public func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
-        swiftUIARView.onCameraDidChangeTrackingStateAction?(session, camera.trackingState)
+        view.onCameraDidChangeTrackingStateAction?(session, camera.trackingState)
     }
     
     public func session(_ session: ARSession, didUpdate frame: ARFrame) {
-        swiftUIARView.onDidUpdateFrameAction?(session, frame)
+        view.onDidUpdateFrameAction?(session, frame)
     }
     
     public func sessionWasInterrupted(_ session: ARSession) {
-        swiftUIARView.onSessionWasInterruptedAction?(session)
+        view.onSessionWasInterruptedAction?(session)
     }
     
     public func sessionInterruptionEnded(_ session: ARSession) {
-        swiftUIARView.onSessionWasInterruptedAction?(session)
+        view.onSessionWasInterruptedAction?(session)
     }
     
     public func sessionShouldAttemptRelocalization(_ session: ARSession) -> Bool {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -37,7 +37,7 @@ struct WorldTrackingSceneView: View {
     private let sceneViewBuilder: (SceneViewProxy) -> SceneView
     /// The time threshold in seconds between location updates to reset the world-tracking session.
     private let timeThreshold: Double
-    /// The proxy for the ARSwiftUIView.
+    /// The proxy for the SwiftUIARView.
     private let arViewProxy: ARSessionProvider<ARView>
     /// The camera controller that will be set on the scene view.
     private let cameraController: TransformationMatrixCameraController
@@ -56,7 +56,7 @@ struct WorldTrackingSceneView: View {
     
     /// Creates a world scale world-tracking scene view.
     /// - Parameters:
-    ///   - arViewProxy: The proxy for the ARSwiftUIView.
+    ///   - arViewProxy: The proxy for the SwiftUIARView.
     ///   - cameraController: The camera controller that will be set on the scene view.
     ///   - calibrationViewModel: The view model for accessing the calibration values.
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
@@ -102,7 +102,7 @@ struct WorldTrackingSceneView: View {
     var body: some View {
         SceneViewReader { sceneViewProxy in
             ZStack {
-                ARSwiftUIView(sessionProvider: arViewProxy)
+                SwiftUIARView(sessionProvider: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation, initialCameraIsSet else { return }
                         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -16,6 +16,7 @@
 import ARKit
 import SwiftUI
 import ArcGIS
+import RealityKit
 
 /// A scene view that provides an augmented reality world scale experience using world-tracking.
 struct WorldTrackingSceneView: View {
@@ -37,7 +38,7 @@ struct WorldTrackingSceneView: View {
     /// The time threshold in seconds between location updates to reset the world-tracking session.
     private let timeThreshold: Double
     /// The proxy for the ARSwiftUIView.
-    private let arViewProxy: ARSwiftUIViewProxy
+    private let arViewProxy: ARSessionProvider<ARView>
     /// The camera controller that will be set on the scene view.
     private let cameraController: TransformationMatrixCameraController
     /// A Boolean value that indicates whether the coaching overlay view is active.
@@ -68,7 +69,7 @@ struct WorldTrackingSceneView: View {
     ///   - sceneView: A closure that builds the scene view to be overlayed on top of the
     ///   augmented reality video feed.
     init(
-        arViewProxy: ARSwiftUIViewProxy,
+        arViewProxy: ARSessionProvider<ARView>,
         cameraController: TransformationMatrixCameraController,
         calibrationViewModel: WorldScaleCalibrationViewModel,
         clippingDistance: Double?,
@@ -101,7 +102,7 @@ struct WorldTrackingSceneView: View {
     var body: some View {
         SceneViewReader { sceneViewProxy in
             ZStack {
-                ARSwiftUIView(proxy: arViewProxy)
+                ARSwiftUIView(sessionProvider: arViewProxy)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation, initialCameraIsSet else { return }
                         

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -34,7 +34,7 @@ public struct WorldScaleSceneView: View {
     var calibrationViewIsHidden = false
 #if os(iOS)
     /// The proxy for the ARSwiftUIView.
-    @MainActor private let arViewProxy = ARSessionProvider<ARView>()
+    @State private var arViewProxy = ARSessionProvider<ARView>()
 #endif
     /// The view model for the calibration view.
     @StateObject private var calibrationViewModel = WorldScaleCalibrationViewModel()

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -33,7 +33,7 @@ public struct WorldScaleSceneView: View {
     /// A Boolean value that indicates whether the calibration view is hidden.
     var calibrationViewIsHidden = false
 #if os(iOS)
-    /// The proxy for the ARSwiftUIView.
+    /// The proxy for the SwiftUIARView.
     @State private var arViewProxy = ARSessionProvider<ARView>()
 #endif
     /// The view model for the calibration view.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -16,6 +16,7 @@ import ARKit
 import SwiftUI
 import ArcGIS
 import CoreLocation
+import RealityKit
 
 /// A scene view that provides an augmented reality world scale experience.
 @available(macCatalyst, unavailable)
@@ -33,7 +34,7 @@ public struct WorldScaleSceneView: View {
     var calibrationViewIsHidden = false
 #if os(iOS)
     /// The proxy for the ARSwiftUIView.
-    @State private var arViewProxy = ARSwiftUIViewProxy()
+    @MainActor private let arViewProxy = ARSessionProvider<ARView>()
 #endif
     /// The view model for the calibration view.
     @StateObject private var calibrationViewModel = WorldScaleCalibrationViewModel()
@@ -358,7 +359,7 @@ public extension WorldScaleSceneView {
     /// - Returns: The scene point corresponding to screen point.
     private func arScreenToLocation(screenPoint: CGPoint) -> Point? {
         // Use the `raycast` method to get the matrix of `screenPoint`.
-        guard let localOffsetMatrix = arViewProxy.raycast(from: screenPoint, allowing: .estimatedPlane) else { return nil }
+        guard let localOffsetMatrix = arViewProxy.arView.raycast(from: screenPoint, allowing: .estimatedPlane) else { return nil }
         let originTransformationMatrix = calibrationViewModel.cameraController.originCamera.transformationMatrix
         let scenePointMatrix = originTransformationMatrix.adding(localOffsetMatrix)
         // Create a camera from transformationMatrix and return its location.


### PR DESCRIPTION
Updates the `ARSwiftUIView` and `ARCoachingOverlay` used in world-scale and tabletop AR.

Related to `swift/8215`.

- Renames `ARSwiftUIView` `ARSwiftUIViewProxy` to `ARSessionProvider<ARView>`.
- Sets `ARSessionDelegate.sessionShouldAttemptRelocalization` to `true` and `ARCoachingOverlayViewDelegate.coachingOverlayViewDidRequestSessionReset(_:)` to enable relocalization via the coaching overlay `Start Over` button.
- Moves `raycast` method to `ARView` extension.
- Adds `activatesAutomatically(_:)` view modifier to `ARCoachingOverlay` to disable automatic activation for tabletop AR.
- Sets  `activatesAutomatically(false)` for the `TableTopSceneView` since `activatesAutomatically = true` overrides the manual setting. The coaching overlay is managed manually since it should not be shown again after the tabletop content is placed.