### PR TITLE
Add Scalebar preview (#976)

### DIFF
--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -198,3 +198,36 @@ public struct Scalebar: View {
         .environment(\.scalebarSettings, settings)
     }
 }
+
+#Preview {
+    @Previewable @State var spatialReference: SpatialReference?
+    @Previewable @State var unitsPerPoint: Double?
+    @Previewable @State var viewpoint: Viewpoint?
+    @Previewable @State var style = ScalebarStyle.alternatingBar
+
+    VStack {
+        Scalebar(
+            maxWidth: 175,
+            spatialReference: spatialReference,
+            style: style,
+            unitsPerPoint: unitsPerPoint,
+            viewpoint: viewpoint
+        )
+        .onAppear {
+            unitsPerPoint = 99689
+            viewpoint = .init(center: .init(x: 0, y: 0, spatialReference: .webMercator), scale: 376777662)
+            spatialReference = .webMercator
+        }
+        .padding()
+
+        Form {
+            Picker("Style", selection: $style) {
+                Text("Alternating Bar").tag(ScalebarStyle.alternatingBar)
+                Text("Bar").tag(ScalebarStyle.bar)
+                Text("Dual Unit Line").tag(ScalebarStyle.dualUnitLine)
+                Text("Graduated Line").tag(ScalebarStyle.graduatedLine)
+                Text("Line").tag(ScalebarStyle.line)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
  This PR adds a `#Preview` to `Scalebar.swift` to allow quick visual validation of changes without needing to build and run the full app, addressing issue #976 .

  ## What changed
  - Added a `#Preview` block to `Scalebar.swift`
  - Seeds required map state (`spatialReference`, `unitsPerPoint`, `viewpoint`) via `.onAppear`
  - Includes a `Picker` to interactively switch between all five `ScalebarStyle` cases

  ## Why this change
  - Removes the need to build and run the full app to validate visual changes
  - `Scalebar` has no internal state, so map inputs must be seeded manually in the preview
  - Enables faster iteration without any network or map dependency