### PR TITLE
Refactor `WorldScaleCalibrationViewModel`

### DIFF
--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/Calibration.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/Calibration.swift
@@ -1,0 +1,59 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+public import Observation
+
+/// Stores incremental and total calibration corrections for heading and
+/// elevation.
+@available(macCatalyst, unavailable)
+@available(visionOS, unavailable)
+@Observable public final class Calibration {
+    /// The most recently applied incremental heading correction in degrees.
+    private(set) var headingCorrection = 0.0
+    /// The most recently applied incremental elevation correction in meters.
+    private(set) var elevationCorrection = 0.0
+    
+    /// The total heading correction.
+    public private(set) var totalHeadingCorrection = 0.0
+    /// The total elevation correction.
+    public private(set) var totalElevationCorrection = 0.0
+    
+    /// Creates a new calibration state with zeroed corrections.
+    init() {}
+}
+
+@available(macCatalyst, unavailable)
+@available(visionOS, unavailable)
+extension Calibration {
+    /// Proposes a new heading correction.
+    ///
+    /// This will limit the total heading correction to -180...180.
+    /// - Parameter headingCorrection: The proposed heading correction in
+    /// degrees. Positive values will rotate the view to the right, and negative
+    /// values will rotate the view to the left.
+    func proposeHeadingCorrection(_ headingCorrection: Double) {
+        let newTotalHeadingCorrection = (totalHeadingCorrection + headingCorrection)
+            .clamped(to: -180...180)
+        self.headingCorrection = newTotalHeadingCorrection - totalHeadingCorrection
+        totalHeadingCorrection = newTotalHeadingCorrection
+    }
+    
+    /// Proposes a new elevation correction.
+    /// - Parameter elevationCorrection: The proposed elevation correction in
+    /// meters.
+    func proposeElevationCorrection(_ elevationCorrection: Double) {
+        self.elevationCorrection = elevationCorrection
+        totalElevationCorrection += elevationCorrection
+    }
+}

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/CalibrationView.swift
@@ -12,66 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ARKit
 import SwiftUI
-import ArcGIS
-
-/// A view model that stores state information for the calibration.
-@MainActor
-class WorldScaleCalibrationViewModel: ObservableObject {
-    /// The total heading correction.
-    @Published
-    private(set) var totalHeadingCorrection: Double = 0
-    
-    /// The total elevation correction.
-    @Published
-    private(set) var totalElevationCorrection: Double = 0
-    
-    /// The camera controller for which corrections will be applied.
-    let cameraController = TransformationMatrixCameraController()
-    
-    /// Creates a calibration view model.
-    init() {
-        cameraController.translationFactor = 1
-    }
-    
-    /// Proposes a heading correction.
-    /// This will limit the total heading correction to -180...180.
-    fileprivate func propose(headingCorrection: Double) {
-        let newTotalHeadingCorrection = (totalHeadingCorrection + headingCorrection)
-            .clamped(to: -180...180)
-        let allowedHeadingCorrection = newTotalHeadingCorrection - totalHeadingCorrection
-        totalHeadingCorrection = newTotalHeadingCorrection
-        
-        // Update camera controller.
-        let originCamera = cameraController.originCamera
-        cameraController.originCamera = originCamera.rotatedTo(
-            heading: originCamera.heading + allowedHeadingCorrection,
-            pitch: originCamera.pitch,
-            roll: originCamera.roll
-        )
-    }
-    
-    /// Proposes an elevation correction.
-    fileprivate func propose(elevationCorrection: Double) {
-        totalElevationCorrection += elevationCorrection
-        
-        // Update camera controller.
-        cameraController.originCamera = cameraController.originCamera.elevated(by: elevationCorrection)
-    }
-}
 
 @available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 extension WorldScaleSceneView {
     /// A view that allows the user to calibrate the heading of the scene view camera controller.
     struct CalibrationView: View {
-        @ObservedObject
-        var viewModel: WorldScaleCalibrationViewModel
-        
+        @Bindable var calibration: Calibration
         /// A Boolean value that indicates if the user is presenting the calibration view.
-        @Binding
-        var isPresented: Bool
+        @Binding var isPresented: Bool
         
         /// A number format style for signed values with their fractional component removed.
         private let numberFormat = FloatingPointFormatStyle<Double>.number
@@ -80,12 +30,12 @@ extension WorldScaleSceneView {
         
         /// The total heading correction measurement in degrees.
         private var totalHeadingCorrectionMeasurement: Measurement<UnitAngle> {
-            Measurement<UnitAngle>(value: viewModel.totalHeadingCorrection, unit: .degrees)
+            Measurement<UnitAngle>(value: calibration.totalHeadingCorrection, unit: .degrees)
         }
         
         /// The total elevation correction measurement in meters.
         private var totalElevationCorrectionMeasurement: Measurement<UnitLength> {
-            Measurement<UnitLength>(value: viewModel.totalElevationCorrection, unit: .meters)
+            Measurement<UnitLength>(value: calibration.totalElevationCorrection, unit: .meters)
         }
         
         var body: some View {
@@ -128,14 +78,14 @@ extension WorldScaleSceneView {
                             Spacer()
                         }
                     } onIncrement: {
-                        viewModel.propose(headingCorrection: 1)
+                        calibration.proposeHeadingCorrection(1)
                     } onDecrement: {
-                        viewModel.propose(headingCorrection: -1)
+                        calibration.proposeHeadingCorrection(-1)
                     }
                 }
                 Joyslider()
                     .onChanged { delta in
-                        viewModel.propose(headingCorrection: delta)
+                        calibration.proposeHeadingCorrection(delta)
                     }
             }
         }
@@ -154,14 +104,14 @@ extension WorldScaleSceneView {
                             Spacer()
                         }
                     } onIncrement: {
-                        viewModel.propose(elevationCorrection: 1)
+                        calibration.proposeElevationCorrection(1)
                     } onDecrement: {
-                        viewModel.propose(elevationCorrection: -1)
+                        calibration.proposeElevationCorrection(-1)
                     }
                 }
                 Joyslider()
                     .onChanged { delta in
-                        viewModel.propose(elevationCorrection: delta)
+                        calibration.proposeElevationCorrection(delta)
                     }
             }
         }
@@ -203,11 +153,12 @@ private extension WorldScaleSceneView.CalibrationView {
     }
 }
 
-#if !os(visionOS) && !targetEnvironment(macCatalyst)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 #Preview {
+    @Previewable @State var isPresented = true
     WorldScaleSceneView.CalibrationView(
-        viewModel: WorldScaleCalibrationViewModel(),
-        isPresented: .constant(true)
+        calibration: Calibration(),
+        isPresented: $isPresented
     )
 }
 #endif

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/GeoTrackingSceneView.swift
@@ -18,12 +18,13 @@ import ArcGIS
 import RealityKit
 
 /// A scene view that provides an augmented reality world scale experience using geo-tracking.
+@available(macCatalyst, unavailable)
 @available(visionOS, unavailable)
 public struct GeoTrackingSceneView: View {
     /// A Boolean value indicating if the camera was initially set.
     @Binding var initialCameraIsSet: Bool
     /// The view model for the calibration view.
-    @ObservedObject private var calibrationViewModel: WorldScaleCalibrationViewModel
+    @Bindable private var calibration: Calibration
 #if os(iOS)
     /// The geo-tracking configuration for the AR session.
     private let configuration = ARGeoTrackingConfiguration()
@@ -58,7 +59,7 @@ public struct GeoTrackingSceneView: View {
     /// - Parameters:
     ///   - arViewProxy: The proxy for the ARSwiftUIView.
     ///   - cameraController: The camera controller that will be set on the scene view.
-    ///   - calibrationViewModel: The view model for accessing the calibration values.
+    ///   - calibration: The view model for accessing the calibration values.
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
     ///   of `nil` means that no data will be clipped.
     ///   - initialCameraIsSet: A Boolean value that indicates whether the initial camera is set for the scene view.
@@ -69,7 +70,7 @@ public struct GeoTrackingSceneView: View {
     init(
         arViewProxy: ARSessionProvider<ARView>,
         cameraController: TransformationMatrixCameraController,
-        calibrationViewModel: WorldScaleCalibrationViewModel,
+        calibration: Calibration,
         clippingDistance: Double?,
         initialCameraIsSet: Binding<Bool>,
         calibrationViewIsPresented: Bool,
@@ -78,7 +79,7 @@ public struct GeoTrackingSceneView: View {
     ) {
         self.arViewProxy = arViewProxy
         self.cameraController = cameraController
-        self.calibrationViewModel = calibrationViewModel
+        self.calibration = calibration
         self.cameraController.clippingDistance = clippingDistance
         _initialCameraIsSet = initialCameraIsSet
         self.calibrationViewIsPresented = calibrationViewIsPresented
@@ -165,11 +166,14 @@ public struct GeoTrackingSceneView: View {
     ///   - heading: The heading for the camera.
     ///   - altitude: The altitude for the camera.
     private func updateCameraController(location: Location, heading: Double, altitude: Double) {
+        let correctedAltitude = altitude + calibration.totalElevationCorrection
+        let correctedHeading = heading + calibration.totalHeadingCorrection
+        
         cameraController.originCamera = Camera(
             latitude: location.position.y,
             longitude: location.position.x,
-            altitude: altitude,
-            heading: heading,
+            altitude: correctedAltitude,
+            heading: correctedHeading,
             pitch: 90,
             roll: 0
         )

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/WorldTrackingSceneView.swift
@@ -19,11 +19,13 @@ import ArcGIS
 import RealityKit
 
 /// A scene view that provides an augmented reality world scale experience using world-tracking.
+@available(macCatalyst, unavailable)
+@available(visionOS, unavailable)
 struct WorldTrackingSceneView: View {
     /// A Boolean value indicating if the camera was initially set.
     @Binding var initialCameraIsSet: Bool
     /// The view model for the calibration view.
-    @ObservedObject private var calibrationViewModel: WorldScaleCalibrationViewModel
+    @Bindable private var calibration: Calibration
     /// The configuration for the AR session.
     private let configuration: ARConfiguration
     /// The distance threshold in meters between camera and device location to reset the
@@ -58,7 +60,7 @@ struct WorldTrackingSceneView: View {
     /// - Parameters:
     ///   - arViewProxy: The proxy for the ARSwiftUIView.
     ///   - cameraController: The camera controller that will be set on the scene view.
-    ///   - calibrationViewModel: The view model for accessing the calibration values.
+    ///   - calibration: The view model for accessing the calibration values.
     ///   - clippingDistance: Determines the clipping distance in meters around the camera. A value
     ///   of `nil` means that no data will be clipped.
     ///   - distanceThreshold: The distance threshold for the camera to be re-aligned with the GPS.
@@ -71,7 +73,7 @@ struct WorldTrackingSceneView: View {
     init(
         arViewProxy: ARSessionProvider<ARView>,
         cameraController: TransformationMatrixCameraController,
-        calibrationViewModel: WorldScaleCalibrationViewModel,
+        calibration: Calibration,
         clippingDistance: Double?,
         distanceThreshold: Double = 2.0,
         initialCameraIsSet: Binding<Bool>,
@@ -82,7 +84,7 @@ struct WorldTrackingSceneView: View {
     ) {
         self.arViewProxy = arViewProxy
         self.cameraController = cameraController
-        self.calibrationViewModel = calibrationViewModel
+        self.calibration = calibration
         self.cameraController.clippingDistance = clippingDistance
         self.distanceThreshold = distanceThreshold
         _initialCameraIsSet = initialCameraIsSet
@@ -196,8 +198,8 @@ struct WorldTrackingSceneView: View {
             cameraController.originCamera = Camera(
                 latitude: location.position.y,
                 longitude: location.position.x,
-                altitude: altitude + calibrationViewModel.totalElevationCorrection,
-                heading: calibrationViewModel.totalHeadingCorrection,
+                altitude: altitude + calibration.totalElevationCorrection,
+                heading: calibration.totalHeadingCorrection,
                 pitch: 90,
                 roll: 0
             )

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -100,6 +100,20 @@ public struct WorldScaleSceneView: View {
             }
 #endif
         }
+        .onChange(of: calibration.headingCorrection) { _, newHeadingCorrection in
+            // Update camera controller.
+            let originCamera = cameraController.originCamera
+            cameraController.originCamera = originCamera.rotatedTo(
+                heading: originCamera.heading + newHeadingCorrection,
+                pitch: originCamera.pitch,
+                roll: originCamera.roll
+            )
+        }
+        .onChange(of: calibration.elevationCorrection) { _, newElevationCorrection in
+            // Update camera controller.
+            cameraController.originCamera = cameraController.originCamera
+                .elevated(by: newElevationCorrection)
+        }
         .onChange(of: clippingDistance, initial: true) {
             cameraController.clippingDistance = clippingDistance
         }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -36,8 +36,9 @@ public struct WorldScaleSceneView: View {
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSessionProvider<ARView>()
 #endif
-    /// The view model for the calibration view.
-    @StateObject private var calibrationViewModel = WorldScaleCalibrationViewModel()
+    /// A Boolean value that indicates whether the coaching overlay view is
+    /// active.
+    @State private var calibration = Calibration()
     /// A Boolean value that indicates whether the geo-tracking configuration is available.
     @State private var geoTrackingIsAvailable = true
     /// A Boolean value that indicates whether the initial camera is set for the scene view.
@@ -48,6 +49,8 @@ public struct WorldScaleSceneView: View {
     @State private var locationDataSource = SystemLocationDataSource()
     /// The error from the view.
     @State private var error: Error?
+    /// The camera controller for this scene view.
+    @State private var cameraController = TransformationMatrixCameraController()
     /// The closure to call upon a single tap.
     private var onSingleTapGestureAction: ((CGPoint, Point?) -> Void)? = nil
     /// The closure to perform when the `isCalibrating` property has changed.
@@ -97,11 +100,8 @@ public struct WorldScaleSceneView: View {
             }
 #endif
         }
-        .onAppear {
-            calibrationViewModel.cameraController.clippingDistance = clippingDistance
-        }
-        .onChange(of: clippingDistance) {
-            calibrationViewModel.cameraController.clippingDistance = clippingDistance
+        .onChange(of: clippingDistance, initial: true) {
+            cameraController.clippingDistance = clippingDistance
         }
         .onDisappear {
             Task { await locationDataSource.stop() }
@@ -153,7 +153,7 @@ public struct WorldScaleSceneView: View {
         }
         .overlay(alignment: .bottom) {
             if isCalibrating {
-                CalibrationView(viewModel: calibrationViewModel, isPresented: $isCalibrating)
+                CalibrationView(calibration: calibration, isPresented: $isCalibrating)
                     .padding(.bottom)
             }
         }
@@ -168,8 +168,8 @@ public struct WorldScaleSceneView: View {
     @ViewBuilder private var geoTrackingSceneView: some View {
         GeoTrackingSceneView(
             arViewProxy: arViewProxy,
-            cameraController: calibrationViewModel.cameraController,
-            calibrationViewModel: calibrationViewModel,
+            cameraController: cameraController,
+            calibration: calibration,
             clippingDistance: clippingDistance,
             initialCameraIsSet: $initialCameraIsSet,
             calibrationViewIsPresented: isCalibrating,
@@ -192,8 +192,8 @@ public struct WorldScaleSceneView: View {
     @ViewBuilder private var worldTrackingSceneView : some View {
         WorldTrackingSceneView(
             arViewProxy: arViewProxy,
-            cameraController: calibrationViewModel.cameraController,
-            calibrationViewModel: calibrationViewModel,
+            cameraController: cameraController,
+            calibration: calibration,
             clippingDistance: clippingDistance,
             initialCameraIsSet: $initialCameraIsSet,
             calibrationViewIsPresented: isCalibrating,
@@ -360,7 +360,7 @@ public extension WorldScaleSceneView {
     private func arScreenToLocation(screenPoint: CGPoint) -> Point? {
         // Use the `raycast` method to get the matrix of `screenPoint`.
         guard let localOffsetMatrix = arViewProxy.arView.raycast(from: screenPoint, allowing: .estimatedPlane) else { return nil }
-        let originTransformationMatrix = calibrationViewModel.cameraController.originCamera.transformationMatrix
+        let originTransformationMatrix = cameraController.originCamera.transformationMatrix
         let scenePointMatrix = originTransformationMatrix.adding(localOffsetMatrix)
         // Create a camera from transformationMatrix and return its location.
         return Camera(transformationMatrix: scenePointMatrix).location

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -36,8 +36,7 @@ public struct WorldScaleSceneView: View {
     /// The proxy for the ARSwiftUIView.
     @State private var arViewProxy = ARSessionProvider<ARView>()
 #endif
-    /// A Boolean value that indicates whether the coaching overlay view is
-    /// active.
+    /// The view model for the calibration view.
     @State private var calibration = Calibration()
     /// A Boolean value that indicates whether the geo-tracking configuration is available.
     @State private var geoTrackingIsAvailable = true


### PR DESCRIPTION
Renames it to `Calibration` and decouples it from the camera controller. Also makes it public and observable. This is preparation for the incoming VPS-related changes to `WorldScaleSceneView`.