### PR TITLE
fe: Only allow layers to be snap sources

### DIFF
--- a/Sources/ArcGISToolkit/Components/GeometryEditorToolbar/SnapSettingsView.swift
+++ b/Sources/ArcGISToolkit/Components/GeometryEditorToolbar/SnapSettingsView.swift
@@ -22,7 +22,7 @@ struct SnapSettingsView: View {
     
     /// The view models for the root `SnapSourceSettingsToggle` views in the outline group.
     @State private var rootSourceSettingsModels: [SnapSourceSettingsToggle.Model] = []
-    /// A Boolean value indicating whether the settings allow snapping to features and graphics.
+    /// A Boolean value indicating whether the settings allow snapping to features.
     @State private var snapsToFeatures = false
     /// A Boolean value indicating whether the settings allow snapping to geometry guides.
     @State private var snapsToGeometryGuides = false
@@ -47,10 +47,10 @@ struct SnapSettingsView: View {
                 
                 Toggle(isOn: $snapsToFeatures.animation()) {
                     Text(
-                        "Snap to Features and Graphics",
+                        "Snap to Features",
                         bundle: .toolkitModule,
                         comment: """
-                                A label for a toggle that enables snapping to features and graphics,
+                                A label for a toggle that enables snapping to features,
                                 which allows vertices and edges of existing features to be snapped to.
                                 """
                     )
@@ -79,9 +79,10 @@ struct SnapSettingsView: View {
             }
             .onChange(of: ObjectIdentifier(settings), initial: true) {
                 // Sets up view's state properties using settings' property values.
-                rootSourceSettingsModels = settings.sourceSettings.map(
-                    SnapSourceSettingsToggle.Model.init(settings:)
-                )
+                // Only allows layers to be snap sources.
+                rootSourceSettingsModels = settings.sourceSettings
+                    .filter { $0.source is LayerContent }
+                    .map(SnapSourceSettingsToggle.Model.init(settings:))
                 snapsToFeatures = settings.snapsToFeatures
                 snapsToGeometryGuides = settings.snapsToGeometryGuides
             }
@@ -148,8 +149,6 @@ private struct SnapSourceSettingsToggle: View {
         let name: String? = switch source {
         case let layer as LayerContent:
             layer.name
-        case let overlay as GraphicsOverlay:
-            overlay.id
         default:
             nil
         }

--- a/Sources/ArcGISToolkit/Components/GeometryEditorToolbar/SnapSettingsView.swift
+++ b/Sources/ArcGISToolkit/Components/GeometryEditorToolbar/SnapSettingsView.swift
@@ -83,6 +83,11 @@ struct SnapSettingsView: View {
                 rootSourceSettingsModels = settings.sourceSettings
                     .filter { $0.source is LayerContent }
                     .map(SnapSourceSettingsToggle.Model.init(settings:))
+                // Disable snapping on other snap sources that aren't exposed
+                // in the UI to avoid confusion.
+                settings.sourceSettings
+                    .filter { !($0.source is LayerContent) }
+                    .forEach { $0.isEnabled = false }
                 snapsToFeatures = settings.snapsToFeatures
                 snapsToGeometryGuides = settings.snapsToGeometryGuides
             }


### PR DESCRIPTION
From a comment on June 9th

> We don't need the option to snap to graphics. That's not a common scenario, plus I don't know if end users will understand our current terminology of "graphics overlay". Best to avoid it and limit it to layers.

This PR removes any mention to graphics from the snap settings view, and filter the snap sources to only allow layers.

- For feature layers

You can test with code in #1450 with `map.loadSettings.featureTilingMode = .enabledWithFullResolutionWhenSupported` on so that lines and polygons can also be snap sources.

- For graphics overlay

You can test with #1451 and see that graphics overlay doesn't show up as a snap source.