### PR TITLE
fe: Add snap sources tests

### DIFF
--- a/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
+++ b/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
@@ -45,4 +45,24 @@ struct GeometryEditorToolbarTests {
         }
         #expect(!model.isStarted)
     }
+    
+    @Test
+    func snapSourcesAllContainsAllSupportedTypes() {
+        let all = GeometryEditorToolbar.SnapSources.all
+        
+        #expect(all.contains(.featureLayer))
+        #expect(all.contains(.graphicsOverlay))
+        #expect(all.contains(.subtypeFeatureLayer))
+        #expect(all.contains(.subtypeSublayer))
+    }
+    
+    @Test
+    func snapSourcesLayersExcludesGraphicsOverlay() {
+        let layers = GeometryEditorToolbar.SnapSources.layers
+        
+        #expect(layers.contains(.featureLayer))
+        #expect(layers.contains(.subtypeFeatureLayer))
+        #expect(layers.contains(.subtypeSublayer))
+        #expect(!layers.contains(.graphicsOverlay))
+    }
 }

--- a/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
+++ b/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
@@ -50,19 +50,12 @@ struct GeometryEditorToolbarTests {
     func snapSourcesAllContainsAllSupportedTypes() {
         let all = GeometryEditorToolbar.SnapSources.all
         
-        #expect(all.contains(.featureLayer))
-        #expect(all.contains(.graphicsOverlay))
-        #expect(all.contains(.subtypeFeatureLayer))
-        #expect(all.contains(.subtypeSublayer))
+#expect(all == [.featureLayer, .graphicsOverlay, .subtypeFeatureLayer, .subtypeSublayer])
     }
     
     @Test
     func snapSourcesLayersExcludesGraphicsOverlay() {
         let layers = GeometryEditorToolbar.SnapSources.layers
         
-        #expect(layers.contains(.featureLayer))
-        #expect(layers.contains(.subtypeFeatureLayer))
-        #expect(layers.contains(.subtypeSublayer))
-        #expect(!layers.contains(.graphicsOverlay))
-    }
+#expect(layers == [.featureLayer, .subtypeFeatureLayer, .subtypeSublayer])
 }

--- a/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
+++ b/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
@@ -57,4 +57,13 @@ struct GeometryEditorToolbarTests {
         let layers = GeometryEditorToolbar.SnapSources.layers
         #expect(layers == [.featureLayer, .subtypeFeatureLayer, .subtypeSublayer])
     }
+
+    @Test
+    func snapSourcesContains() {
+        let all = GeometryEditorToolbar.SnapSources.all
+        let layers = GeometryEditorToolbar.SnapSources.layers
+        let graphicsOverlay = GraphicsOverlay()
+        #expect(all.contains(source: graphicsOverlay))
+        #expect(!layers.contains(source: graphicsOverlay))
+    }
 }

--- a/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
+++ b/Tests/ArcGISToolkitTests/GeometryEditorToolbarTests.swift
@@ -49,13 +49,12 @@ struct GeometryEditorToolbarTests {
     @Test
     func snapSourcesAllContainsAllSupportedTypes() {
         let all = GeometryEditorToolbar.SnapSources.all
-        
-#expect(all == [.featureLayer, .graphicsOverlay, .subtypeFeatureLayer, .subtypeSublayer])
+        #expect(all == [.featureLayer, .graphicsOverlay, .subtypeFeatureLayer, .subtypeSublayer])
     }
     
     @Test
-    func snapSourcesLayersExcludesGraphicsOverlay() {
+    func snapSourcesLayersOnlyContainLayers() {
         let layers = GeometryEditorToolbar.SnapSources.layers
-        
-#expect(layers == [.featureLayer, .subtypeFeatureLayer, .subtypeSublayer])
+        #expect(layers == [.featureLayer, .subtypeFeatureLayer, .subtypeSublayer])
+    }
 }


### PR DESCRIPTION
Add unit tests for the `GeometryEditorToolbar.SnapSources` OptionSet.

There is no unit test for the Feature Editor Toolbar due to its properties and style initializers being private.