### PR TITLE
`FeatureFormView` - Fix navigation title in inspector

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/EmbeddedFeatureFormViewModel.swift
@@ -47,7 +47,7 @@ final class EmbeddedFeatureFormViewModel {
     var previouslyFocusedElements = [FormElement]()
     
     /// The title of the feature form view.
-    var title = ""
+    var title: String
     
     /// The list of visible form elements.
     var visibleElements: [FormElement] {
@@ -86,6 +86,10 @@ final class EmbeddedFeatureFormViewModel {
     /// - Parameter featureForm: The feature form defining the editing experience.
     public init(featureForm: FeatureForm) {
         self.featureForm = featureForm
+        // Prevents a bug where the view's navigation title won't always appear
+        // when the view is shown in an inspector.
+        self.title = featureForm.title
+        
         evaluateExpressions()
         monitorEdits()
         monitorVisibility()


### PR DESCRIPTION
## Description

This PR fixes a bug with the `FeatureFormView` where that navigation title wouldn't always display when the view was shown in an inspector. Discovered while implementing https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1470.


## How To Test

Using the example to verify everything is still working is probably sufficient. If you want to reproduce the bug, run the code below and try opening a form a couple of times. The bug happens the most on iPad.

<details><summary>Reproducible Code</summary><p>

```swift
import ArcGIS
import ArcGISToolkit
import SwiftUI

struct ContentView: View {
    @State private var map = Map(
        url: URL(string: "https://www.arcgis.com/apps/mapviewer/index.html?webmap=f72207ac170a40d8992b7a3507b44fad")!
    )!
    @State private var featureForm: FeatureForm?
    @State private var isPresented = false
    
    var body: some View {
        NavigationStack {
            MapViewReader { proxy in
                MapView(map: map)
                    .onSingleTapGesture { screenPoint, _ in
                        Task {
                            let results = try! await proxy.identifyLayers(
                                screenPoint: screenPoint,
                                tolerance: 10
                            )
                            let feature = results.first?.geoElements.first as? ArcGISFeature
                            featureForm = feature.map(FeatureForm.init)
                            isPresented = featureForm != nil
                        }
                    }
            }
        }
        .inspector(isPresented: $isPresented) {
            if let featureForm {
                FeatureFormView(root: featureForm, isPresented: $isPresented)
            }
        }
    }
}
```

</p></details>


## Screenshots

|Before|After|
|:-:|:-:|
| <img width="2360" height="1640" alt="Screenshot iPad (A16) 06-16-2026 at 2 28 25 PM" src="https://github.com/user-attachments/assets/4e12cb89-506d-4b6e-b95f-371efab5d9c2" /> | <img width="2360" height="1640" alt="Screenshot iPad (A16) 06-16-2026 at 2 27 47 PM" src="https://github.com/user-attachments/assets/80ee5265-f46b-4192-bf94-eaf9d11de4f4" /> |


## vTest

- `vtest/job/interface/4690/`