### PR TITLE
Change `SceneViewProxy` methods to take camera

### DIFF
--- a/CustomVPSProviderExample/CustomVPSProviderExample/CustomWorldTrackingCameraFeedView.swift
+++ b/CustomVPSProviderExample/CustomVPSProviderExample/CustomWorldTrackingCameraFeedView.swift
@@ -52,14 +52,16 @@ struct CustomWorldTrackingCameraFeedView: View {
                     return
                 }
                 
+                let camera = frame.camera
+                
                 if context.isLocalized {
                     updateCameraController(
-                        camera: frame.camera,
+                        camera: camera,
                         geospatialTransform: earth.cameraGeospatialTransform
                     )
                     
                     context.sceneView.setFieldOfView(
-                        for: frame,
+                        for: camera,
                         orientation: interfaceOrientation
                     )
                     

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Apple World Tracking/AppleWorldTrackingCameraFeedView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Apple World Tracking/AppleWorldTrackingCameraFeedView.swift
@@ -57,14 +57,16 @@ public struct AppleWorldTrackingCameraFeedView: View {
             .onDidUpdateFrame { _, frame in
                 guard let interfaceOrientation, context.isLocalized else { return }
                 
+                let camera = frame.camera
+                
                 context.sceneView.updateCamera(
-                    frame: frame,
+                    camera: camera,
                     cameraController: context.cameraController,
                     orientation: interfaceOrientation,
                     initialTransformation: .identity
                 )
                 context.sceneView.setFieldOfView(
-                    for: frame,
+                    for: camera,
                     orientation: interfaceOrientation
                 )
             }

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -147,9 +147,9 @@ public struct FlyoverSceneView: View {
                 }
                 .onDisappear { session.pause() }
                 .onChange(of: session.currentFrame) {
-                    guard let frame = session.currentFrame, let interfaceOrientation else { return }
+                    guard let camera = session.currentFrame?.camera, let interfaceOrientation else { return }
                     sceneViewProxy.updateCamera(
-                        frame: frame,
+                        camera: camera,
                         cameraController: cameraController,
                         orientation: interfaceOrientation
                     )

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -102,14 +102,17 @@ public struct TableTopSceneView: View {
                 SwiftUIARView(sessionProvider: arSessionProvider)
                     .onDidUpdateFrame { _, frame in
                         guard let interfaceOrientation else { return }
+                        
+                        let camera = frame.camera
+                        
                         sceneViewProxy.updateCamera(
-                            frame: frame,
+                            camera: camera,
                             cameraController: cameraController,
                             orientation: interfaceOrientation,
                             initialTransformation: initialTransformation
                         )
                         sceneViewProxy.setFieldOfView(
-                            for: frame,
+                            for: camera,
                             orientation: interfaceOrientation
                         )
                     }

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
@@ -12,25 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
 import ArcGIS
 import ARKit
+import Foundation
 import SwiftUI
 
 #if os(iOS)
 public extension SceneViewProxy {
-    /// Updates the scene view's camera for a given augmented reality frame.
+    /// Updates the scene view's camera for a given augmented reality camera.
     /// - Parameters:
-    ///   - frame: The current AR frame.
-    ///   - cameraController: The current camera controller assigned to the scene view.
+    ///   - camera: The current AR camera.
+    ///   - cameraController: The current camera controller assigned to the
+    ///   scene view.
     ///   - orientation: The interface orientation.
+    ///   - initialTransformation: The initial transformation matrix.
     func updateCamera(
-        frame: ARFrame,
+        camera: ARCamera,
         cameraController: TransformationMatrixCameraController,
         orientation: InterfaceOrientation,
         initialTransformation: TransformationMatrix? = nil
     ) {
-        let transform = frame.camera.transform(for: orientation)
+        let transform = camera.transform(for: orientation)
         let quaternion = simd_quatf(transform)
         let transformationMatrix = TransformationMatrix.normalized(
             quaternionX: Double(quaternion.vector.x),
@@ -43,19 +45,19 @@ public extension SceneViewProxy {
         )
         
         // Set the matrix on the camera controller.
-        if let initialTransformation {
-            cameraController.transformationMatrix = initialTransformation.adding(transformationMatrix)
+        cameraController.transformationMatrix = if let initialTransformation {
+            initialTransformation.adding(transformationMatrix)
         } else {
-            cameraController.transformationMatrix = transformationMatrix
+            transformationMatrix
         }
     }
     
-    /// Sets the field of view for the scene view's camera for a given augmented reality frame.
+    /// Sets the field of view for the scene view's camera for a given augmented
+    /// reality camera.
     /// - Parameters:
-    ///   - frame: The current AR frame.
+    ///   - camera: The current AR camera.
     ///   - orientation: The interface orientation.
-    func setFieldOfView(for frame: ARFrame, orientation: InterfaceOrientation) {
-        let camera = frame.camera
+    func setFieldOfView(for camera: ARCamera, orientation: InterfaceOrientation) {
         let intrinsics = camera.intrinsics
         let imageResolution = camera.imageResolution
         
@@ -73,7 +75,8 @@ public extension SceneViewProxy {
 
 private extension ARCamera {
     /// The transform rotated for a particular interface orientation.
-    /// - Parameter orientation: The interface orientation that the transform is appropriate for.
+    /// - Parameter orientation: The interface orientation that the transform is
+    /// appropriate for.
     func transform(for orientation: InterfaceOrientation) -> simd_float4x4 {
         switch orientation {
         case .portrait:


### PR DESCRIPTION
They only used the frame to get at the camera, so it makes more sense for them to take the camera directly.