### PR TITLE
Fix `UtilityTraceFunction`-related errors

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -480,7 +480,7 @@ public struct UtilityNetworkTrace: View {
                                     Text(item.function.networkAttribute.name)
                                     Spacer()
                                     VStack(alignment: .trailing) {
-                                        Text(item.function.functionType.title)
+                                        Text(item.function.kind.title)
                                             .font(.caption)
                                             .foregroundStyle(.secondary)
                                         if let result = item.result as? Double {

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/UtilityTraceFunction.Kind.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/UtilityTraceFunction.Kind.swift
@@ -14,7 +14,7 @@
 
 import ArcGIS
 
-extension UtilityTraceFunction.FunctionType {
+extension UtilityTraceFunction.Kind {
     var title: String {
         switch self {
         case .add: return "Add"

--- a/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
+++ b/Tests/ArcGISToolkitTests/UtilityNetworkTraceViewModelTests.swift
@@ -257,7 +257,7 @@ final class UtilityNetworkTraceViewModelTests: XCTestCase {
         XCTAssertTrue(success)
         XCTAssertFalse(viewModel.canRunTrace)
         XCTAssertEqual(viewModel.completedTraces.first?.functionOutputs.count, 6)
-        XCTAssertEqual(functionOutput.function.functionType, .add)
+        XCTAssertEqual(functionOutput.function.kind, .add)
         XCTAssertEqual(functionOutput.function.networkAttribute.name, "Service Load")
         XCTAssertEqual(functionOutput.result as? Double, 600.0)
     }


### PR DESCRIPTION
Errors were a result of API changes introduced in swift/8304.