### PR TITLE
`FeatureEditor` - Add viewpoint centering support

### DIFF
--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -39,9 +39,20 @@ struct ExampleMapView: View {
     /// The point on the screen where the user tapped.
     @State private var tapPoint: CGPoint?
     
+    /// Insets that indicate the area obscured by the feature editor's UI to the map view.
+    private var contentInsets: EdgeInsets {
+        if UIDevice.current.userInterfaceIdiom == .phone, featureToEdit != nil {
+            // Accounts for the feature editor inspector and view on iPhone.
+            EdgeInsets(top: 0, leading: 0, bottom: 400, trailing: 75)
+        } else {
+            EdgeInsets()
+        }
+    }
+    
     var body: some View {
         MapViewReader { mapViewProxy in
             MapView(map: map)
+                .contentInsets(contentInsets)
                 .geometryEditor(geometryEditor)
                 .onSingleTapGesture { screenPoint, _ in
                     guard tapPoint == nil else { return }
@@ -65,15 +76,16 @@ struct ExampleMapView: View {
                         print("Identify error:", error)
                     }
                 }
-        }
-        .overlay(alignment: .topTrailing) {
-            // The feature editor needs to be placed below the
-            // `featureEditorInspector` modifier in the view hierarchy.
-            FeatureEditor(
-                $featureToEdit,
-                geometryEditor: geometryEditor
-            )
-            .padding()
+                .overlay(alignment: .topTrailing) {
+                    // The feature editor needs to be placed below the
+                    // `featureEditorInspector` modifier in the view hierarchy.
+                    FeatureEditor(
+                        $featureToEdit,
+                        geometryEditor: geometryEditor,
+                        mapViewProxy: mapViewProxy
+                    )
+                    .padding()
+                }
         }
         .task {
             do {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -102,10 +102,7 @@ public struct FeatureEditor: View {
                 await model.monitorGeometryEditorStreams()
             }
             .task(id: model.viewpointGeometry, setViewpoint)
-            .onDisappear {
-                // Hides the inspector when this view disappears.
-                model.featureForm = nil
-            }
+            .onDisappear(perform: model.reset)
     }
     
     /// Sets the viewpoint using `model.viewpointGeometry` and the `mapViewProxy`.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -107,8 +107,9 @@ public struct FeatureEditor: View {
     
     /// Sets the viewpoint using `model.viewpointGeometry` and the `mapViewProxy`.
     private func setViewpoint() async {
-        guard let mapViewProxy, let viewpointGeometry = model.viewpointGeometry else { return }
+        guard let viewpointGeometry = model.viewpointGeometry else { return }
         defer { model.viewpointGeometry = nil }
+        guard let mapViewProxy else { return }
         
         let expandedGeometry = viewpointGeometry.extent.withBuilder { $0.expand(by: 2) }
         let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -53,14 +53,14 @@ import SwiftUI
 /// - Since: 300.1
 @available(visionOS, unavailable)
 public struct FeatureEditor: View {
-    /// The style to apply to the toolbar's controls.
-    private let toolbarStyle: ToolbarStyle?
     /// A binding to the feature to edit.
     @Binding private var feature: ArcGISFeature?
     /// A geometry editor used to edit the feature's geometry on an associated `MapView`.
     private let geometryEditor: GeometryEditor
     /// A proxy for performing map view operations.
     private let mapViewProxy: MapViewProxy?
+    /// The style to apply to the toolbar's controls.
+    private let toolbarStyle: ToolbarStyle?
     
     /// The shared feature editor model from the environment.
     @Environment(FeatureEditorModel.self) private var model

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -59,6 +59,9 @@ public struct FeatureEditor: View {
     @Binding private var feature: ArcGISFeature?
     /// A geometry editor used to edit the feature's geometry on an associated `MapView`.
     private let geometryEditor: GeometryEditor
+    /// A proxy for performing map view operations.
+    private let mapViewProxy: MapViewProxy?
+    
     /// The shared feature editor model from the environment.
     @Environment(FeatureEditorModel.self) private var model
     
@@ -68,6 +71,8 @@ public struct FeatureEditor: View {
     ///   The Feature Editor is displayed when the value is non-`nil`.
     ///   - geometryEditor: A geometry editor used to edit the feature's
     ///   geometry on an associated `MapView`.
+    ///   - mapViewProxy: A proxy used to set the viewpoint on an associated
+    ///   `MapView`.
     ///   - toolbarStyle: The style that determines the toolbar's appearance and
     ///   layout. A `nil` value displays the toolbar's controls without
     ///   built-in layout or styling.
@@ -75,10 +80,12 @@ public struct FeatureEditor: View {
     public init(
         _ feature: Binding<ArcGISFeature?>,
         geometryEditor: GeometryEditor,
+        mapViewProxy: MapViewProxy? = nil,
         toolbarStyle: ToolbarStyle? = .vertical
     ) {
         self._feature = feature
         self.geometryEditor = geometryEditor
+        self.mapViewProxy = mapViewProxy
         self.toolbarStyle = toolbarStyle
     }
     
@@ -94,10 +101,21 @@ public struct FeatureEditor: View {
                 model.geometryEditor = geometryEditor
                 await model.monitorGeometryEditorStreams()
             }
+            .task(id: model.viewpointGeometry, setViewpoint)
             .onDisappear {
                 // Hides the inspector when this view disappears.
                 model.featureForm = nil
             }
+    }
+    
+    /// Sets the viewpoint using `model.viewpointGeometry` and the `mapViewProxy`.
+    private func setViewpoint() async {
+        guard let mapViewProxy, let viewpointGeometry = model.viewpointGeometry else { return }
+        defer { model.viewpointGeometry = nil }
+        
+        let expandedGeometry = viewpointGeometry.extent.withBuilder { $0.expand(by: 2) }
+        let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)
+        await mapViewProxy.setViewpoint(viewpoint, duration: 0.5)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -22,6 +22,8 @@ import Observation
 final class FeatureEditorModel {
     /// The feature form to edit with the feature editor.
     var featureForm: FeatureForm?
+    /// The geometry used to set the viewpoint.
+    var viewpointGeometry: Geometry?
     
     // MARK: Geometry Editor
     

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -56,4 +56,16 @@ final class FeatureEditorModel {
             }
         }
     }
+    
+    /// Resets the model's properties to their initial values.
+    ///
+    /// This is needed to prevent the current state from interfering with
+    /// future uses of the `FeatureEditor` view.
+    func reset() {
+        featureForm = nil
+        viewpointGeometry = nil
+        geometryEditorCanUndo = false
+        geometryEditorGeometry = nil
+        geometryEditorIsStarted = false
+    }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -135,6 +135,7 @@ private struct FeatureEditorView: View {
                     model.geometryEditor.stop()
                     
                     try await loadFeature()
+                    model.viewpointGeometry = presentedFeatureForm.feature.geometry
                     startGeometryEditor()
                 } catch {
                     Logger.featureEditor.error(
@@ -156,6 +157,8 @@ private struct FeatureEditorView: View {
             // Restarts the geometry editor when the form footer discard button is pressed.
             guard !willNavigate else { break }
             startGeometryEditor()
+        case .showOnMapRequested(let feature):
+            model.viewpointGeometry = feature.geometry
         default:
             break
         }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -149,14 +149,14 @@ private struct FeatureEditorView: View {
     /// - Parameter event: The form editing event to handle.
     private func handleFormEditingEvent(_ event: FeatureFormView.EditingEvent) {
         switch event {
-        case .savedEdits(let willNavigate):
-            // Closes the inspector when the form footer save button is pressed.
-            guard !willNavigate else { break }
-            isPresented = false
         case .discardedEdits(let willNavigate):
             // Restarts the geometry editor when the form footer discard button is pressed.
             guard !willNavigate else { break }
             startGeometryEditor()
+        case .savedEdits(let willNavigate):
+            // Closes the inspector when the form footer save button is pressed.
+            guard !willNavigate else { break }
+            isPresented = false
         case .showOnMapRequested(let feature):
             model.viewpointGeometry = feature.geometry
         default:


### PR DESCRIPTION
## Description

This PR adds support for automatic viewpoint centering to the Feature Editor. The viewpoint is centered when a `MapViewProxy` is provided and:
- The component starts editing.
- The user navigates to a new feature through an association.
- The user presses the "Show on Map" button on an association.

Closes `swift/issues/8274`.

### New Public API:
```swift
FeatureEditor(
    _ feature: Binding<ArcGISFeature?>,
    geometryEditor: GeometryEditor,
    mapViewProxy: MapViewProxy? = nil,
    toolbarStyle: ToolbarStyle? = .vertical
)
```

### Other Minor Changes

- Set content insets on the example's map view to prevent the viewpoint from being centered behind the sheet on iPhone.
- Added `FeatureEditorModel` resetting to prevent its state (like the `viewpointGeometry`) from carrying across multiple `FeatureEditor` view lifecycles. (201fd6a)
- Sorted the `FeatureEditorView.handleFormEditingEvent(_:)` switch cases and `FeatureEditor` properties. (f623aa5)


## How To Test

- Run the `FeatureEditorExample` and tap on a feature to start editing.
- Navigate to a new feature through associations or tap the "Show on Map" button on an association.
  -  **Note**: Most of the example's associations have the same location as the origin feature, so you will have to adjust the viewpoint from the default before trying to center the viewpoint to see anything happen.

https://github.com/user-attachments/assets/2049dd7d-1756-461b-a370-81fb9acc2082

