### PR TITLE
UN Trace: Support function name

### DIFF
--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -476,21 +476,15 @@ public struct UtilityNetworkTrace: View {
                     ) {
                         if let selectedTrace = viewModel.selectedTrace {
                             ForEach(selectedTrace.functionOutputs, id: \.objectID) { item in
-                                HStack {
-                                    if !item.function.name.isEmpty {
-                                        Text(item.function.name)
-                                    } else {
-                                        Text(item.function.networkAttribute.name)
-                                    }
-                                    Spacer()
+                                LabeledContent {
                                     VStack(alignment: .trailing) {
                                         if item.function.name.isEmpty {
                                             Text(item.function.kind.title)
                                                 .font(.caption)
-                                                .foregroundStyle(.secondary)
                                         }
                                         if let result = item.result as? Double {
                                             Text(result, format: .number)
+                                                .foregroundStyle(.primary)
                                         } else {
                                             Text(
                                                 "Not Available",
@@ -498,6 +492,12 @@ public struct UtilityNetworkTrace: View {
                                                 comment: "A trace function output result was not provided."
                                             )
                                         }
+                                    }
+                                } label: {
+                                    if !item.function.name.isEmpty {
+                                        Text(item.function.name)
+                                    } else {
+                                        Text(item.function.networkAttribute.name)
                                     }
                                 }
                             }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -477,12 +477,18 @@ public struct UtilityNetworkTrace: View {
                         if let selectedTrace = viewModel.selectedTrace {
                             ForEach(selectedTrace.functionOutputs, id: \.objectID) { item in
                                 HStack {
-                                    Text(item.function.networkAttribute.name)
+                                    if !item.function.name.isEmpty {
+                                        Text(item.function.name)
+                                    } else {
+                                        Text(item.function.networkAttribute.name)
+                                    }
                                     Spacer()
                                     VStack(alignment: .trailing) {
-                                        Text(item.function.kind.title)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
+                                        if item.function.name.isEmpty {
+                                            Text(item.function.kind.title)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
                                         if let result = item.result as? Double {
                                             Text(result, format: .number)
                                         } else {


### PR DESCRIPTION
Related to `swift/8293`

The `UtilityNetworkTrace` component displays function results with a label and value and now uses the function name for the label when available, otherwise, falls back to use the network attribute name combined with the function type.

Here is an example of the labels for function results before and after this change:

Before:
<img width="1006" height="758" alt="Before_Catalyst" src="https://github.com/user-attachments/assets/83257722-fc7d-4961-a897-b9bf5d8b7faa" />

After:
<img width="1006" height="754" alt="After_Catalyst" src="https://github.com/user-attachments/assets/5a2e6a94-80ac-4a28-8053-b8e9ee86b1bf" />

