### PR TITLE
`FeatureEditor` - Add snap settings syncing

### DIFF
--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -82,7 +82,7 @@ struct ExampleMapView: View {
                     FeatureEditor(
                         $featureToEdit,
                         geometryEditor: geometryEditor,
-                        map: map, 
+                        map: map,
                         mapViewProxy: mapViewProxy
                     )
                     .padding()
@@ -97,7 +97,7 @@ struct ExampleMapView: View {
         }
     }
     
-    /// Sets up the map and snap settings.
+    /// Sets up the map.
     private func setUp() async throws {
         // Note: Never hardcode login information in a production application.
         // This is done solely for the sake of the example.

--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -82,6 +82,7 @@ struct ExampleMapView: View {
                     FeatureEditor(
                         $featureToEdit,
                         geometryEditor: geometryEditor,
+                        map: map, 
                         mapViewProxy: mapViewProxy
                     )
                     .padding()
@@ -107,16 +108,5 @@ struct ExampleMapView: View {
         )
         ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(credential)
         try await map.retryLoad()
-        
-        // Enables the geometry editor's snap settings and sources.
-        let snapSettings = geometryEditor.snapSettings
-        snapSettings.snapsToGeometryGuides = true
-        
-        await map.operationalLayers.load()
-        try snapSettings.syncSourceSettings()
-        
-        for sourceSetting in snapSettings.sourceSettings {
-            sourceSetting.isEnabled = true
-        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -85,7 +85,7 @@ public struct FeatureEditor: View {
     public init(
         _ feature: Binding<ArcGISFeature?>,
         geometryEditor: GeometryEditor,
-        map: Map? = nil,
+        map: Map?,
         mapViewProxy: MapViewProxy? = nil,
         toolbarStyle: ToolbarStyle? = .vertical
     ) {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -42,9 +42,7 @@ import SwiftUI
 ///
 /// **Behavior**
 ///
-/// The toolbar is visible only while a feature's geometry is being edited. The
-/// snap settings button is shown only when the geometry editor has non-empty
-/// snap source settings.
+/// The toolbar is visible only while a feature's geometry is being edited.
 ///
 /// **Associated Types**
 ///

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
-import OSLog
+internal import os
 import SwiftUI
 
 /// A feature editing component that provides both the geometry editing via a

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -96,6 +96,13 @@ public struct FeatureEditor: View {
         self.toolbarStyle = toolbarStyle
     }
     
+    /// A collection of object ids used to determine when to start editing.
+    /// This updates when the `feature` or `map` instances change.
+    private var startEditingIDs: [ObjectIdentifier] {
+        let objects: [AnyObject?] = [feature, map]
+        return objects.compactMap { $0.map(ObjectIdentifier.init) }
+    }
+    
     public var body: some View {
         FeatureEditorToolbar(style: toolbarStyle)
             .task(id: ObjectIdentifier(geometryEditor)) {
@@ -103,7 +110,7 @@ public struct FeatureEditor: View {
                 model.restartGeometryEditor()
                 await model.monitorGeometryEditorStreams()
             }
-            .task(id: EquatableBox(objects: [feature, map])) {
+            .task(id: startEditingIDs) {
                 if let feature {
                     do {
                         try await model.startEditing(rootFeature: feature, on: map)
@@ -136,15 +143,6 @@ public struct FeatureEditor: View {
         let expandedGeometry = viewpointGeometry.extent.withBuilder { $0.expand(by: 2) }
         let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)
         await mapViewProxy.setViewpoint(viewpoint, duration: 0.5)
-    }
-    
-    /// A box that provides `Equatable` conformance for an array of objects using their identifiers.
-    private struct EquatableBox: Equatable {
-        private let objectIdentifiers: [ObjectIdentifier]
-        
-        init(objects: [AnyObject?]) {
-            objectIdentifiers = objects.compactMap { $0.map(ObjectIdentifier.init) }
-        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -109,7 +109,7 @@ public struct FeatureEditor: View {
                         try await model.startEditing(rootFeature: feature, on: map)
                     } catch {
                         Logger.featureEditor.error(
-                            "Error starting feature editor: \(String(describing: error))"
+                            "Error starting feature editor: \(error.localizedDescription)"
                         )
                     }
                 } else {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -104,14 +104,16 @@ public struct FeatureEditor: View {
                 await model.monitorGeometryEditorStreams()
             }
             .task(id: EquatableBox(objects: [feature, map])) {
-                guard let feature else { return }
-                
-                do {
-                    try await model.startEditing(rootFeature: feature, on: map)
-                } catch {
-                    Logger.featureEditor.error(
-                        "Error starting geometry editor: \(String(describing: error))"
-                    )
+                if let feature {
+                    do {
+                        try await model.startEditing(rootFeature: feature, on: map)
+                    } catch {
+                        Logger.featureEditor.error(
+                            "Error starting feature editor: \(String(describing: error))"
+                        )
+                    }
+                } else {
+                    model.stopEditing()
                 }
             }
             .onChange(of: model.isPresented) {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
+import OSLog
 import SwiftUI
 
 /// A feature editing component that provides both the geometry editing via a
@@ -55,6 +56,8 @@ public struct FeatureEditor: View {
     @Binding private var feature: ArcGISFeature?
     /// A geometry editor used to edit the feature's geometry on an associated `MapView`.
     private let geometryEditor: GeometryEditor
+    /// The map that `feature` is part of, used to set up rule-based snapping.
+    private let map: Map?
     /// A proxy for performing map view operations.
     private let mapViewProxy: MapViewProxy?
     /// The style to apply to the toolbar's controls.
@@ -69,6 +72,10 @@ public struct FeatureEditor: View {
     ///   The Feature Editor is displayed when the value is non-`nil`.
     ///   - geometryEditor: A geometry editor used to edit the feature's
     ///   geometry on an associated `MapView`.
+    ///   - map: The map that `feature` is part of, used to set up rule-based
+    ///   snapping for the geometry editor. If `nil` is passed, or the feature
+    ///   is not part of a utility network contained in the map, snapping is
+    ///   set up without snap rules.
     ///   - mapViewProxy: A proxy used to set the viewpoint on an associated
     ///   `MapView`.
     ///   - toolbarStyle: The style that determines the toolbar's appearance and
@@ -78,29 +85,44 @@ public struct FeatureEditor: View {
     public init(
         _ feature: Binding<ArcGISFeature?>,
         geometryEditor: GeometryEditor,
+        map: Map? = nil,
         mapViewProxy: MapViewProxy? = nil,
         toolbarStyle: ToolbarStyle? = .vertical
     ) {
         self._feature = feature
         self.geometryEditor = geometryEditor
+        self.map = map
         self.mapViewProxy = mapViewProxy
         self.toolbarStyle = toolbarStyle
     }
     
     public var body: some View {
         FeatureEditorToolbar(style: toolbarStyle)
-            .onChange(of: feature.map(ObjectIdentifier.init), initial: true) {
-                model.featureForm = feature.map(FeatureForm.init)
-            }
-            .onChange(of: model.featureForm.map(ObjectIdentifier.init)) {
-                feature = model.featureForm?.feature
-            }
             .task(id: ObjectIdentifier(geometryEditor)) {
                 model.geometryEditor = geometryEditor
+                model.restartGeometryEditor()
                 await model.monitorGeometryEditorStreams()
             }
+            .task(id: EquatableBox(objects: [feature, map])) {
+                guard let feature else { return }
+                
+                do {
+                    try await model.startEditing(rootFeature: feature, on: map)
+                } catch {
+                    Logger.featureEditor.error(
+                        "Error starting geometry editor: \(String(describing: error))"
+                    )
+                }
+            }
+            .onChange(of: model.isPresented) {
+                guard !model.isPresented else { return }
+                feature = nil
+            }
+            .onChange(of: ObjectIdentifier(model.geometryEditor.snapSettings)) {
+                model.syncSnapSourceSettings()
+            }
             .task(id: model.viewpointGeometry, setViewpoint)
-            .onDisappear(perform: model.reset)
+            .onDisappear(perform: model.stopEditing)
     }
     
     /// Sets the viewpoint using `model.viewpointGeometry` and the `mapViewProxy`.
@@ -113,6 +135,15 @@ public struct FeatureEditor: View {
         let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)
         await mapViewProxy.setViewpoint(viewpoint, duration: 0.5)
     }
+    
+    /// A box that provides `Equatable` conformance for an array of objects using their identifiers.
+    private struct EquatableBox: Equatable {
+        private let objectIdentifiers: [ObjectIdentifier]
+        
+        init(objects: [AnyObject?]) {
+            objectIdentifiers = objects.compactMap { $0.map(ObjectIdentifier.init) }
+        }
+    }
 }
 
 extension FeatureEditor {
@@ -123,5 +154,12 @@ extension FeatureEditor {
         case horizontal
         /// Displays the toolbar in a styled vertical layout.
         case vertical
+    }
+}
+
+extension Logger {
+    /// A logger for the feature editor component.
+    static var featureEditor: Logger {
+        Logger(subsystem: "com.esri.ArcGISToolkit", category: "FeatureEditor")
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -14,18 +14,37 @@
 
 import ArcGIS
 import Observation
+import OSLog
 
 /// A data model that contains various properties that are needed for the
 /// feature editor and shared between the modifier and the view.
 @MainActor
 @Observable
 final class FeatureEditorModel {
-    /// The feature form to edit with the feature editor.
-    var featureForm: FeatureForm?
+    // MARK: Properties
+    
+    /// The feature currently being edited by the feature editor.
+    var feature: ArcGISFeature? {
+        presentedFeatureForm?.feature ?? rootFeatureForm?.feature
+    }
+    /// A Boolean value that indicates whether the Feature Editor inspector is presented.
+    /// This maps `rootFeatureForm` to a Boolean value.
+    var isPresented: Bool {
+        get { rootFeatureForm != nil }
+        set {
+            guard !newValue else { return }
+            stopEditing()
+        }
+    }
+    /// The form currently presented in the feature editor's `FeatureFormView`.
+    /// This is non-`nil` after navigating to an association feature.
+    private var presentedFeatureForm: FeatureForm?
+    /// The root feature form to edit with the feature editor.
+    private(set) var rootFeatureForm: FeatureForm?
     /// The geometry used to set the viewpoint.
     var viewpointGeometry: Geometry?
     
-    // MARK: Geometry Editor
+    // MARK: Geometry Editor Properties
     
     /// The geometry editor that the feature editor will use to edit geometries on the `MapView`.
     var geometryEditor = GeometryEditor()
@@ -35,6 +54,15 @@ final class FeatureEditorModel {
     private(set) var geometryEditorGeometry: Geometry?
     /// A Boolean value indicating whether the geometry editor has started.
     private(set) var geometryEditorIsStarted = false
+    
+    // MARK: Snapping Properties
+    
+    /// The snap rules for the `feature`, if applicable, used to sync snap source settings.
+    private var snapRules: SnapRules?
+    /// The `feature`'s utility network, if applicable, used to create snap rules.
+    private var utilityNetwork: UtilityNetwork?
+    
+    // MARK: Methods
     
     /// Monitors geometry editor streams and updates the corresponding properties.
     func monitorGeometryEditorStreams() async {
@@ -57,15 +85,117 @@ final class FeatureEditorModel {
         }
     }
     
-    /// Resets the model's properties to their initial values.
+    /// Restarts the `geometryEditor` if it is started.
+    /// This can be used to discard geometry edits or set up a new geometry editor.
+    func restartGeometryEditor() {
+        guard geometryEditorIsStarted else { return }
+        startGeometryEditor()
+    }
+    
+    /// Starts editing a new `FeatureForm` that is shown in the feature editor's `FeatureFormView`.
+    /// - Parameter featureForm: The new feature form to edit.
+    func startEditing(newFeatureForm featureForm: FeatureForm) async throws {
+        geometryEditor.stop()
+        presentedFeatureForm = featureForm
+        
+        try await setUpGeometryEditing()
+    }
+    
+    /// Starts an editing session for the given `feature`.
+    /// - Parameters:
+    ///   - feature: The root feature to edit.
+    ///   - map: The map that `feature` is part of, used to set up rule-based snapping.
+    func startEditing(rootFeature feature: ArcGISFeature, on map: Map?) async throws {
+        stopEditing()
+        rootFeatureForm = FeatureForm(feature: feature)
+        
+        // Sets up the utility network so snap rules can be created.
+        if let map {
+            try? await map.load()
+            await map.utilityNetworks.load()
+            utilityNetwork = map.utilityNetworks.first { utilityNetwork in
+                utilityNetwork.makeElement(arcGISFeature: feature) != nil
+            }
+        }
+        
+        try await setUpGeometryEditing()
+    }
+    
+    /// Stops the feature editor and resets the model's properties.
     ///
     /// This is needed to prevent the current state from interfering with
     /// future uses of the `FeatureEditor` view.
-    func reset() {
-        featureForm = nil
+    func stopEditing() {
+        rootFeatureForm = nil
+        presentedFeatureForm = nil
         viewpointGeometry = nil
+        
+        geometryEditor.stop()
         geometryEditorCanUndo = false
         geometryEditorGeometry = nil
         geometryEditorIsStarted = false
+        
+        snapRules = nil
+        utilityNetwork = nil
+    }
+    
+    /// Syncs the `geometryEditor.snapSettings`' source settings.
+    func syncSnapSourceSettings() {
+        do {
+            let snapSettings = geometryEditor.snapSettings
+            
+            if let snapRules {
+                try snapSettings.syncSourceSettings(
+                    rules: snapRules,
+                    sourceEnablingBehavior: .setFromRules
+                )
+            } else {
+                try snapSettings.syncSourceSettings()
+            }
+            
+            // Snapping is enabled by default to simplify the `SnapSettingsView` UI.
+            snapSettings.isEnabled = true
+        } catch {
+            Logger.featureEditor.error(
+                "Error syncing snap source settings: \(String(describing: error))"
+            )
+        }
+    }
+    
+    /// Performs setup needed for geometry editing and starts the geometry editor if applicable.
+    private func setUpGeometryEditing() async throws {
+        guard let feature else { return }
+        
+        // Loads the feature so canUpdateGeometry can be accessed. It is always false otherwise.
+        try await feature.load()
+        guard feature.canUpdateGeometry else { return }
+        
+        // Loads the feature's table if the geometry is nil so geometryType can be accessed.
+        // It is always nil otherwise.
+        if feature.geometry == nil, let table = feature.table {
+            try await table.load()
+        }
+        
+        // Sets up the snap rules and syncs the snap source settings.
+        if let utilityNetwork, let element = utilityNetwork.makeElement(arcGISFeature: feature) {
+            snapRules = try? await .rules(for: utilityNetwork, assetType: element.assetType)
+        } else {
+            snapRules = nil
+        }
+        syncSnapSourceSettings()
+        
+        startGeometryEditor()
+    }
+    
+    /// Starts the geometry editor using the `feature`.
+    private func startGeometryEditor() {
+        guard let feature else { return }
+        
+        if let geometry = feature.geometry {
+            geometryEditor.start(withInitial: geometry)
+            viewpointGeometry = geometry
+        } else if let geometryType = feature.table?.geometryType {
+            geometryEditor.start(withType: geometryType)
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -175,6 +175,8 @@ final class FeatureEditorModel {
         
         // Sets up the snap rules and syncs the snap source settings.
         if let utilityNetwork, let element = utilityNetwork.makeElement(arcGISFeature: feature) {
+            // Errors are ignored to set snapRules to nil if creation fails, so
+            // the old rules don't get used in future syncing.
             snapRules = try? await .rules(for: utilityNetwork, assetType: element.assetType)
         } else {
             snapRules = nil

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -105,7 +105,7 @@ final class FeatureEditorModel {
     /// - Parameters:
     ///   - feature: The root feature to edit.
     ///   - map: The map that `feature` is part of, used to set up rule-based snapping.
-    func startEditing(rootFeature feature: ArcGISFeature, on map: Map? = nil) async throws {
+    func startEditing(rootFeature feature: ArcGISFeature, on map: Map?) async throws {
         stopEditing()
         rootFeatureForm = FeatureForm(feature: feature)
         

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -105,7 +105,7 @@ final class FeatureEditorModel {
     /// - Parameters:
     ///   - feature: The root feature to edit.
     ///   - map: The map that `feature` is part of, used to set up rule-based snapping.
-    func startEditing(rootFeature feature: ArcGISFeature, on map: Map?) async throws {
+    func startEditing(rootFeature feature: ArcGISFeature, on map: Map? = nil) async throws {
         stopEditing()
         rootFeatureForm = FeatureForm(feature: feature)
         

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -14,7 +14,7 @@
 
 import ArcGIS
 import Observation
-import OSLog
+internal import os
 
 /// A data model that contains various properties that are needed for the
 /// feature editor and shared between the modifier and the view.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -111,7 +111,7 @@ final class FeatureEditorModel {
         
         // Sets up the utility network so snap rules can be created.
         if let map {
-            try? await map.load()
+            try await map.load()
             await map.utilityNetworks.load()
             utilityNetwork = map.utilityNetworks.first { utilityNetwork in
                 utilityNetwork.makeElement(arcGISFeature: feature) != nil

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -154,7 +154,7 @@ final class FeatureEditorModel {
             snapSettings.isEnabled = true
         } catch {
             Logger.featureEditor.error(
-                "Error syncing snap source settings: \(String(describing: error))"
+                "Error syncing snap source settings: \(error.localizedDescription)"
             )
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -144,11 +144,8 @@ final class FeatureEditorModel {
         do {
             let snapSettings = geometryEditor.snapSettings
             
-            if let snapRules {
-                try snapSettings.syncSourceSettings(
-                    rules: snapRules,
-                    sourceEnablingBehavior: .setFromRules
-                )
+            if let rules = snapRules {
+                try snapSettings.syncSourceSettings(rules: rules, sourceEnablingBehavior: .preserve)
             } else {
                 try snapSettings.syncSourceSettings()
             }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
-import OSLog
+internal import os
 import SwiftUI
 
 public extension View {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -36,24 +36,12 @@ private struct FeatureEditorModifier: ViewModifier {
     /// This is needed to set the default detent to medium.
     @State private var selectedPresentationDetent = PresentationDetent.medium
     
-    /// A binding to a Boolean value that indicates whether the inspector should be presented.
-    /// This maps `model.featureForm` to a Boolean value.
-    private var isPresented: Binding<Bool> {
-        Binding { model.featureForm != nil } set: { _ in model.featureForm = nil }
-    }
-    
     func body(content: Content) -> some View {
         content
-            .safeInspector(isPresented: isPresented) {
+            .safeInspector(isPresented: $model.isPresented) {
                 // VStack is needed for presentation modifiers to be applied.
                 VStack(spacing: 0) {
-                    if let featureForm = model.featureForm {
-                        FeatureEditorView(
-                            featureForm: featureForm,
-                            isPresented: isPresented,
-                            isMinimized: selectedPresentationDetent == .bar
-                        )
-                    }
+                    FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
                 }
                 .presentationBackgroundInteraction(.enabled)
                 .presentationContentInteraction(.scrolls)
@@ -65,39 +53,20 @@ private struct FeatureEditorModifier: ViewModifier {
                 .interactiveDismissDisabled()
             }
             .environment(model)
-            .onChange(of: isPresented.wrappedValue) {
-                // Stops the geometry editor when the inspector is dismissed.
-                // This is done in an onChange modifier to sync the stop with
-                // the inspector's disappearance (onDisappear is too slow).
-                // It needs to happen outside of the inspector since onChange
-                // doesn't fire before it is dismissed on some platforms.
-                model.geometryEditor.stop()
-            }
     }
 }
 
-/// A view that displays a `FeatureFormView` and manages a geometry editor for editing a feature.
-private struct FeatureEditorView: View {
-    /// The root feature form to display in the `FeatureFormView`.
-    private let rootFeatureForm: FeatureForm
-    /// A Boolean value indicating whether the view is presented.
-    @Binding private var isPresented: Bool
+/// A view that contains the `FeatureFormView` for the feature editor.
+private struct FeatureEditorFormView: View {
+    /// A Boolean value indicating whether the parent presentation is minimized.
+    let isMinimized: Bool
+    
     /// The feature editor model from the environment. This is needed to access
     /// the geometry editor.
     @Environment(FeatureEditorModel.self) private var model
-    /// A Boolean value indicating whether the parent presentation is minimized.
-    private let isMinimized: Bool
     
     /// The form currently presented in the `FeatureFormView`.
-    @State private var presentedFeatureForm: FeatureForm
-    
-    /// A value that changes when the geometry editor needs to be started.
-    private var startGeometryEditorID: Int {
-        var hasher = Hasher()
-        hasher.combine(ObjectIdentifier(model.geometryEditor))
-        hasher.combine(ObjectIdentifier(presentedFeatureForm))
-        return hasher.finalize()
-    }
+    @State private var presentedFeatureForm: FeatureForm?
     
     /// A closure that saves geometry edits to the form's feature. This is
     /// non-`nil` only when there are edits, so the `FeatureFormView`
@@ -108,41 +77,32 @@ private struct FeatureEditorView: View {
             guard let geometry = model.geometryEditorGeometry, geometry.sketchIsValid else {
                 throw InvalidGeometryError()
             }
-            presentedFeatureForm.feature.geometry = geometry
+            model.feature?.geometry = geometry
         }
     }
     
-    init(featureForm: FeatureForm, isPresented: Binding<Bool>, isMinimized: Bool) {
-        self.rootFeatureForm = featureForm
-        self._isPresented = isPresented
-        self._presentedFeatureForm = State(initialValue: rootFeatureForm)
-        self.isMinimized = isMinimized
-    }
-    
     var body: some View {
-        FeatureFormView(root: rootFeatureForm, isPresented: $isPresented)
-            .editingButtons(isMinimized ? .hidden : .automatic)
-            .onFeatureFormChanged { presentedFeatureForm = $0 }
-            .onFormEditingEvent(perform: handleFormEditingEvent)
-            .environment(\.externalSaveAction, saveGeometryEditsAction)
-            .onChange(of: ObjectIdentifier(rootFeatureForm), initial: true) {
-                presentedFeatureForm = rootFeatureForm
-            }
-            .task(id: startGeometryEditorID) {
-                do {
-                    // Stops the geometry editor so it will not continue running if
-                    // the new feature cannot be edited.
-                    model.geometryEditor.stop()
+        if let rootFeatureForm = model.rootFeatureForm {
+            @Bindable var model = model
+            
+            FeatureFormView(root: rootFeatureForm, isPresented: $model.isPresented)
+                .editingButtons(isMinimized ? .hidden : .automatic)
+                .onFeatureFormChanged { presentedFeatureForm = $0 }
+                .onFormEditingEvent(perform: handleFormEditingEvent)
+                .environment(\.externalSaveAction, saveGeometryEditsAction)
+                .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
+                    guard let presentedFeatureForm else { return }
+                    defer { self.presentedFeatureForm = nil }
                     
-                    try await loadFeature()
-                    model.viewpointGeometry = presentedFeatureForm.feature.geometry
-                    startGeometryEditor()
-                } catch {
-                    Logger.featureEditor.error(
-                        "Error starting geometry editor: \(String(describing: error))"
-                    )
+                    do {
+                        try await model.startEditing(newFeatureForm: presentedFeatureForm)
+                    } catch {
+                        Logger.featureEditor.error(
+                            "Error starting feature editor: \(String(describing: error))"
+                        )
+                    }
                 }
-            }
+        }
     }
     
     /// Handles events from the `FeatureFormView.onFormEditingEvent(perform:)` modifier.
@@ -152,41 +112,15 @@ private struct FeatureEditorView: View {
         case .discardedEdits(let willNavigate):
             // Restarts the geometry editor when the form footer discard button is pressed.
             guard !willNavigate else { break }
-            startGeometryEditor()
+            model.restartGeometryEditor()
         case .savedEdits(let willNavigate):
             // Closes the inspector when the form footer save button is pressed.
             guard !willNavigate else { break }
-            isPresented = false
+            model.isPresented = false
         case .showOnMapRequested(let feature):
             model.viewpointGeometry = feature.geometry
         default:
             break
-        }
-    }
-    
-    /// Loads the form's feature and its properties needed to start the geometry editor.
-    private func loadFeature() async throws {
-        // Loads the feature so that canUpdateGeometry can be accessed. It is false otherwise.
-        let feature = presentedFeatureForm.feature
-        try await feature.load()
-        
-        // Loads the feature's table if the geometry is nil so that geometryType can be accessed.
-        // It is nil otherwise.
-        guard feature.canUpdateGeometry, feature.geometry == nil, let table = feature.table else {
-            return
-        }
-        try await table.load()
-    }
-    
-    /// Starts the geometry editor using the form's feature.
-    private func startGeometryEditor() {
-        let feature = presentedFeatureForm.feature
-        guard feature.canUpdateGeometry else { return }
-        
-        if let geometry = feature.geometry {
-            model.geometryEditor.start(withInitial: geometry)
-        } else if let geometryType = feature.table?.geometryType {
-            model.geometryEditor.start(withType: geometryType)
         }
     }
 }
@@ -212,13 +146,6 @@ private struct InvalidGeometryError: LocalizedError {
 }
 
 // MARK: - Extensions
-
-private extension Logger {
-    /// A logger for the Feature Editor.
-    static var featureEditor: Logger {
-        Logger(subsystem: "com.esri.ArcGISToolkit", category: "FeatureEditor")
-    }
-}
 
 private extension PresentationDetent {
     /// A custom presentation detent that sizes to the approximate height of a top system toolbar.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -26,8 +26,7 @@ public extension View {
     }
 }
 
-/// A view modifier that presents a `FeatureEditorView` in an inspector when
-/// a feature is non-`nil`.
+/// A view modifier that presents a `FeatureEditorFormView` in an inspector.
 @available(visionOS, unavailable)
 private struct FeatureEditorModifier: ViewModifier {
     /// The feature editor model shared by the toolbar and inspector.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -97,7 +97,7 @@ private struct FeatureEditorFormView: View {
                         try await model.startEditing(newFeatureForm: presentedFeatureForm)
                     } catch {
                         Logger.featureEditor.error(
-                            "Error starting feature editor: \(String(describing: error))"
+                            "Error starting feature editor: \(error.localizedDescription)"
                         )
                     }
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -154,11 +154,9 @@ private struct SnapSettingsButton: View {
     /// A Boolean value indicating whether the settings view is presented.
     @State private var isShowingSettings = false
     
-    /// The snap settings for the feature editor model's geometry editor.
-    private var snapSettings: SnapSettings { featureEditorModel.geometryEditor.snapSettings }
-    
     var body: some View {
         Button {
+            featureEditorModel.syncSnapSourceSettings()
             isShowingSettings.toggle()
         } label: {
             Label {
@@ -172,13 +170,9 @@ private struct SnapSettingsButton: View {
             }
         }
         .sheet(isPresented: $isShowingSettings) {
-            SnapSettingsView(settings: snapSettings)
+            SnapSettingsView(settings: featureEditorModel.geometryEditor.snapSettings)
             // Needed to override the font set in toolbarStackStyle.
                 .font(nil)
-        }
-        .onChange(of: ObjectIdentifier(snapSettings), initial: true) {
-            // Snapping is enabled by default to simplify the SnapSettingsView UI.
-            snapSettings.isEnabled = true
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -158,29 +158,27 @@ private struct SnapSettingsButton: View {
     private var snapSettings: SnapSettings { featureEditorModel.geometryEditor.snapSettings }
     
     var body: some View {
-        if !snapSettings.sourceSettings.isEmpty {
-            Button {
-                isShowingSettings.toggle()
-            } label: {
-                Label {
-                    Text(
-                        "Settings",
-                        bundle: .toolkitModule,
-                        comment: "A label for a button to show settings for configuring snapping."
-                    )
-                } icon: {
-                    Image(systemName: "gear")
-                }
+        Button {
+            isShowingSettings.toggle()
+        } label: {
+            Label {
+                Text(
+                    "Settings",
+                    bundle: .toolkitModule,
+                    comment: "A label for a button to show settings for configuring snapping."
+                )
+            } icon: {
+                Image(systemName: "gear")
             }
-            .sheet(isPresented: $isShowingSettings) {
-                SnapSettingsView(settings: snapSettings)
-                // Needed to override the font set in toolbarStackStyle.
-                    .font(nil)
-            }
-            .onChange(of: ObjectIdentifier(snapSettings), initial: true) {
-                // Snapping is enabled by default to simplify the SnapSettingsView UI.
-                snapSettings.isEnabled = true
-            }
+        }
+        .sheet(isPresented: $isShowingSettings) {
+            SnapSettingsView(settings: snapSettings)
+            // Needed to override the font set in toolbarStackStyle.
+                .font(nil)
+        }
+        .onChange(of: ObjectIdentifier(snapSettings), initial: true) {
+            // Snapping is enabled by default to simplify the SnapSettingsView UI.
+            snapSettings.isEnabled = true
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/SnapSettingsView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/SnapSettingsView.swift
@@ -56,6 +56,7 @@ struct SnapSettingsView: View {
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .disabled(rootSourceSettingsModels.isEmpty)
                 .onChange(of: snapsToFeatures) {
                     settings.snapsToFeatures = snapsToFeatures
                 }
@@ -94,7 +95,9 @@ struct SnapSettingsView: View {
                 }
                 
                 // Sets up view's state properties using settings' property values.
-                snapsToFeatures = settings.snapsToFeatures
+                snapsToFeatures = !rootSourceSettingsModels.isEmpty
+                ? settings.snapsToFeatures
+                : false
                 snapsToGeometryGuides = settings.snapsToGeometryGuides
             }
             .navigationTitle(

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/SnapSettingsView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/SnapSettingsView.swift
@@ -95,9 +95,7 @@ struct SnapSettingsView: View {
                 }
                 
                 // Sets up view's state properties using settings' property values.
-                snapsToFeatures = !rootSourceSettingsModels.isEmpty
-                ? settings.snapsToFeatures
-                : false
+                snapsToFeatures = settings.snapsToFeatures
                 snapsToGeometryGuides = settings.snapsToGeometryGuides
             }
             .navigationTitle(


### PR DESCRIPTION
## Description

This PR adds automatic snap source setting syncing to the Feature Editor. Closes `swift/issues/8279`.

### Public API Changes

```swift
FeatureEditor(
    _ feature: Binding<ArcGISFeature?>,
    geometryEditor: GeometryEditor,
    map: Map?,
    mapViewProxy: MapViewProxy? = nil,
    toolbarStyle: ToolbarStyle? = .vertical
)
```

### Behavior Changes

- Snap settings are synced when:
  - The FE starts geometry editing.
  - A new feature is navigated to in the form.
  - The snap setting button is pressed.
- Snap rules are used if a map with an applicable utility network is passed into the `FeatureEditor` view.
- `SnapSettingsButton` no longer hides when there are no snap sources.
- There is a delay between when the inspector and toolbar appear, due to the increased async snap settings setup.

### Architecture Changes

- Moved editing start/stop logic into `FeatureEditorModel`: This was needed to support snap settings setup in both the modifier and the view.


## How To Test

- Run the `FeatureEditorExample` and tap on a feature to start editing.
- Tap on the snap settings button to configure snapping.
- Edit and start/stop the feature editor to ensure everything still works correctly.

**Note**: Unit tests for these changes will be added in another PR, so the `TestRunner` project currently doesn't build (`swift/issues/8354`).  