### PR TITLE
`FeatureEditor`: Fix Examples build

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -117,6 +117,7 @@ public struct FeatureEditor: View {
     }
 }
 
+@available(visionOS, unavailable)
 extension FeatureEditor {
     /// A style that determines the appearance and layout of a feature editor's toolbar.
     /// - Since: 300.1

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -233,6 +233,7 @@ private extension View {
     /// - Parameters:
     ///   - isPresented: A Boolean value indicating whether the inspector is presented.
     ///   - content: The content to display in the inspector.
+    @available(visionOS, unavailable)
     @ViewBuilder
     func safeInspector<Content>(
         isPresented: Binding<Bool>,

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -17,6 +17,7 @@ import SwiftUI
 
 /// A toolbar for the feature editor containing controls for performing common
 /// geometry editor actions.
+@available(visionOS, unavailable)
 struct FeatureEditorToolbar: View {
     /// The style to apply to the toolbar's controls.
     let style: FeatureEditor.ToolbarStyle?
@@ -207,6 +208,7 @@ private extension View {
     }
 }
 
+@available(visionOS, unavailable)
 #Preview {
     @Previewable @State var model = FeatureEditorModel()
     


### PR DESCRIPTION
### Description

This PR fixes the Examples build in on visionOS by excluding some Feature Editor types. The `TestRunner` will be fixed later in https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1490.

### How To Test

Ensure the `Examples` project builds on visionOS.


