### PR TITLE
`FeatureEditor`: Add snap setting syncing tests

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -37,7 +37,7 @@ final class FeatureEditorModel {
         }
     }
     /// The form currently presented in the feature editor's `FeatureFormView`.
-    /// This is non-`nil` after navigating to an association feature.
+    /// This is non-`nil` after a new feature form is shown in the view.
     private var presentedFeatureForm: FeatureForm?
     /// The root feature form to edit with the feature editor.
     private(set) var rootFeatureForm: FeatureForm?
@@ -57,9 +57,11 @@ final class FeatureEditorModel {
     
     // MARK: Snapping Properties
     
-    /// The snap rules for the `feature`, if applicable, used to sync snap source settings.
+    /// The snap rules for the `feature`, used to sync snap source settings.
+    /// This is non-`nil` when snap rules were successfully created using the `utilityNetwork`.
     private var snapRules: SnapRules?
-    /// The `feature`'s utility network, if applicable, used to create snap rules.
+    /// The `feature`'s utility network used to create snap rules.
+    /// This is non-`nil` when a map containing the feature's UN is used to start editing.
     private var utilityNetwork: UtilityNetwork?
     
     // MARK: Methods

--- a/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
@@ -32,7 +32,8 @@ struct FeatureEditorTestView: View {
             .overlay(alignment: .topTrailing) {
                 FeatureEditor(
                     $featureToEdit,
-                    geometryEditor: geometryEditor
+                    geometryEditor: geometryEditor,
+                    map: map
                 )
                 .padding()
             }

--- a/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
@@ -71,7 +71,6 @@ private extension FeatureEditorTestView {
             return
         }
         
-        try geometryEditor.snapSettings.syncSourceSettings()
         featureToEdit = feature
     }
     

--- a/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
+++ b/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
@@ -168,20 +168,30 @@ final class FeatureEditorToolbarTests: XCTestCase {
         
         // Use one snap source toggle to verify that snapping to snap sources
         // are disabled by default.
-        let structureLineToggle = app.snapToggle(named: "Structure Line")
+        let electricDistributionLine = app.snapToggle(
+            named: "Electric Distribution Line, Rules limit snapping."
+        )
+        electricDistributionLine.assertExistence()
+        XCTAssertEqual(electricDistributionLine.boolValue, false)
+        
+        // Snap source toggles with 'Rules limit snapping' should be enabled.
+        XCTAssertTrue(electricDistributionLine.isEnabled)
+        
+        // Snap source toggles with 'Rules prevent snapping' should be disabled.
+        let structureLineToggle = app.snapToggle(named: "Structure Line, Rules prevent snapping.")
         structureLineToggle.assertExistence()
-        XCTAssertEqual(structureLineToggle.boolValue, false)
+        XCTAssertFalse(structureLineToggle.isEnabled)
         
         // Turn on some toggles and verify their states are preserved when the
         // settings view is reopened.
         geometryGuidesToggle.tapResolvedToggleControl()
-        structureLineToggle.tapResolvedToggleControl()
+        electricDistributionLine.tapResolvedToggleControl()
         // Close the settings view.
         app.buttons["Close"].assertExistenceAndTap()
         // Reopen the settings view and verify the toggles states are preserved.
         app.buttons["Settings"].assertExistenceAndTap()
         XCTAssertEqual(geometryGuidesToggle.boolValue, true)
-        XCTAssertEqual(structureLineToggle.boolValue, true)
+        XCTAssertEqual(electricDistributionLine.boolValue, true)
     }
 }
 

--- a/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
+++ b/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
@@ -166,6 +166,12 @@ final class FeatureEditorToolbarTests: XCTestCase {
         XCTAssertEqual(geometryGuidesToggle.boolValue, false)
         XCTAssertEqual(featuresToggle.boolValue, true)
         
+        // Snap sources should have been synced with snap rules and source
+        // toggles with "Rules prevent snapping" should be disabled.
+        let structureLineToggle = app.snapToggle(named: "Structure Line, Rules prevent snapping.")
+        structureLineToggle.assertExistence()
+        XCTAssertFalse(structureLineToggle.isEnabled)
+        
         // Use one snap source toggle to verify that snapping to snap sources
         // are disabled by default.
         let dirtyAreasToggle = app.snapToggle(named: "NapervilleElectricV5 - Dirty Areas")

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -22,7 +22,10 @@ struct FeatureEditorModelTests {
     @Test
     func initializer() {
         let model = FeatureEditorModel()
-        #expect(model.featureForm == nil)
+        #expect(model.feature == nil)
+        #expect(!model.isPresented)
+        #expect(model.rootFeatureForm == nil)
+        #expect(model.viewpointGeometry == nil)
         #expect(!model.geometryEditorCanUndo)
         #expect(model.geometryEditorGeometry == nil)
         #expect(!model.geometryEditorIsStarted)

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -63,9 +63,9 @@ struct FeatureEditorModelTests {
         // Starts the geometry editor with a geometry.
         let geometry = Point(x: 0, y: 0)
         model.geometryEditor.start(withInitial: geometry)
-        await Task.expect(model.geometryEditorIsStarted)
-        await Task.expect(model.geometryEditorGeometry == geometry)
-        await Task.expect(!model.geometryEditorCanUndo)
+        await Task.yieldExpect(model.geometryEditorIsStarted)
+        await Task.yieldExpect(model.geometryEditorGeometry == geometry)
+        await Task.yieldExpect(!model.geometryEditorCanUndo)
         
         // Stops the geometry editor.
         model.geometryEditor.stop()
@@ -198,9 +198,9 @@ struct FeatureEditorModelTests {
         model.expectIsEditing(rootFeature: feature)
         
         // Geometry editor is not started.
-        await Task.expect(!model.geometryEditorIsStarted)
-        await Task.expect(model.geometryEditorGeometry == nil)
-        await Task.expect(!model.geometryEditorCanUndo)
+        await Task.yieldExpect(!model.geometryEditorIsStarted)
+        await Task.yieldExpect(model.geometryEditorGeometry == nil)
+        await Task.yieldExpect(!model.geometryEditorCanUndo)
         #expect(model.viewpointGeometry == nil)
         #expect(!model.geometryEditor.snapSettings.isEnabled)
     }
@@ -240,9 +240,9 @@ private extension FeatureEditorModel {
         #expect(viewpointGeometry == nil, sourceLocation: sourceLocation)
         
         // Yields to ensure geometry editor properties are updated by monitorGeometryEditorStreams().
-        await Task.expect(!self.geometryEditorCanUndo, sourceLocation: sourceLocation)
-        await Task.expect(self.geometryEditorGeometry == nil, sourceLocation: sourceLocation)
-        await Task.expect(!self.geometryEditorIsStarted, sourceLocation: sourceLocation)
+        await Task.yieldExpect(!self.geometryEditorCanUndo, sourceLocation: sourceLocation)
+        await Task.yieldExpect(self.geometryEditorGeometry == nil, sourceLocation: sourceLocation)
+        await Task.yieldExpect(!self.geometryEditorIsStarted, sourceLocation: sourceLocation)
     }
     
     /// Verifies the model has started editing a given feature instance as the root feature.
@@ -263,7 +263,10 @@ private extension FeatureEditorModel {
         geometry: Geometry,
         sourceLocation: SourceLocation = #_sourceLocation
     ) async {
-        await Task.expect(self.geometryEditorGeometry == geometry, sourceLocation: sourceLocation)
+        await Task.yieldExpect(
+            self.geometryEditorGeometry == geometry,
+            sourceLocation: sourceLocation
+        )
         
         // The geometry is used to set the viewpoint.
         #expect(viewpointGeometry == geometry, sourceLocation: sourceLocation)
@@ -271,10 +274,10 @@ private extension FeatureEditorModel {
     
     /// Verifies the model's geometry editor has started.
     func expectIsGeometryEditing(sourceLocation: SourceLocation = #_sourceLocation) async {
-        await Task.expect(self.geometryEditorIsStarted, sourceLocation: sourceLocation)
+        await Task.yieldExpect(self.geometryEditorIsStarted, sourceLocation: sourceLocation)
         
         // Verifies it started without any edits.
-        await Task.expect(!self.geometryEditorCanUndo, sourceLocation: sourceLocation)
+        await Task.yieldExpect(!self.geometryEditorCanUndo, sourceLocation: sourceLocation)
         
         // Verifies snap settings are enabled by default.
         #expect(geometryEditor.snapSettings.isEnabled, sourceLocation: sourceLocation)
@@ -289,9 +292,9 @@ private extension TableDescription {
 }
 
 private extension Task where Failure == Never, Success == Never {
-    /// Verifies a condition eventually becomes true.
+    /// Yields until a condition is met or a timeout occurs and then verifies the condition is true.
     @MainActor
-    static func expect(
+    static func yieldExpect(
         _ condition: @autoclosure @escaping @MainActor () -> Bool,
         sourceLocation: SourceLocation = #_sourceLocation
     ) async {

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -66,12 +66,10 @@ struct FeatureEditorModelTests {
         model.geometryEditor.start(withInitial: geometry)
         await Task.expect(model.geometryEditorIsStarted)
         await Task.expect(model.geometryEditorGeometry == geometry)
+        await Task.expect(!model.geometryEditorCanUndo)
         
         // Stops the geometry editor.
         model.geometryEditor.stop()
-        await Task.expect(!model.geometryEditorIsStarted)
-        await Task.expect(model.geometryEditorGeometry == nil)
-        
         // Verifies no other properties have been modified.
         await model.expectDefaultPropertyValues()
     }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -16,11 +16,11 @@ import ArcGIS
 @testable import ArcGISToolkit
 import Testing
 
-@Suite("FeatureEditor Tests")
+@Suite("FeatureEditorModel Tests")
 @MainActor
-struct FeatureEditorTests {
+struct FeatureEditorModelTests {
     @Test
-    func modelInitializer() {
+    func initializer() {
         let model = FeatureEditorModel()
         #expect(model.featureForm == nil)
         #expect(!model.geometryEditorCanUndo)

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -70,7 +70,8 @@ struct FeatureEditorModelTests {
         
         // Stops the geometry editor.
         model.geometryEditor.stop()
-        // Verifies no other properties have been modified.
+        // Verifies the geometry editor properties have been reset and no other
+        // properties have been modified.
         await model.expectDefaultPropertyValues()
     }
     

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -22,9 +22,9 @@ import Testing
 struct FeatureEditorModelTests {
     /// Verifies the model properties' default values.
     @Test
-    func initializer() {
+    func initializer() async {
         let model = FeatureEditorModel()
-        model.expectHasDefaultPropertyValues()
+        await model.expectHasDefaultPropertyValues()
     }
     
     /// Verifies `isPresented` is `true` when editing and resets the model's properties when set
@@ -45,18 +45,18 @@ struct FeatureEditorModelTests {
         model.expectIsEditing(rootFeature: feature)
         #expect(model.isPresented == (model.rootFeatureForm != nil))
         
-        try await model.expectIsGeometryEditing()
-        model.expectIsEditing(geometry: geometry)
+        await model.expectIsGeometryEditing()
+        await model.expectIsEditing(geometry: geometry)
         
         // Verifies setting isPresented to false resets the model's properties.
         model.isPresented = false
-        model.expectHasDefaultPropertyValues()
+        await model.expectHasDefaultPropertyValues()
     }
     
     /// Verifies `monitorGeometryEditorStreams()` updates model properties
     /// when the geometry editor starts and stops.
     @Test
-    func monitorGeometryEditorStreams() async throws {
+    func monitorGeometryEditorStreams() async {
         let model = FeatureEditorModel()
         let monitorTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorTask.cancel() }
@@ -64,22 +64,16 @@ struct FeatureEditorModelTests {
         // Starts the geometry editor with a geometry.
         let geometry = Point(x: 0, y: 0)
         model.geometryEditor.start(withInitial: geometry)
-        try await Task.yield(timeout: 0.1) { @MainActor in
-            model.geometryEditorIsStarted
-        }
-        #expect(model.geometryEditorIsStarted)
-        #expect(model.geometryEditorGeometry == geometry)
+        await Task.expect(model.geometryEditorIsStarted)
+        await Task.expect(model.geometryEditorGeometry == geometry)
         
         // Stops the geometry editor.
         model.geometryEditor.stop()
-        try await Task.yield(timeout: 0.1) { @MainActor in
-            !model.geometryEditorIsStarted
-        }
-        #expect(!model.geometryEditorIsStarted)
-        #expect(model.geometryEditorGeometry == nil)
+        await Task.expect(!model.geometryEditorIsStarted)
+        await Task.expect(model.geometryEditorGeometry == nil)
         
         // Verifies no other properties have been modified.
-        model.expectHasDefaultPropertyValues()
+        await model.expectHasDefaultPropertyValues()
     }
     
     /// Verifies `restartGeometryEditor()` restarts the geometry editor if it is started.
@@ -91,8 +85,7 @@ struct FeatureEditorModelTests {
         
         // Verifies restartGeometryEditor does nothing if the geometry editor has not started.
         model.restartGeometryEditor()
-        await Task.yield()
-        model.expectHasDefaultPropertyValues()
+        await model.expectHasDefaultPropertyValues()
         
         // Starts the feature editor.
         let geodatabaseFile = try await GeodatabaseFile()
@@ -101,16 +94,16 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
         try await model.startEditing(rootFeature: feature, on: nil)
-        try await model.expectIsGeometryEditing()
-        model.expectIsEditing(geometry: geometry)
+        await model.expectIsGeometryEditing()
+        await model.expectIsEditing(geometry: geometry)
         
         // Verifies restartGeometryEditor restarts the geometry editor when it is started.
         let newGeometry = Point(latitude: 1, longitude: 1)
         feature.geometry = newGeometry
         
         model.restartGeometryEditor()
-        try await model.expectIsGeometryEditing()
-        model.expectIsEditing(geometry: newGeometry)
+        await model.expectIsGeometryEditing()
+        await model.expectIsEditing(geometry: newGeometry)
     }
     
     /// Verifies `startEditing(rootFeature:on:)` and `startEditing(newFeatureForm:)` using
@@ -135,8 +128,8 @@ struct FeatureEditorModelTests {
             model.expectIsEditing(rootFeature: feature)
             
             // Verifies geometry editor is started using the feature's geometry.
-            try await model.expectIsGeometryEditing()
-            model.expectIsEditing(geometry: geometry)
+            await model.expectIsGeometryEditing()
+            await model.expectIsEditing(geometry: geometry)
             
             // Verifies map is loaded when starting.
             #expect(map.loadStatus == .loaded)
@@ -158,8 +151,8 @@ struct FeatureEditorModelTests {
             #expect(model.isPresented)
             
             // Verifies geometry editor uses the new geometry.
-            try await model.expectIsGeometryEditing()
-            model.expectIsEditing(geometry: geometry)
+            await model.expectIsGeometryEditing()
+            await model.expectIsEditing(geometry: geometry)
         }
     }
     
@@ -178,7 +171,7 @@ struct FeatureEditorModelTests {
         // Verifies feature editor and geometry editor are started.
         try await model.startEditing(rootFeature: feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
-        try await model.expectIsGeometryEditing()
+        await model.expectIsGeometryEditing()
         
         // Verifies geometry editor is using the table's geometry type.
         let modelGeometry = try #require(model.geometryEditorGeometry)
@@ -207,10 +200,9 @@ struct FeatureEditorModelTests {
         model.expectIsEditing(rootFeature: feature)
         
         // Geometry editor is not started.
-        await Task.yield()
-        #expect(!model.geometryEditorIsStarted)
-        #expect(model.geometryEditorGeometry == nil)
-        #expect(!model.geometryEditorCanUndo)
+        await Task.expect(!model.geometryEditorIsStarted)
+        await Task.expect(model.geometryEditorGeometry == nil)
+        await Task.expect(!model.geometryEditorCanUndo)
         #expect(model.viewpointGeometry == nil)
         #expect(!model.geometryEditor.snapSettings.isEnabled)
     }
@@ -230,12 +222,12 @@ struct FeatureEditorModelTests {
         // Verifies feature editor and geometry editor are started.
         try await model.startEditing(rootFeature: feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
-        try await model.expectIsGeometryEditing()
-        model.expectIsEditing(geometry: geometry)
+        await model.expectIsGeometryEditing()
+        await model.expectIsEditing(geometry: geometry)
         
         // Verifies stopEditing resets the model's properties.
         model.stopEditing()
-        model.expectHasDefaultPropertyValues()
+        await model.expectHasDefaultPropertyValues()
     }
 }
 
@@ -243,14 +235,16 @@ struct FeatureEditorModelTests {
 
 private extension FeatureEditorModel {
     /// Verifies the model's properties have their default values.
-    func expectHasDefaultPropertyValues(sourceLocation: SourceLocation = #_sourceLocation) {
+    func expectHasDefaultPropertyValues(sourceLocation: SourceLocation = #_sourceLocation) async {
         #expect(feature == nil, sourceLocation: sourceLocation)
         #expect(!isPresented, sourceLocation: sourceLocation)
         #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)
         #expect(viewpointGeometry == nil, sourceLocation: sourceLocation)
-        #expect(!geometryEditorCanUndo, sourceLocation: sourceLocation)
-        #expect(geometryEditorGeometry == nil, sourceLocation: sourceLocation)
-        #expect(!geometryEditorIsStarted, sourceLocation: sourceLocation)
+        
+        // Yields to ensure geometry editor properties are updated by monitorGeometryEditorStreams().
+        await Task.expect(!self.geometryEditorCanUndo, sourceLocation: sourceLocation)
+        await Task.expect(self.geometryEditorGeometry == nil, sourceLocation: sourceLocation)
+        await Task.expect(!self.geometryEditorIsStarted, sourceLocation: sourceLocation)
     }
     
     /// Verifies the model has started editing a given feature instance as the root feature.
@@ -267,22 +261,22 @@ private extension FeatureEditorModel {
     }
     
     /// Verifies the model is editing a given geometry.
-    func expectIsEditing(geometry: Geometry, sourceLocation: SourceLocation = #_sourceLocation) {
-        #expect(geometryEditorGeometry == geometry, sourceLocation: sourceLocation)
+    func expectIsEditing(
+        geometry: Geometry,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        await Task.expect(self.geometryEditorGeometry == geometry, sourceLocation: sourceLocation)
         
         // The geometry is used to set the viewpoint.
         #expect(viewpointGeometry == geometry, sourceLocation: sourceLocation)
     }
     
     /// Verifies the model's geometry editor has started.
-    func expectIsGeometryEditing(sourceLocation: SourceLocation = #_sourceLocation) async throws {
-        try await Task.yield(timeout: 0.1) { @MainActor in
-            self.geometryEditorIsStarted
-        }
-        #expect(geometryEditorIsStarted, sourceLocation: sourceLocation)
+    func expectIsGeometryEditing(sourceLocation: SourceLocation = #_sourceLocation) async {
+        await Task.expect(self.geometryEditorIsStarted, sourceLocation: sourceLocation)
         
         // Verifies it started without any edits.
-        #expect(!geometryEditorCanUndo, sourceLocation: sourceLocation)
+        await Task.expect(!self.geometryEditorCanUndo, sourceLocation: sourceLocation)
         
         // Verifies snap settings are enabled by default.
         #expect(geometryEditor.snapSettings.isEnabled, sourceLocation: sourceLocation)
@@ -316,5 +310,18 @@ private extension TableDescription {
     /// A description for table containing WGS84 points.
     static var points: TableDescription {
         TableDescription(name: "Points", spatialReference: .wgs84, geometryType: Point.self)
+    }
+}
+
+private extension Task where Failure == Never, Success == Never {
+    /// Verifies a given condition is true after yielding if needed.
+    @MainActor
+    static func expect(
+        _ condition: @autoclosure @escaping @MainActor () -> Bool,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        // The timeout error is ignored since the condition is already verified in the expect below.
+        try? await yield(timeout: 0.1, until: condition)
+        #expect(condition(), sourceLocation: sourceLocation)
     }
 }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -24,7 +24,7 @@ struct FeatureEditorModelTests {
     @Test
     func initializer() async {
         let model = FeatureEditorModel()
-        await model.expectHasDefaultPropertyValues()
+        await model.expectDefaultPropertyValues()
     }
     
     /// Verifies `isPresented` is `true` when editing and resets the model's properties when set
@@ -35,7 +35,7 @@ struct FeatureEditorModelTests {
         let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorGeometryEditorStreamsTask.cancel() }
         
-        let geodatabaseFile = try await GeodatabaseFile()
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         let geometry = Point(latitude: 0, longitude: 0)
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
@@ -50,7 +50,7 @@ struct FeatureEditorModelTests {
         
         // Verifies setting isPresented to false resets the model's properties.
         model.isPresented = false
-        await model.expectHasDefaultPropertyValues()
+        await model.expectDefaultPropertyValues()
     }
     
     /// Verifies `monitorGeometryEditorStreams()` updates model properties
@@ -73,7 +73,7 @@ struct FeatureEditorModelTests {
         await Task.expect(model.geometryEditorGeometry == nil)
         
         // Verifies no other properties have been modified.
-        await model.expectHasDefaultPropertyValues()
+        await model.expectDefaultPropertyValues()
     }
     
     /// Verifies `restartGeometryEditor()` restarts the geometry editor if it is started.
@@ -85,10 +85,10 @@ struct FeatureEditorModelTests {
         
         // Verifies restartGeometryEditor does nothing if the geometry editor has not started.
         model.restartGeometryEditor()
-        await model.expectHasDefaultPropertyValues()
+        await model.expectDefaultPropertyValues()
         
         // Starts the feature editor.
-        let geodatabaseFile = try await GeodatabaseFile()
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         let geometry = Point(latitude: 0, longitude: 0)
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
@@ -114,7 +114,7 @@ struct FeatureEditorModelTests {
         let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorGeometryEditorStreamsTask.cancel() }
         
-        let geodatabaseFile = try await GeodatabaseFile()
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         
         // Verifies startEditing(rootFeature:on:) starts the feature editor and geometry editor.
@@ -163,7 +163,7 @@ struct FeatureEditorModelTests {
         let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorGeometryEditorStreamsTask.cancel() }
         
-        let geodatabaseFile = try await GeodatabaseFile()
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         let feature = try #require(table.makeFeature() as? ArcGISFeature)
         #expect(feature.geometry == nil)
@@ -175,7 +175,7 @@ struct FeatureEditorModelTests {
         
         // Verifies geometry editor is using the table's geometry type.
         let modelGeometry = try #require(model.geometryEditorGeometry)
-        #expect(type(of: modelGeometry) == Point.self)
+        #expect(modelGeometry is Point)
         #expect(modelGeometry.isEmpty)
         #expect(model.viewpointGeometry == nil)
     }
@@ -187,7 +187,7 @@ struct FeatureEditorModelTests {
         let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorGeometryEditorStreamsTask.cancel() }
         
-        let geodatabaseFile = try await GeodatabaseFile()
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let tableDescription = TableDescription(name: "NonSpatial")
         let table = try await geodatabaseFile.geodatabase.makeTable(description: tableDescription)
         
@@ -214,7 +214,7 @@ struct FeatureEditorModelTests {
         let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorGeometryEditorStreamsTask.cancel() }
         
-        let geodatabaseFile = try await GeodatabaseFile()
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         let geometry = Point(latitude: 0, longitude: 0)
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
@@ -227,7 +227,7 @@ struct FeatureEditorModelTests {
         
         // Verifies stopEditing resets the model's properties.
         model.stopEditing()
-        await model.expectHasDefaultPropertyValues()
+        await model.expectDefaultPropertyValues()
     }
 }
 
@@ -235,7 +235,7 @@ struct FeatureEditorModelTests {
 
 private extension FeatureEditorModel {
     /// Verifies the model's properties have their default values.
-    func expectHasDefaultPropertyValues(sourceLocation: SourceLocation = #_sourceLocation) async {
+    func expectDefaultPropertyValues(sourceLocation: SourceLocation = #_sourceLocation) async {
         #expect(feature == nil, sourceLocation: sourceLocation)
         #expect(!isPresented, sourceLocation: sourceLocation)
         #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)
@@ -283,8 +283,28 @@ private extension FeatureEditorModel {
     }
 }
 
+private extension TableDescription {
+    /// A description for a table containing WGS84 points.
+    static var points: TableDescription {
+        TableDescription(name: "Points", spatialReference: .wgs84, geometryType: Point.self)
+    }
+}
+
+private extension Task where Failure == Never, Success == Never {
+    /// Verifies a condition eventually becomes true.
+    @MainActor
+    static func expect(
+        _ condition: @autoclosure @escaping @MainActor () -> Bool,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        // Timeout error is ignored since the condition is already verified in the expect below.
+        try? await yield(timeout: 0.1, until: condition)
+        #expect(condition(), sourceLocation: sourceLocation)
+    }
+}
+
 /// A file containing a temporary mobile geodatabase.
-private final class GeodatabaseFile {
+private final class TemporaryGeodatabaseFile {
     /// The geodatabase contained in the file.
     let geodatabase: Geodatabase
     
@@ -303,25 +323,5 @@ private final class GeodatabaseFile {
         geodatabase.close()
         let temporaryDirectoryURL = geodatabase.fileURL.deletingLastPathComponent()
         try? FileManager.default.removeItem(at: temporaryDirectoryURL)
-    }
-}
-
-private extension TableDescription {
-    /// A description for table containing WGS84 points.
-    static var points: TableDescription {
-        TableDescription(name: "Points", spatialReference: .wgs84, geometryType: Point.self)
-    }
-}
-
-private extension Task where Failure == Never, Success == Never {
-    /// Verifies a given condition is true after yielding if needed.
-    @MainActor
-    static func expect(
-        _ condition: @autoclosure @escaping @MainActor () -> Bool,
-        sourceLocation: SourceLocation = #_sourceLocation
-    ) async {
-        // The timeout error is ignored since the condition is already verified in the expect below.
-        try? await yield(timeout: 0.1, until: condition)
-        #expect(condition(), sourceLocation: sourceLocation)
     }
 }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -43,7 +43,6 @@ struct FeatureEditorModelTests {
         // Verifies isPresented is true when feature editor starts.
         try await model.startEditing(rootFeature: feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
-        #expect(model.isPresented == (model.rootFeatureForm != nil))
         
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -14,28 +14,50 @@
 
 import ArcGIS
 @testable import ArcGISToolkit
+import Foundation
 import Testing
 
 @Suite("FeatureEditorModel Tests")
 @MainActor
 struct FeatureEditorModelTests {
+    /// Verifies the model properties' default values.
     @Test
     func initializer() {
         let model = FeatureEditorModel()
-        #expect(model.feature == nil)
-        #expect(!model.isPresented)
-        #expect(model.rootFeatureForm == nil)
-        #expect(model.viewpointGeometry == nil)
-        #expect(!model.geometryEditorCanUndo)
-        #expect(model.geometryEditorGeometry == nil)
-        #expect(!model.geometryEditorIsStarted)
+        model.expectHasDefaultPropertyValues()
     }
     
+    /// Verifies `isPresented` is `true` when editing and resets the model's properties when set
+    /// to `false`.
+    @Test
+    func isPresented() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        let geodatabaseFile = try await GeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        let geometry = Point(latitude: 0, longitude: 0)
+        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+        
+        // Verifies isPresented is true when feature editor starts.
+        try await model.startEditing(rootFeature: feature, on: nil)
+        model.expectIsEditing(rootFeature: feature)
+        #expect(model.isPresented == (model.rootFeatureForm != nil))
+        
+        try await model.expectIsGeometryEditing()
+        model.expectIsEditing(geometry: geometry)
+        
+        // Verifies setting isPresented to false resets the model's properties.
+        model.isPresented = false
+        model.expectHasDefaultPropertyValues()
+    }
+    
+    /// Verifies `monitorGeometryEditorStreams()` updates model properties
+    /// when the geometry editor starts and stops.
     @Test
     func monitorGeometryEditorStreams() async throws {
         let model = FeatureEditorModel()
-        #expect(model.geometryEditorGeometry == nil)
-        #expect(!model.geometryEditorIsStarted)
         let monitorTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorTask.cancel() }
         
@@ -55,5 +77,244 @@ struct FeatureEditorModelTests {
         }
         #expect(!model.geometryEditorIsStarted)
         #expect(model.geometryEditorGeometry == nil)
+        
+        // Verifies no other properties have been modified.
+        model.expectHasDefaultPropertyValues()
+    }
+    
+    /// Verifies `restartGeometryEditor()` restarts the geometry editor if it is started.
+    @Test
+    func restartGeometryEditor() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        // Verifies restartGeometryEditor does nothing if the geometry editor has not started.
+        model.restartGeometryEditor()
+        await Task.yield()
+        model.expectHasDefaultPropertyValues()
+        
+        // Starts the feature editor.
+        let geodatabaseFile = try await GeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        let geometry = Point(latitude: 0, longitude: 0)
+        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+        
+        try await model.startEditing(rootFeature: feature, on: nil)
+        try await model.expectIsGeometryEditing()
+        model.expectIsEditing(geometry: geometry)
+        
+        // Verifies restartGeometryEditor restarts the geometry editor when it is started.
+        let newGeometry = Point(latitude: 1, longitude: 1)
+        feature.geometry = newGeometry
+        
+        model.restartGeometryEditor()
+        try await model.expectIsGeometryEditing()
+        model.expectIsEditing(geometry: newGeometry)
+    }
+    
+    /// Verifies `startEditing(rootFeature:on:)` and `startEditing(newFeatureForm:)` using
+    /// features with geometries.
+    @Test
+    func startEditing() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        let geodatabaseFile = try await GeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        
+        // Verifies startEditing(rootFeature:on:) starts the feature editor and geometry editor.
+        do {
+            let geometry = Point(latitude: 0, longitude: 0)
+            let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+            let map = Map(spatialReference: .wgs84)
+            
+            // Verifies feature editor is started using the feature instance.
+            try await model.startEditing(rootFeature: feature, on: map)
+            model.expectIsEditing(rootFeature: feature)
+            
+            // Verifies geometry editor is started using the feature's geometry.
+            try await model.expectIsGeometryEditing()
+            model.expectIsEditing(geometry: geometry)
+            
+            // Verifies map is loaded when starting.
+            #expect(map.loadStatus == .loaded)
+        }
+        
+        // Verifies startEditing(newFeatureForm:) updates the correct model properties.
+        do {
+            let geometry = Point(latitude: 1, longitude: 1)
+            let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+            let featureForm = FeatureForm(feature: feature)
+            
+            // Verifies feature editor uses the new feature instance.
+            try await model.startEditing(newFeatureForm: featureForm)
+            #expect(model.feature === feature)
+            
+            // Verifies rootFeatureForm does not update.
+            #expect(model.rootFeatureForm !== featureForm)
+            #expect(model.rootFeatureForm?.feature !== feature)
+            #expect(model.isPresented)
+            
+            // Verifies geometry editor uses the new geometry.
+            try await model.expectIsGeometryEditing()
+            model.expectIsEditing(geometry: geometry)
+        }
+    }
+    
+    /// Verifies `startEditing(rootFeature:on:)` using a feature without a geometry.
+    @Test
+    func startEditingFeatureWithoutGeometry() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        let geodatabaseFile = try await GeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        let feature = try #require(table.makeFeature() as? ArcGISFeature)
+        #expect(feature.geometry == nil)
+        
+        // Verifies feature editor and geometry editor are started.
+        try await model.startEditing(rootFeature: feature, on: nil)
+        model.expectIsEditing(rootFeature: feature)
+        try await model.expectIsGeometryEditing()
+        
+        // Verifies geometry editor is using the table's geometry type.
+        let modelGeometry = try #require(model.geometryEditorGeometry)
+        #expect(type(of: modelGeometry) == Point.self)
+        #expect(modelGeometry.isEmpty)
+        #expect(model.viewpointGeometry == nil)
+    }
+    
+    /// Verifies `startEditing(rootFeature:on:)` using a non-spatial feature.
+    @Test
+    func startEditingNonSpatialFeature() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        let geodatabaseFile = try await GeodatabaseFile()
+        let tableDescription = TableDescription(name: "NonSpatial")
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: tableDescription)
+        
+        let feature = try #require(table.makeFeature() as? ArcGISFeature)
+        try await feature.load()
+        #expect(!feature.canUpdateGeometry)
+        
+        // Verifies feature editor is started using the feature instance.
+        try await model.startEditing(rootFeature: feature, on: nil)
+        model.expectIsEditing(rootFeature: feature)
+        
+        // Geometry editor is not started.
+        await Task.yield()
+        #expect(!model.geometryEditorIsStarted)
+        #expect(model.geometryEditorGeometry == nil)
+        #expect(!model.geometryEditorCanUndo)
+        #expect(model.viewpointGeometry == nil)
+        #expect(!model.geometryEditor.snapSettings.isEnabled)
+    }
+    
+    /// Verifies `stopEditing()` resets the model's properties to their default values.
+    @Test
+    func stopEditing() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        let geodatabaseFile = try await GeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        let geometry = Point(latitude: 0, longitude: 0)
+        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+        
+        // Verifies feature editor and geometry editor are started.
+        try await model.startEditing(rootFeature: feature, on: nil)
+        model.expectIsEditing(rootFeature: feature)
+        try await model.expectIsGeometryEditing()
+        model.expectIsEditing(geometry: geometry)
+        
+        // Verifies stopEditing resets the model's properties.
+        model.stopEditing()
+        model.expectHasDefaultPropertyValues()
+    }
+}
+
+// MARK: Helper
+
+private extension FeatureEditorModel {
+    /// Verifies the model's properties have their default values.
+    func expectHasDefaultPropertyValues(sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(feature == nil, sourceLocation: sourceLocation)
+        #expect(!isPresented, sourceLocation: sourceLocation)
+        #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)
+        #expect(viewpointGeometry == nil, sourceLocation: sourceLocation)
+        #expect(!geometryEditorCanUndo, sourceLocation: sourceLocation)
+        #expect(geometryEditorGeometry == nil, sourceLocation: sourceLocation)
+        #expect(!geometryEditorIsStarted, sourceLocation: sourceLocation)
+    }
+    
+    /// Verifies the model has started editing a given feature instance as the root feature.
+    func expectIsEditing(
+        rootFeature: ArcGISFeature,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        #expect(feature === rootFeature, sourceLocation: sourceLocation)
+        #expect(isPresented, sourceLocation: sourceLocation)
+        #expect(rootFeatureForm?.feature === rootFeature, sourceLocation: sourceLocation)
+        
+        // Verifies starting loaded the feature.
+        #expect(rootFeature.loadStatus == .loaded, sourceLocation: sourceLocation)
+    }
+    
+    /// Verifies the model is editing a given geometry.
+    func expectIsEditing(geometry: Geometry, sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(geometryEditorGeometry == geometry, sourceLocation: sourceLocation)
+        
+        // The geometry is used to set the viewpoint.
+        #expect(viewpointGeometry == geometry, sourceLocation: sourceLocation)
+    }
+    
+    /// Verifies the model's geometry editor has started.
+    func expectIsGeometryEditing(sourceLocation: SourceLocation = #_sourceLocation) async throws {
+        try await Task.yield(timeout: 0.1) { @MainActor in
+            self.geometryEditorIsStarted
+        }
+        #expect(geometryEditorIsStarted, sourceLocation: sourceLocation)
+        
+        // Verifies it started without any edits.
+        #expect(!geometryEditorCanUndo, sourceLocation: sourceLocation)
+        
+        // Verifies snap settings are enabled by default.
+        #expect(geometryEditor.snapSettings.isEnabled, sourceLocation: sourceLocation)
+    }
+}
+
+/// A file containing a temporary mobile geodatabase.
+private final class GeodatabaseFile {
+    /// The geodatabase contained in the file.
+    let geodatabase: Geodatabase
+    
+    init() async throws {
+        let temporaryDirectoryURL = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        let temporaryGeodatabaseURL = temporaryDirectoryURL.appending(path: "temp.geodatabase")
+        geodatabase = try await Geodatabase.createEmpty(fileURL: temporaryGeodatabaseURL)
+    }
+    
+    deinit {
+        geodatabase.close()
+        let temporaryDirectoryURL = geodatabase.fileURL.deletingLastPathComponent()
+        try? FileManager.default.removeItem(at: temporaryDirectoryURL)
+    }
+}
+
+private extension TableDescription {
+    /// A description for table containing WGS84 points.
+    static var points: TableDescription {
+        TableDescription(name: "Points", spatialReference: .wgs84, geometryType: Point.self)
     }
 }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -33,32 +33,14 @@ struct FeatureEditorModelTests {
     
     @Test
     func monitorGeometryEditorStreams() async throws {
-        // Loads a Naperville water network web map with a feature layer and
-        // queries a feature to create a feature form.
-        let map = Map(item: PortalItem(
-            portal: .arcGISOnline(connection: .anonymous),
-            id: PortalItem.ID("acc027394bc84c2fb04d1ed317aac674")!
-        ))
-        try await map.load()
-        let layer = try #require(map.operationalLayers.first { $0.name == "Main" } as? FeatureLayer)
-        let parameters = QueryParameters()
-        parameters.addObjectID(3651)
-        let result = try await #require(layer.featureTable?.queryFeatures(using: parameters))
-        let feature = try #require(result.features().makeIterator().next() as? ArcGISFeature)
-        let featureForm = FeatureForm(feature: feature)
-        let geometry = try #require(feature.geometry)
-        
-        // Creates a model and starts the geometry editor with the feature form
-        // and geometry.
         let model = FeatureEditorModel()
-        #expect(model.featureForm == nil)
         #expect(model.geometryEditorGeometry == nil)
         #expect(!model.geometryEditorIsStarted)
-        let monitorTask = Task { await model.monitorGeometryEditorStreams() }
+        let monitorTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorTask.cancel() }
-        model.featureForm = featureForm
         
-        // Starts the geometry editor with the feature's geometry.
+        // Starts the geometry editor with a geometry.
+        let geometry = Point(x: 0, y: 0)
         model.geometryEditor.start(withInitial: geometry)
         try await Task.yield(timeout: 0.1) { @MainActor in
             model.geometryEditorIsStarted
@@ -73,14 +55,5 @@ struct FeatureEditorModelTests {
         }
         #expect(!model.geometryEditorIsStarted)
         #expect(model.geometryEditorGeometry == nil)
-        
-        // The feature form remains the same after stopping the geometry editor.
-        #expect(model.featureForm === featureForm)
-        
-        // Resets the model.
-        model.reset()
-        #expect(model.featureForm == nil)
-        #expect(model.geometryEditorGeometry == nil)
-        #expect(!model.geometryEditorIsStarted)
     }
 }


### PR DESCRIPTION
## Description

This PR updates Feature Editor tests corresponding to the changes made in https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1491:

- `FeatureEditorModelTests`: Adds unit tests for the start/stop logic that was moved into the `FeatureEditorModel`.
- `FeatureEditorToolbarTests`: Updates `testDefaultToggleStatesAndPreservation()` include coverage for snap rule syncing.

Closes `swift/issues/8354`.


## How To Test

Ensure `FeatureEditorModelTests` & `FeatureEditorToolbarTests` run successfully.
