### PR TITLE
`FeatureEditor`: Fix presentation issues

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -41,6 +41,10 @@ final class FeatureEditorModel {
     private var presentedFeatureForm: FeatureForm?
     /// The root feature form to edit with the feature editor.
     private(set) var rootFeatureForm: FeatureForm?
+    /// A Boolean value indicating whether the snap settings sheet is presented.
+    /// This is needed to prevent the sheet from dismissing the feature editor
+    /// when the horizontal size class is compact.
+    var snapSettingsSheetIsPresented = false
     /// The geometry used to set the viewpoint.
     var viewpointGeometry: Geometry?
     
@@ -130,6 +134,7 @@ final class FeatureEditorModel {
     func stopEditing() {
         rootFeatureForm = nil
         presentedFeatureForm = nil
+        snapSettingsSheetIsPresented = false
         viewpointGeometry = nil
         
         geometryEditor.stop()

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -42,8 +42,8 @@ final class FeatureEditorModel {
     /// The root feature form to edit with the feature editor.
     private(set) var rootFeatureForm: FeatureForm?
     /// A Boolean value indicating whether the snap settings sheet is presented.
-    /// This is needed to prevent the sheet from dismissing the feature editor
-    /// when the horizontal size class is compact.
+    /// This is needed to display the sheet from the modifier to prevent it from
+    /// dismissing the feature editor when the horizontal size class is compact.
     var snapSettingsSheetIsPresented = false
     /// The geometry used to set the viewpoint.
     var viewpointGeometry: Geometry?

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -50,6 +50,9 @@ private struct FeatureEditorModifier: ViewModifier {
                 )
                 .inspectorColumnWidth(ideal: 320)
                 .interactiveDismissDisabled()
+                .sheet(isPresented: $model.snapSettingsSheetIsPresented) {
+                    SnapSettingsView(settings: model.geometryEditor.snapSettings)
+                }
             }
             .environment(model)
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -38,21 +38,22 @@ private struct FeatureEditorModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .safeInspector(isPresented: $model.isPresented) {
-                // VStack is needed for presentation modifiers to be applied.
-                VStack(spacing: 0) {
-                    FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
-                }
-                .presentationBackgroundInteraction(.enabled)
-                .presentationContentInteraction(.scrolls)
-                .presentationDetents(
-                    [.bar, .medium, .large],
-                    selection: $selectedPresentationDetent
-                )
-                .inspectorColumnWidth(ideal: 320)
-                .interactiveDismissDisabled()
-                .sheet(isPresented: $model.snapSettingsSheetIsPresented) {
-                    SnapSettingsView(settings: model.geometryEditor.snapSettings)
-                }
+                FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
+                    .presentationBackgroundInteraction(.enabled)
+                    .presentationContentInteraction(.scrolls)
+                    .presentationDetents(
+                        [.bar, .medium, .large],
+                        selection: $selectedPresentationDetent
+                    )
+#if !targetEnvironment(macCatalyst)
+                // Needed to ensure the inspector presents at full width on iPad.
+                // This is not done on Mac Catalyst because 320 is smaller than its default.
+                    .inspectorColumnWidth(ideal: 320)
+#endif
+                    .interactiveDismissDisabled()
+                    .sheet(isPresented: $model.snapSettingsSheetIsPresented) {
+                        SnapSettingsView(settings: model.geometryEditor.snapSettings)
+                    }
             }
             .environment(model)
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -171,7 +171,10 @@ private extension View {
         if UIDevice.current.userInterfaceIdiom == .phone {
             sheet(isPresented: isPresented, content: content)
         } else {
-            inspector(isPresented: isPresented, content: content)
+            // The inspector is given a constant to prevent it from setting isPresented to false
+            // when the window is minimized in iPad Stage Manager. Otherwise, the feature editor
+            // will stop editing and be in an invalid state when the window is re-expanded.
+            inspector(isPresented: .constant(isPresented.wrappedValue), content: content)
         }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -158,8 +158,7 @@ private extension PresentationDetent {
 private extension View {
     /// Presents content in a sheet on iPhone and in an inspector on all other devices.
     ///
-    /// This is needed because the `View.presentationDetents(_:selection:)`
-    /// selection value does not update with inspectors.
+    /// This is needed for the presentation modifiers to be applied on iPhone.
     /// - Parameters:
     ///   - isPresented: A Boolean value indicating whether the inspector is presented.
     ///   - content: The content to display in the inspector.
@@ -174,7 +173,7 @@ private extension View {
         } else {
             // The inspector is given a constant to prevent it from setting isPresented to false
             // when the window is minimized in iPad Stage Manager. Otherwise, the feature editor
-            // will stop editing and be in an invalid state when the window is re-expanded.
+            // will stop editing and show an empty inspector when the window is re-expanded.
             inspector(isPresented: .constant(isPresented.wrappedValue), content: content)
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -38,22 +38,25 @@ private struct FeatureEditorModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .safeInspector(isPresented: $model.isPresented) {
-                FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
-                    .presentationBackgroundInteraction(.enabled)
-                    .presentationContentInteraction(.scrolls)
-                    .presentationDetents(
-                        [.bar, .medium, .large],
-                        selection: $selectedPresentationDetent
-                    )
+                // VStack is needed for presentation modifiers to be applied.
+                VStack(spacing: 0) {
+                    FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
+                }
+                .presentationBackgroundInteraction(.enabled)
+                .presentationContentInteraction(.scrolls)
+                .presentationDetents(
+                    [.bar, .medium, .large],
+                    selection: $selectedPresentationDetent
+                )
 #if !targetEnvironment(macCatalyst)
                 // Needed to ensure the inspector presents at full width on iPad.
                 // This is not done on Mac Catalyst because 320 is smaller than its default.
-                    .inspectorColumnWidth(ideal: 320)
+                .inspectorColumnWidth(ideal: 320)
 #endif
-                    .interactiveDismissDisabled()
-                    .sheet(isPresented: $model.snapSettingsSheetIsPresented) {
-                        SnapSettingsView(settings: model.geometryEditor.snapSettings)
-                    }
+                .interactiveDismissDisabled()
+                .sheet(isPresented: $model.snapSettingsSheetIsPresented) {
+                    SnapSettingsView(settings: model.geometryEditor.snapSettings)
+                }
             }
             .environment(model)
     }
@@ -158,7 +161,8 @@ private extension PresentationDetent {
 private extension View {
     /// Presents content in a sheet on iPhone and in an inspector on all other devices.
     ///
-    /// This is needed for the presentation modifiers to be applied on iPhone.
+    /// This is needed because the `View.presentationDetents(_:selection:)`
+    /// selection value does not update with inspectors.
     /// - Parameters:
     ///   - isPresented: A Boolean value indicating whether the inspector is presented.
     ///   - content: The content to display in the inspector.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -152,13 +152,10 @@ private struct SnapSettingsButton: View {
     /// The model for the parent feature editor containing the snap settings.
     @Environment(FeatureEditorModel.self) private var featureEditorModel
     
-    /// A Boolean value indicating whether the settings view is presented.
-    @State private var isShowingSettings = false
-    
     var body: some View {
         Button {
             featureEditorModel.syncSnapSourceSettings()
-            isShowingSettings.toggle()
+            featureEditorModel.snapSettingsSheetIsPresented.toggle()
         } label: {
             Label {
                 Text(
@@ -169,11 +166,6 @@ private struct SnapSettingsButton: View {
             } icon: {
                 Image(systemName: "gear")
             }
-        }
-        .sheet(isPresented: $isShowingSettings) {
-            SnapSettingsView(settings: featureEditorModel.geometryEditor.snapSettings)
-            // Needed to override the font set in toolbarStackStyle.
-                .font(nil)
         }
     }
 }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -237,6 +237,7 @@ private extension FeatureEditorModel {
         #expect(feature == nil, sourceLocation: sourceLocation)
         #expect(!isPresented, sourceLocation: sourceLocation)
         #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)
+        #expect(!snapSettingsSheetIsPresented, sourceLocation: sourceLocation)
         #expect(viewpointGeometry == nil, sourceLocation: sourceLocation)
         
         // Yields to ensure geometry editor properties are updated by monitorGeometryEditorStreams().


### PR DESCRIPTION
## Description

This PR fixes some Feature Editor presentation issues:
1. A bug where opening the snap settings sheet would dismiss the feature editor inspector when the horizontal size class was compact. On iPhone, this would cause some state, like the form view navigation, to reset. On iPad, this would prevent the sheet from being closed while the window was minimized in Stage Manager.
2. A bug where minimizing the window using iPad Stage Manager would stop the Feature Editor, which would then result in an empty inspector when the window was re-expanded.
3. The inspector width on Mac Catalyst, which was smaller than the default.

Closes `swift/issues/8276`.


## How To Test

Run the `FeatureEditorExample` and ensure the inspector and snapping sheet work as expected. If you want to verify the bug fixes, use the workflows in the gifs below.


## Screenshots

### 1. Snapping Sheet Bug
|Before|After|
|:-:|:-:|
| <img width="230" height="500" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-07-10 at 13 12 46" src="https://github.com/user-attachments/assets/621c4de4-0fe9-46af-91bf-a78400cc9a4c" /> | <img width="230" height="500" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-07-10 at 13 21 08" src="https://github.com/user-attachments/assets/73b4c140-c067-4e66-ac79-e4d3efa92547" /> |

### 2. Stage Manager Bug
|Before|After|
|:-:|:-:|
| <img alt="Simulator Screen Recording - iPad (A16) - 2026-07-10 at 13 17 08" src="https://github.com/user-attachments/assets/ab9e393b-1920-4f59-a877-cfc8c5d0e24c" /> | <img alt="Simulator Screen Recording - iPad (A16) - 2026-07-10 at 13 19 58" src="https://github.com/user-attachments/assets/7d55354c-5dc2-4a38-af2a-5b2698b8917e" /> |

### 3. Mac Catalyst Inspector Width
|Before|After|
|:-:|:-:|
| <img width="1136" height="880" alt="Screenshot 2026-07-10 at 12 19 09 PM" src="https://github.com/user-attachments/assets/1521355f-43b1-4f75-ba6a-1b462ebf0997" /> | <img width="1136" height="880" alt="Screenshot 2026-07-10 at 12 20 28 PM" src="https://github.com/user-attachments/assets/6d00ff4f-5fb6-49ac-b059-6ae3583fa168" /> |
