### PR TITLE
fe: Address build and test failures

### DIFF
--- a/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
@@ -32,7 +32,8 @@ struct FeatureEditorTestView: View {
             .overlay(alignment: .topTrailing) {
                 FeatureEditor(
                     $featureToEdit,
-                    geometryEditor: geometryEditor
+                    geometryEditor: geometryEditor,
+                    map: map
                 )
                 .padding()
             }

--- a/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
+++ b/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
@@ -168,7 +168,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         
         // Use one snap source toggle to verify that snapping to snap sources
         // are disabled by default.
-        let structureLineToggle = app.snapToggle(named: "Structure Line")
+        let structureLineToggle = app.snapToggle(named: "NapervilleElectricV5 - Dirty Areas")
         structureLineToggle.assertExistence()
         XCTAssertEqual(structureLineToggle.boolValue, false)
         

--- a/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
+++ b/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
@@ -168,20 +168,20 @@ final class FeatureEditorToolbarTests: XCTestCase {
         
         // Use one snap source toggle to verify that snapping to snap sources
         // are disabled by default.
-        let structureLineToggle = app.snapToggle(named: "NapervilleElectricV5 - Dirty Areas")
-        structureLineToggle.assertExistence()
-        XCTAssertEqual(structureLineToggle.boolValue, false)
+        let dirtyAreasToggle = app.snapToggle(named: "NapervilleElectricV5 - Dirty Areas")
+        dirtyAreasToggle.assertExistence()
+        XCTAssertEqual(dirtyAreasToggle.boolValue, false)
         
         // Turn on some toggles and verify their states are preserved when the
         // settings view is reopened.
         geometryGuidesToggle.tapResolvedToggleControl()
-        structureLineToggle.tapResolvedToggleControl()
+        dirtyAreasToggle.tapResolvedToggleControl()
         // Close the settings view.
         app.buttons["Close"].assertExistenceAndTap()
         // Reopen the settings view and verify the toggles states are preserved.
         app.buttons["Settings"].assertExistenceAndTap()
         XCTAssertEqual(geometryGuidesToggle.boolValue, true)
-        XCTAssertEqual(structureLineToggle.boolValue, true)
+        XCTAssertEqual(dirtyAreasToggle.boolValue, true)
     }
 }
 


### PR DESCRIPTION
#1491 added snap rules and it breaks the UI test. The previous "Structure Line" layer disables snapping due to snap rules. Change the snap source toggle test to the "NapervilleElectricV5 - Dirty Areas" source at the top of the section.

<img width="1032" height="1376" alt="snap-rules" src="https://github.com/user-attachments/assets/3524eabc-f994-43d7-9cf3-876fabb1eccc" />
