### PR TITLE
`FeatureEditor`: Fix `FeatureEditorToolbarTests`

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -162,7 +162,7 @@ private struct SnapSettingsButton: View {
         } label: {
             Label {
                 Text(
-                    "Settings",
+                    "Snap Settings",
                     bundle: .toolkitModule,
                     comment: "A label for a button to show settings for configuring snapping."
                 )

--- a/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
+++ b/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
@@ -154,7 +154,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         let app = XCUIApplication()
         
         openFeatureEditorTestViewWithStartingFeature(3321, on: .electricDistributionDevice)
-        app.buttons["Settings"].assertExistenceAndTap(timeout: 30)
+        app.buttons["Snap Settings"].assertExistenceAndTap(timeout: 30)
         
         let geometryGuidesToggle = app.snapToggle(named: "Snap to Geometry Guides")
         let featuresToggle = app.snapToggle(named: "Snap to Features")
@@ -185,7 +185,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         // Close the settings view.
         app.buttons["Close"].assertExistenceAndTap()
         // Reopen the settings view and verify the toggles states are preserved.
-        app.buttons["Settings"].assertExistenceAndTap()
+        app.buttons["Snap Settings"].assertExistenceAndTap()
         XCTAssertEqual(geometryGuidesToggle.boolValue, true)
         XCTAssertEqual(dirtyAreasToggle.boolValue, true)
     }

--- a/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
+++ b/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
@@ -47,7 +47,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         let toolButton = app.toolButton
         let deleteButton = app.buttons["Delete Selected Element"]
         
-        toolButton.assertExistence(timeout: 3)
+        toolButton.assertExistence(timeout: 30)
         deleteButton.assertExistence()
         
         let toolMidY = toolButton.frame.midY
@@ -66,7 +66,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         openFeatureEditorTestViewWithStartingFeature(3321, on: .electricDistributionDevice)
         
         let toolButton = app.toolButton
-        toolButton.assertExistence(timeout: 3)
+        toolButton.assertExistence(timeout: 30)
         
         app.buttons["Cancel"].assertExistenceAndTap()
         toolButton.assertNonExistence(timeout: 1)
@@ -79,7 +79,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         openFeatureEditorTestViewWithStartingFeature(3321, on: .electricDistributionDevice)
         
         let toolButton = app.toolButton
-        toolButton.assertExistenceAndTap(timeout: 3)
+        toolButton.assertExistenceAndTap(timeout: 30)
         
         [
             "Vertex",
@@ -101,7 +101,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         openFeatureEditorTestViewWithStartingFeature(2525, on: .electricDistributionLine)
         
         let toolButton = app.toolButton
-        toolButton.assertExistenceAndTap(timeout: 3)
+        toolButton.assertExistenceAndTap(timeout: 30)
         
         [
             "Freehand",
@@ -128,7 +128,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         openFeatureEditorTestViewWithStartingFeature(1, on: .structureBoundary)
         
         let toolButton = app.toolButton
-        toolButton.assertExistenceAndTap(timeout: 3)
+        toolButton.assertExistenceAndTap(timeout: 30)
         
         [
             "Freehand",
@@ -154,7 +154,7 @@ final class FeatureEditorToolbarTests: XCTestCase {
         let app = XCUIApplication()
         
         openFeatureEditorTestViewWithStartingFeature(3321, on: .electricDistributionDevice)
-        app.buttons["Settings"].assertExistenceAndTap()
+        app.buttons["Settings"].assertExistenceAndTap(timeout: 30)
         
         let geometryGuidesToggle = app.snapToggle(named: "Snap to Geometry Guides")
         let featuresToggle = app.snapToggle(named: "Snap to Features")


### PR DESCRIPTION
## Description

This PR makes some `FeatureEditorToolbarTests` fixes:
- Increased the toolbar appearance timeout, needed due to the additional async setup added in https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/pull/1491.
- Updated the `SnapSettingsButton` label from `Settings` -> `Snap Settings`.

## How To Test

Ensure the `FeatureEditorToolbarTests` pass.
