### PR TITLE
fe: Add error handling for setup

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -112,7 +112,7 @@ public struct FeatureEditor: View {
             }
             .task(id: startEditingIDs) {
                 if let feature {
-                    await model.startEditing(rootFeature: feature, on: map)
+                    await model.startEditingFeature(feature, on: map)
                 } else {
                     model.stopEditing()
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -112,13 +112,7 @@ public struct FeatureEditor: View {
             }
             .task(id: startEditingIDs) {
                 if let feature {
-                    do {
-                        try await model.startEditing(rootFeature: feature, on: map)
-                    } catch {
-                        Logger.featureEditor.error(
-                            "Error starting feature editor: \(error.localizedDescription)"
-                        )
-                    }
+                    await model.startEditing(rootFeature: feature, on: map)
                 } else {
                     model.stopEditing()
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -201,6 +201,9 @@ final class FeatureEditorModel {
         // Loads the feature so canUpdateGeometry can be accessed. It is always
         // false otherwise.
         try await feature.retryLoad()
+        // No need to load the feature's table upfront if the we don't edit its
+        // geometry.
+        guard feature.canUpdateGeometry else { return }
         
         // Loads the feature's table if the geometry is nil so geometryType
         // can be accessed. It is always nil otherwise.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -49,6 +49,8 @@ final class FeatureEditorModel {
     var snapSettingsSheetIsPresented = false
     /// The geometry used to set the viewpoint.
     var viewpointGeometry: Geometry?
+    /// A Boolean value indicating whether the model is loaded.
+    var isLoaded = false
     
     // MARK: Geometry Editor Properties
     
@@ -117,6 +119,8 @@ final class FeatureEditorModel {
         presentedFeatureForm = featureForm
         
         do {
+            defer { isLoaded = true }
+            try await loadFeature()
             try await setUpGeometryEditing()
         } catch {
             startEditingError = error
@@ -135,6 +139,8 @@ final class FeatureEditorModel {
         rootFeatureForm = FeatureForm(feature: feature)
         self.map = map
         do {
+            defer { isLoaded = true }
+            try await loadFeature()
             if let map {
                 // Only try to set up snap rules when a map is provided.
                 // Sets up the utility network so snap rules can be created.
@@ -155,6 +161,8 @@ final class FeatureEditorModel {
     func retryStartEditing() async {
         guard startEditingError != nil else { return }
         do {
+            defer { isLoaded = true }
+            try await loadFeature()
             if let map {
                 try await map.retryLoad()
                 await map.utilityNetworks.retryLoad()
@@ -188,6 +196,7 @@ final class FeatureEditorModel {
         
         snapRules = nil
         map = nil
+        isLoaded = false
     }
     
     /// Syncs the `geometryEditor.snapSettings`' source settings.
@@ -210,10 +219,9 @@ final class FeatureEditorModel {
         }
     }
     
-    /// Performs setup needed for geometry editing and starts the geometry editor if applicable.
-    private func setUpGeometryEditing() async throws {
+    /// Loads the feature and its table if needed to allow geometry editing.
+    private func loadFeature() async throws {
         guard let feature else { return }
-        
         // Loads the feature so canUpdateGeometry can be accessed. It is always false otherwise.
         try await feature.retryLoad()
         guard feature.canUpdateGeometry else { return }
@@ -223,7 +231,11 @@ final class FeatureEditorModel {
         if feature.geometry == nil, let table = feature.table {
             try await table.retryLoad()
         }
-        
+    }
+    
+    /// Performs setup needed for geometry editing and starts the geometry editor if applicable.
+    private func setUpGeometryEditing() async throws {
+        guard let feature else { return }
         // Sets up the snap rules and syncs the snap source settings.
         if let utilityNetwork, let element = utilityNetwork.makeElement(arcGISFeature: feature) {
             // Errors are ignored to set snapRules to nil if creation fails, so

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -38,6 +38,7 @@ final class FeatureEditorModel {
     }
     /// The form currently presented in the feature editor's `FeatureFormView`.
     /// This is non-`nil` after a new feature form is shown in the view.
+    @ObservationIgnored
     private var presentedFeatureForm: FeatureForm?
     /// The root feature form to edit with the feature editor.
     private(set) var rootFeatureForm: FeatureForm?
@@ -66,9 +67,11 @@ final class FeatureEditorModel {
     // MARK: Snapping Properties
     
     /// The map that contains the utility network being edited.
+    @ObservationTracked
     private var map: Map?
     /// The snap rules for the `feature`, used to sync snap source settings.
     /// This is non-`nil` when snap rules were successfully created using the `utilityNetwork`.
+    @ObservationTracked
     private var snapRules: SnapRules?
     /// The `feature`'s utility network used to create snap rules.
     /// This is non-`nil` when a map containing the feature's UN is used to start editing.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -119,9 +119,9 @@ final class FeatureEditorModel {
         presentedFeatureForm = featureForm
         
         do {
-            defer { isLoaded = true }
             try await loadFeature()
             try await setUpGeometryEditing()
+            isLoaded = true
         } catch {
             startEditingError = error
             Logger.featureEditor.error(
@@ -139,7 +139,6 @@ final class FeatureEditorModel {
         rootFeatureForm = FeatureForm(feature: feature)
         self.map = map
         do {
-            defer { isLoaded = true }
             try await loadFeature()
             if let map {
                 // Only try to set up snap rules when a map is provided.
@@ -148,6 +147,7 @@ final class FeatureEditorModel {
                 await map.utilityNetworks.load()
             }
             try await setUpGeometryEditing()
+            isLoaded = true
         } catch {
             // Don't start editing whichever error occurs, and let user retry.
             startEditingError = error
@@ -161,7 +161,6 @@ final class FeatureEditorModel {
     func retryStartEditing() async {
         guard startEditingError != nil else { return }
         do {
-            defer { isLoaded = true }
             try await loadFeature()
             if let map {
                 try await map.retryLoad()
@@ -169,6 +168,7 @@ final class FeatureEditorModel {
             }
             try await setUpGeometryEditing()
             startEditingError = nil
+            isLoaded = true
         } catch {
             // Don't start editing whichever error occurs, and let user retry.
             startEditingError = error

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -140,9 +140,7 @@ final class FeatureEditorModel {
                 // Only try to set up snap rules when a map is provided.
                 // Sets up the utility network so snap rules can be created.
                 try await map.load()
-                for utilityNetwork in map.utilityNetworks {
-                    try await utilityNetwork.load()
-                }
+                await map.utilityNetworks.load()
             }
             try await setUpGeometryEditing()
         } catch {
@@ -160,9 +158,7 @@ final class FeatureEditorModel {
         do {
             if let map {
                 try await map.retryLoad()
-                if let utilityNetwork {
-                    try await utilityNetwork.retryLoad()
-                }
+                await map.utilityNetworks.retryLoad()
             }
             try await setUpGeometryEditing()
         } catch {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -133,10 +133,9 @@ final class FeatureEditorModel {
     func startEditing(rootFeature feature: ArcGISFeature, on map: Map?) async {
         stopEditing()
         rootFeatureForm = FeatureForm(feature: feature)
-        
+        self.map = map
         do {
             if let map {
-                self.map = map
                 // Only try to set up snap rules when a map is provided.
                 // Sets up the utility network so snap rules can be created.
                 try await map.load()

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -73,13 +73,9 @@ final class FeatureEditorModel {
     /// The `feature`'s utility network used to create snap rules.
     /// This is non-`nil` when a map containing the feature's UN is used to start editing.
     private var utilityNetwork: UtilityNetwork? {
-        if let map, let feature {
-            return map.utilityNetworks.first { utilityNetwork in
-                utilityNetwork.makeElement(arcGISFeature: feature) != nil
-            }
-        } else {
-            return nil
-        }
+        guard let map, let feature else { return nil }
+        return map.utilityNetworks
+            .first(where: { $0.makeElement(arcGISFeature: feature) != nil })
     }
     
     // MARK: Methods

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -131,8 +131,9 @@ final class FeatureEditorModel {
         loadResult = await Result {
             try await loadFeature()
             if let map {
-                // Only tries to set up snap rules when a map is provided.
-                // Sets up the utility network so snap rules can be created.
+                // When a map is provided, it implies the user wants to set up
+                // rule-based snapping for the geometry editor. Loads the
+                // utility network so snap rules can be created.
                 try await map.load()
                 await map.utilityNetworks.load()
             }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -154,6 +154,7 @@ final class FeatureEditorModel {
     
     /// Retries starting an editing session.
     func retryStartEditing() async {
+        guard startEditingError != nil else { return }
         startEditingError = nil
         do {
             if let map {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -219,13 +219,13 @@ final class FeatureEditorModel {
         guard let feature else { return }
         
         // Loads the feature so canUpdateGeometry can be accessed. It is always false otherwise.
-        try await feature.load()
+        try await feature.retryLoad()
         guard feature.canUpdateGeometry else { return }
         
         // Loads the feature's table if the geometry is nil so geometryType can be accessed.
         // It is always nil otherwise.
         if feature.geometry == nil, let table = feature.table {
-            try await table.load()
+            try await table.retryLoad()
         }
         
         // Sets up the snap rules and syncs the snap source settings.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -155,13 +155,13 @@ final class FeatureEditorModel {
     /// Retries starting an editing session.
     func retryStartEditing() async {
         guard startEditingError != nil else { return }
-        startEditingError = nil
         do {
             if let map {
                 try await map.retryLoad()
                 await map.utilityNetworks.retryLoad()
             }
             try await setUpGeometryEditing()
+            startEditingError = nil
         } catch {
             // Don't start editing whichever error occurs, and let user retry.
             startEditingError = error

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -224,7 +224,6 @@ final class FeatureEditorModel {
         guard let feature else { return }
         // Loads the feature so canUpdateGeometry can be accessed. It is always false otherwise.
         try await feature.retryLoad()
-        guard feature.canUpdateGeometry else { return }
         
         // Loads the feature's table if the geometry is nil so geometryType can be accessed.
         // It is always nil otherwise.
@@ -235,7 +234,7 @@ final class FeatureEditorModel {
     
     /// Performs setup needed for geometry editing and starts the geometry editor if applicable.
     private func setUpGeometryEditing() async throws {
-        guard let feature else { return }
+        guard let feature, feature.canUpdateGeometry else { return }
         // Sets up the snap rules and syncs the snap source settings.
         if let utilityNetwork, let element = utilityNetwork.makeElement(arcGISFeature: feature) {
             // Errors are ignored to set snapRules to nil if creation fails, so

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -41,6 +41,8 @@ final class FeatureEditorModel {
     private var presentedFeatureForm: FeatureForm?
     /// The root feature form to edit with the feature editor.
     private(set) var rootFeatureForm: FeatureForm?
+    /// The error when starting editing fails.
+    private(set) var startEditingError: (any Error)?
     /// A Boolean value indicating whether the snap settings sheet is presented.
     /// This is needed to display the sheet from the modifier to prevent it from
     /// dismissing the feature editor when the horizontal size class is compact.
@@ -61,12 +63,22 @@ final class FeatureEditorModel {
     
     // MARK: Snapping Properties
     
+    /// The map that contains the utility network being edited.
+    private var map: Map?
     /// The snap rules for the `feature`, used to sync snap source settings.
     /// This is non-`nil` when snap rules were successfully created using the `utilityNetwork`.
     private var snapRules: SnapRules?
     /// The `feature`'s utility network used to create snap rules.
     /// This is non-`nil` when a map containing the feature's UN is used to start editing.
-    private var utilityNetwork: UtilityNetwork?
+    private var utilityNetwork: UtilityNetwork? {
+        if let map, let feature {
+            return map.utilityNetworks.first { utilityNetwork in
+                utilityNetwork.makeElement(arcGISFeature: feature) != nil
+            }
+        } else {
+            return nil
+        }
+    }
     
     // MARK: Methods
     
@@ -100,31 +112,66 @@ final class FeatureEditorModel {
     
     /// Starts editing a new `FeatureForm` that is shown in the feature editor's `FeatureFormView`.
     /// - Parameter featureForm: The new feature form to edit.
-    func startEditing(newFeatureForm featureForm: FeatureForm) async throws {
+    func startEditing(newFeatureForm featureForm: FeatureForm) async {
         geometryEditor.stop()
         presentedFeatureForm = featureForm
         
-        try await setUpGeometryEditing()
+        do {
+            try await setUpGeometryEditing()
+        } catch {
+            startEditingError = error
+            Logger.featureEditor.error(
+                "Error starting feature editor: \(error.localizedDescription)"
+            )
+        }
     }
     
     /// Starts an editing session for the given `feature`.
     /// - Parameters:
     ///   - feature: The root feature to edit.
     ///   - map: The map that `feature` is part of, used to set up rule-based snapping.
-    func startEditing(rootFeature feature: ArcGISFeature, on map: Map?) async throws {
+    func startEditing(rootFeature feature: ArcGISFeature, on map: Map?) async {
         stopEditing()
         rootFeatureForm = FeatureForm(feature: feature)
         
-        // Sets up the utility network so snap rules can be created.
-        if let map {
-            try await map.load()
-            await map.utilityNetworks.load()
-            utilityNetwork = map.utilityNetworks.first { utilityNetwork in
-                utilityNetwork.makeElement(arcGISFeature: feature) != nil
+        do {
+            if let map {
+                self.map = map
+                // Only try to set up snap rules when a map is provided.
+                // Sets up the utility network so snap rules can be created.
+                try await map.load()
+                for utilityNetwork in map.utilityNetworks {
+                    try await utilityNetwork.load()
+                }
             }
+            try await setUpGeometryEditing()
+        } catch {
+            // Don't start editing whichever error occurs, and let user retry.
+            startEditingError = error
+            Logger.featureEditor.error(
+                "Error starting feature editor: \(error.localizedDescription)"
+            )
         }
-        
-        try await setUpGeometryEditing()
+    }
+    
+    /// Retries starting an editing session.
+    func retryStartEditing() async {
+        startEditingError = nil
+        do {
+            if let map {
+                try await map.retryLoad()
+                if let utilityNetwork {
+                    try await utilityNetwork.retryLoad()
+                }
+            }
+            try await setUpGeometryEditing()
+        } catch {
+            // Don't start editing whichever error occurs, and let user retry.
+            startEditingError = error
+            Logger.featureEditor.error(
+                "Error retry starting feature editor: \(error.localizedDescription)"
+            )
+        }
     }
     
     /// Stops the feature editor and resets the model's properties.
@@ -136,6 +183,7 @@ final class FeatureEditorModel {
         presentedFeatureForm = nil
         snapSettingsSheetIsPresented = false
         viewpointGeometry = nil
+        startEditingError = nil
         
         geometryEditor.stop()
         geometryEditorCanUndo = false
@@ -143,7 +191,7 @@ final class FeatureEditorModel {
         geometryEditorIsStarted = false
         
         snapRules = nil
-        utilityNetwork = nil
+        map = nil
     }
     
     /// Syncs the `geometryEditor.snapSettings`' source settings.
@@ -151,8 +199,8 @@ final class FeatureEditorModel {
         do {
             let snapSettings = geometryEditor.snapSettings
             
-            if let rules = snapRules {
-                try snapSettings.syncSourceSettings(rules: rules, sourceEnablingBehavior: .preserve)
+            if let snapRules {
+                try snapSettings.syncSourceSettings(rules: snapRules, sourceEnablingBehavior: .preserve)
             } else {
                 try snapSettings.syncSourceSettings()
             }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -42,16 +42,14 @@ final class FeatureEditorModel {
     private var presentedFeatureForm: FeatureForm?
     /// The root feature form to edit with the feature editor.
     private(set) var rootFeatureForm: FeatureForm?
-    /// The error when starting editing fails.
-    private(set) var startEditingError: (any Error)?
+    /// The result of trying to load the resources and starting editing.
+    private(set) var loadResult: Result<Void, Error>?
     /// A Boolean value indicating whether the snap settings sheet is presented.
     /// This is needed to display the sheet from the modifier to prevent it from
     /// dismissing the feature editor when the horizontal size class is compact.
     var snapSettingsSheetIsPresented = false
     /// The geometry used to set the viewpoint.
     var viewpointGeometry: Geometry?
-    /// A Boolean value indicating whether the model is loaded.
-    var isLoaded = false
     
     // MARK: Geometry Editor Properties
     
@@ -121,15 +119,9 @@ final class FeatureEditorModel {
         geometryEditor.stop()
         presentedFeatureForm = featureForm
         
-        do {
+        loadResult = await Result {
             try await loadFeature()
             try await setUpGeometryEditing()
-            isLoaded = true
-        } catch {
-            startEditingError = error
-            Logger.featureEditor.error(
-                "Error starting feature editor: \(error.localizedDescription)"
-            )
         }
     }
     
@@ -141,43 +133,29 @@ final class FeatureEditorModel {
         stopEditing()
         rootFeatureForm = FeatureForm(feature: feature)
         self.map = map
-        do {
+        loadResult = await Result {
             try await loadFeature()
             if let map {
-                // Only try to set up snap rules when a map is provided.
+                // Only tries to set up snap rules when a map is provided.
                 // Sets up the utility network so snap rules can be created.
                 try await map.load()
                 await map.utilityNetworks.load()
             }
             try await setUpGeometryEditing()
-            isLoaded = true
-        } catch {
-            // Don't start editing whichever error occurs, and let user retry.
-            startEditingError = error
-            Logger.featureEditor.error(
-                "Error starting feature editor: \(error.localizedDescription)"
-            )
         }
     }
     
     /// Retries starting an editing session.
     func retryStartEditing() async {
-        guard startEditingError != nil else { return }
-        do {
+        // Makes sure the previous load failed and sets the loadResult to nil.
+        guard case .failure = loadResult.take() else { return }
+        loadResult = await Result { [weak map] in
             try await loadFeature()
             if let map {
                 try await map.retryLoad()
                 await map.utilityNetworks.retryLoad()
             }
             try await setUpGeometryEditing()
-            startEditingError = nil
-            isLoaded = true
-        } catch {
-            // Don't start editing whichever error occurs, and let user retry.
-            startEditingError = error
-            Logger.featureEditor.error(
-                "Error retry starting feature editor: \(error.localizedDescription)"
-            )
         }
     }
     
@@ -190,7 +168,6 @@ final class FeatureEditorModel {
         presentedFeatureForm = nil
         snapSettingsSheetIsPresented = false
         viewpointGeometry = nil
-        startEditingError = nil
         
         geometryEditor.stop()
         geometryEditorCanUndo = false
@@ -199,7 +176,7 @@ final class FeatureEditorModel {
         
         snapRules = nil
         map = nil
-        isLoaded = false
+        loadResult = nil
     }
     
     /// Syncs the `geometryEditor.snapSettings`' source settings.
@@ -225,11 +202,12 @@ final class FeatureEditorModel {
     /// Loads the feature and its table if needed to allow geometry editing.
     private func loadFeature() async throws {
         guard let feature else { return }
-        // Loads the feature so canUpdateGeometry can be accessed. It is always false otherwise.
+        // Loads the feature so canUpdateGeometry can be accessed. It is always
+        // false otherwise.
         try await feature.retryLoad()
         
-        // Loads the feature's table if the geometry is nil so geometryType can be accessed.
-        // It is always nil otherwise.
+        // Loads the feature's table if the geometry is nil so geometryType
+        // can be accessed. It is always nil otherwise.
         if feature.geometry == nil, let table = feature.table {
             try await table.retryLoad()
         }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -64,11 +64,11 @@ final class FeatureEditorModel {
     // MARK: Snapping Properties
     
     /// The map that contains the utility network being edited.
-    @ObservationTracked
+    @ObservationIgnored
     private var map: Map?
     /// The snap rules for the `feature`, used to sync snap source settings.
     /// This is non-`nil` when snap rules were successfully created using the `utilityNetwork`.
-    @ObservationTracked
+    @ObservationIgnored
     private var snapRules: SnapRules?
     /// The `feature`'s utility network used to create snap rules.
     /// This is non-`nil` when a map containing the feature's UN is used to start editing.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -114,7 +114,7 @@ final class FeatureEditorModel {
     
     /// Starts editing a new `FeatureForm` that is shown in the feature editor's `FeatureFormView`.
     /// - Parameter featureForm: The new feature form to edit.
-    func startEditing(newFeatureForm featureForm: FeatureForm) async {
+    func startEditingFeatureForm(_ featureForm: FeatureForm) async {
         geometryEditor.stop()
         presentedFeatureForm = featureForm
         

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -201,7 +201,7 @@ final class FeatureEditorModel {
         // Loads the feature so canUpdateGeometry can be accessed. It is always
         // false otherwise.
         try await feature.retryLoad()
-        // No need to load the feature's table upfront if the we don't edit its
+        // No need to load the feature's table upfront if we don't edit its
         // geometry.
         guard feature.canUpdateGeometry else { return }
         

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -38,7 +38,6 @@ final class FeatureEditorModel {
     }
     /// The form currently presented in the feature editor's `FeatureFormView`.
     /// This is non-`nil` after a new feature form is shown in the view.
-    @ObservationIgnored
     private var presentedFeatureForm: FeatureForm?
     /// The root feature form to edit with the feature editor.
     private(set) var rootFeatureForm: FeatureForm?

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -128,7 +128,7 @@ final class FeatureEditorModel {
     /// - Parameters:
     ///   - feature: The root feature to edit.
     ///   - map: The map that `feature` is part of, used to set up rule-based snapping.
-    func startEditing(rootFeature feature: ArcGISFeature, on map: Map?) async {
+    func startEditingFeature(_ feature: ArcGISFeature, on map: Map?) async {
         stopEditing()
         rootFeatureForm = FeatureForm(feature: feature)
         self.map = map

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -67,7 +67,7 @@ private struct FeatureEditorModifier: ViewModifier {
                             .task(id: isRetrying) {
                                 guard isRetrying else { return }
                                 defer {
-                                    // Avoid state updates from cancelled tasks.
+                                    // Avoids state updates from cancelled tasks.
                                     if !Task.isCancelled {
                                         isRetrying = false
                                     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -59,6 +59,7 @@ private struct FeatureEditorModifier: ViewModifier {
                             } label: {
                                 Text.tryAgain
                             }
+                            .buttonStyle(.borderedProminent)
                             
                             Button {
                                 model.stopEditing()
@@ -66,6 +67,7 @@ private struct FeatureEditorModifier: ViewModifier {
                             } label: {
                                 Text.cancel
                             }
+                            .buttonStyle(.bordered)
                         }
                     } else {
                         FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -42,7 +42,10 @@ private struct FeatureEditorModifier: ViewModifier {
             .safeInspector(isPresented: $model.isPresented) {
                 // VStack is needed for presentation modifiers to be applied.
                 VStack(spacing: 0) {
-                    if let error = model.startEditingError {
+                    switch model.loadResult {
+                    case .success:
+                        FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
+                    case .failure(let error):
                         ContentUnavailableView {
                             Label {
                                 Text(
@@ -78,10 +81,8 @@ private struct FeatureEditorModifier: ViewModifier {
                             }
                             .buttonStyle(.bordered)
                         }
-                    } else if !model.isLoaded {
+                    default:
                         ProgressView()
-                    } else {
-                        FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
                     }
                 }
                 .presentationBackgroundInteraction(.enabled)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -40,7 +40,29 @@ private struct FeatureEditorModifier: ViewModifier {
             .safeInspector(isPresented: $model.isPresented) {
                 // VStack is needed for presentation modifiers to be applied.
                 VStack(spacing: 0) {
-                    FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
+                    if let error = model.startEditingError {
+                        ContentUnavailableView {
+                            Label {
+                                Text(
+                                    "Failed to start editing",
+                                    bundle: .toolkitModule,
+                                    comment: "A title shown when feature editing could not start."
+                                )
+                            } icon: {
+                                Image(systemName: "exclamationmark.triangle")
+                            }
+                        } description: {
+                            Text(error.localizedDescription)
+                        } actions: {
+                            Button {
+                                Task { await model.retryStartEditing() }
+                            } label: {
+                                Text.tryAgain
+                            }
+                        }
+                    } else {
+                        FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
+                    }
                 }
                 .presentationBackgroundInteraction(.enabled)
                 .presentationContentInteraction(.scrolls)
@@ -99,14 +121,7 @@ private struct FeatureEditorFormView: View {
                 .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
                     guard let presentedFeatureForm else { return }
                     defer { self.presentedFeatureForm = nil }
-                    
-                    do {
-                        try await model.startEditing(newFeatureForm: presentedFeatureForm)
-                    } catch {
-                        Logger.featureEditor.error(
-                            "Error starting feature editor: \(error.localizedDescription)"
-                        )
-                    }
+                    await model.startEditing(newFeatureForm: presentedFeatureForm)
                 }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -66,7 +66,12 @@ private struct FeatureEditorModifier: ViewModifier {
                             }
                             .task(id: isRetrying) {
                                 guard isRetrying else { return }
-                                defer { isRetrying = false }
+                                defer {
+                                    // Avoid state updates from cancelled tasks.
+                                    if !Task.isCancelled {
+                                        isRetrying = false
+                                    }
+                                }
                                 await model.retryStartEditing()
                             }
                             .buttonStyle(.borderedProminent)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -142,7 +142,7 @@ private struct FeatureEditorFormView: View {
                 .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
                     guard let presentedFeatureForm else { return }
                     defer { self.presentedFeatureForm = nil }
-                    await model.startEditing(newFeatureForm: presentedFeatureForm)
+                    await model.startEditingFeatureForm(presentedFeatureForm)
                 }
         }
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -34,6 +34,8 @@ private struct FeatureEditorModifier: ViewModifier {
     /// The inspector's currently selected presentation detent.
     /// This is needed to set the default detent to medium.
     @State private var selectedPresentationDetent = PresentationDetent.medium
+    /// A Boolean value indicating whether the feature editor is retrying to start editing.
+    @State private var isRetrying = false
     
     func body(content: Content) -> some View {
         content
@@ -55,11 +57,16 @@ private struct FeatureEditorModifier: ViewModifier {
                             Text(error.localizedDescription)
                         } actions: {
                             Button {
-                                Task { await model.retryStartEditing() }
+                                isRetrying = true
                             } label: {
                                 Text.tryAgain
                             }
+                            .task(id: isRetrying) {
+                                defer { isRetrying = false }
+                                await model.retryStartEditing()
+                            }
                             .buttonStyle(.borderedProminent)
+                            .disabled(isRetrying)
                             
                             Button {
                                 model.stopEditing()

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -46,48 +46,27 @@ private struct FeatureEditorModifier: ViewModifier {
                     case .success:
                         FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
                     case .failure(let error):
-                        ContentUnavailableView {
-                            Label {
-                                Text(
-                                    "Failed to start editing",
-                                    bundle: .toolkitModule,
-                                    comment: "A title shown when feature editing could not start."
-                                )
-                            } icon: {
-                                Image(systemName: "exclamationmark.triangle")
-                            }
-                        } description: {
-                            Text(error.localizedDescription)
-                        } actions: {
-                            Button {
-                                isRetrying = true
-                            } label: {
-                                Text.tryAgain
-                            }
-                            .task(id: isRetrying) {
-                                guard isRetrying else { return }
-                                defer {
-                                    // Avoids state updates from cancelled tasks.
-                                    if !Task.isCancelled {
-                                        isRetrying = false
+                        NavigationStack {
+                            makeContentUnavailableView(error: error)
+                                .toolbar {
+                                    ToolbarItem(placement: .topBarTrailing) {
+                                        DismissButton(kind: .close) {
+                                            model.isPresented = false
+                                        }
                                     }
                                 }
-                                await model.retryStartEditing()
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .disabled(isRetrying)
-                            
-                            Button {
-                                // When the inspector is dismissed, the
-                                // feature editor will also stop editing.
-                                model.isPresented = false
-                            } label: {
-                                Text.cancel
-                            }
-                            .buttonStyle(.bordered)
                         }
                     case .none:
-                        ProgressView()
+                        NavigationStack {
+                            ProgressView()
+                                .toolbar {
+                                    ToolbarItem(placement: .topBarTrailing) {
+                                        DismissButton(kind: .close) {
+                                            model.isPresented = false
+                                        }
+                                    }
+                                }
+                        }
                     }
                 }
                 .presentationBackgroundInteraction(.enabled)
@@ -107,6 +86,43 @@ private struct FeatureEditorModifier: ViewModifier {
                 }
             }
             .environment(model)
+    }
+    
+    /// Creates a view for start editing failure.
+    /// - Parameter error: The error that caused the failure.
+    /// - Returns: A `ContentUnavailableView` with failure reason and actions.
+    private func makeContentUnavailableView(error: Error) -> some View {
+        ContentUnavailableView {
+            Label {
+                Text(
+                    "Failed to start editing",
+                    bundle: .toolkitModule,
+                    comment: "A title shown when feature editing could not start."
+                )
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+            }
+        } description: {
+            Text(error.localizedDescription)
+        } actions: {
+            Button {
+                isRetrying = true
+            } label: {
+                Text.tryAgain
+            }
+            .task(id: isRetrying) {
+                guard isRetrying else { return }
+                defer {
+                    // Avoids state updates from cancelled tasks.
+                    if !Task.isCancelled {
+                        isRetrying = false
+                    }
+                }
+                await model.retryStartEditing()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isRetrying)
+        }
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -69,7 +69,8 @@ private struct FeatureEditorModifier: ViewModifier {
                             .disabled(isRetrying)
                             
                             Button {
-                                model.stopEditing()
+                                // When the inspector is dismissed, the
+                                // feature editor will also stop editing.
                                 model.isPresented = false
                             } label: {
                                 Text.cancel

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -69,6 +69,18 @@ private struct FeatureEditorModifier: ViewModifier {
                         }
                     }
                 }
+                .task(id: isRetrying) {
+                    // The task modifier is attached to the VStack so it is
+                    // not canceled when the ContentUnavailableView disappears.
+                    guard isRetrying else { return }
+                    defer {
+                        // Avoids state updates from cancelled tasks.
+                        if !Task.isCancelled {
+                            isRetrying = false
+                        }
+                    }
+                    await model.retryStartEditing()
+                }
                 .presentationBackgroundInteraction(.enabled)
                 .presentationContentInteraction(.scrolls)
                 .presentationDetents(
@@ -109,16 +121,6 @@ private struct FeatureEditorModifier: ViewModifier {
                 isRetrying = true
             } label: {
                 Text.tryAgain
-            }
-            .task(id: isRetrying) {
-                guard isRetrying else { return }
-                defer {
-                    // Avoids state updates from cancelled tasks.
-                    if !Task.isCancelled {
-                        isRetrying = false
-                    }
-                }
-                await model.retryStartEditing()
             }
             .buttonStyle(.borderedProminent)
             .disabled(isRetrying)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -59,6 +59,13 @@ private struct FeatureEditorModifier: ViewModifier {
                             } label: {
                                 Text.tryAgain
                             }
+                            
+                            Button {
+                                model.stopEditing()
+                                model.isPresented = false
+                            } label: {
+                                Text.cancel
+                            }
                         }
                     } else {
                         FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -81,7 +81,7 @@ private struct FeatureEditorModifier: ViewModifier {
                             }
                             .buttonStyle(.bordered)
                         }
-                    default:
+                    case .none:
                         ProgressView()
                     }
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -62,6 +62,7 @@ private struct FeatureEditorModifier: ViewModifier {
                                 Text.tryAgain
                             }
                             .task(id: isRetrying) {
+                                guard isRetrying else { return }
                                 defer { isRetrying = false }
                                 await model.retryStartEditing()
                             }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -77,6 +77,8 @@ private struct FeatureEditorModifier: ViewModifier {
                             }
                             .buttonStyle(.bordered)
                         }
+                    } else if !model.isLoaded {
+                        ProgressView()
                     } else {
                         FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
                     }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -167,7 +167,7 @@ struct FeatureEditorModelTests {
         #expect(feature.geometry == nil)
         
         // Verifies feature editor and geometry editor are started.
-        try await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditing(rootFeature: feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         await model.expectIsGeometryEditing()
         
@@ -194,7 +194,7 @@ struct FeatureEditorModelTests {
         #expect(!feature.canUpdateGeometry)
         
         // Verifies feature editor is started using the feature instance.
-        try await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditing(rootFeature: feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         
         // Geometry editor is not started.
@@ -218,7 +218,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
         // Verifies feature editor and geometry editor are started.
-        try await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditing(rootFeature: feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -182,7 +182,7 @@ struct FeatureEditorModelTests {
         map.setSpatialReference(.wgs84)
         await model.retryStartEditing()
         
-        try model.loadResult?.get()
+        try result.get()
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)
     }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -154,7 +154,7 @@ struct FeatureEditorModelTests {
         }
     }
     
-    /// Verifies setup failure records `startEditingError`, blocks editing,
+    /// Verifies setup failure leads to loadResult failure, blocks editing,
     /// and `retryStartEditing()` clears the error on success.
     @Test
     func startEditingErrorAndRetry() async throws {

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -157,7 +157,7 @@ struct FeatureEditorModelTests {
     /// Verifies setup failure leads to loadResult failure, blocks editing,
     /// and `retryStartEditing()` clears the error on success.
     @Test
-    func startEditingErrorAndRetry() async throws {
+    func retryStartEditingAfterFailure() async throws {
         let model = FeatureEditorModel()
         let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorGeometryEditorStreamsTask.cancel() }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -170,9 +170,8 @@ struct FeatureEditorModelTests {
         
         // Simulates map fails to load by creating a map with nil spatial reference.
         await model.startEditing(rootFeature: feature, on: map)
-        let result = try #require(model.loadResult)
         let error = #expect(throws: MappingError.self) {
-            try result.get()
+            try #require(model.loadResult).get()
         }
         #expect(error == .missingSpatialReference(details: ""))
         await Task.yieldExpect(!model.geometryEditorIsStarted)
@@ -182,7 +181,7 @@ struct FeatureEditorModelTests {
         map.setSpatialReference(.wgs84)
         await model.retryStartEditing()
         
-        try result.get()
+        try #require(model.loadResult).get()
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)
     }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -170,8 +170,11 @@ struct FeatureEditorModelTests {
         
         // Simulates map fails to load by creating a map with nil spatial reference.
         await model.startEditing(rootFeature: feature, on: map)
-        
-        #expect(model.startEditingError != nil)
+        let result = try #require(model.loadResult)
+        let error = #expect(throws: MappingError.self) {
+            try result.get()
+        }
+        #expect(error == .missingSpatialReference(details: ""))
         await Task.yieldExpect(!model.geometryEditorIsStarted)
         await Task.yieldExpect(model.geometryEditorGeometry == nil)
         
@@ -179,7 +182,7 @@ struct FeatureEditorModelTests {
         map.setSpatialReference(.wgs84)
         await model.retryStartEditing()
         
-        #expect(model.startEditingError == nil)
+        try model.loadResult?.get()
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)
     }
@@ -267,7 +270,7 @@ private extension FeatureEditorModel {
         #expect(feature == nil, sourceLocation: sourceLocation)
         #expect(!isPresented, sourceLocation: sourceLocation)
         #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)
-        #expect(startEditingError == nil, sourceLocation: sourceLocation)
+        #expect(loadResult == nil, sourceLocation: sourceLocation)
         #expect(!snapSettingsSheetIsPresented, sourceLocation: sourceLocation)
         #expect(viewpointGeometry == nil, sourceLocation: sourceLocation)
         

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -104,6 +104,38 @@ struct FeatureEditorModelTests {
         await model.expectIsEditing(geometry: newGeometry)
     }
     
+    /// Verifies setup failure leads to loadResult failure, blocks editing,
+    /// and `retryStartEditing()` clears the error on success.
+    @Test
+    func retryStartEditingAfterFailure() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        let geometry = Point(latitude: 2, longitude: 2)
+        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+        let map = Map(spatialReference: nil)
+        
+        // Simulates map fails to load by creating a map with nil spatial reference.
+        await model.startEditingFeature(feature, on: map)
+        let error = #expect(throws: MappingError.self) {
+            try #require(model.loadResult).get()
+        }
+        #expect(error == .missingSpatialReference(details: ""))
+        await Task.yieldExpect(!model.geometryEditorIsStarted)
+        await Task.yieldExpect(model.geometryEditorGeometry == nil)
+        
+        // Sets the map's spatial reference to a valid value and retries starting the feature editor.
+        map.setSpatialReference(.wgs84)
+        await model.retryStartEditing()
+        
+        try #require(model.loadResult).get()
+        await model.expectIsGeometryEditing()
+        await model.expectIsEditing(geometry: geometry)
+    }
+    
     /// Verifies `startEditingFeature(_:on:)` and `startEditingFeatureForm(_:)` using
     /// features with geometries.
     @Test
@@ -152,38 +184,6 @@ struct FeatureEditorModelTests {
             await model.expectIsGeometryEditing()
             await model.expectIsEditing(geometry: geometry)
         }
-    }
-    
-    /// Verifies setup failure leads to loadResult failure, blocks editing,
-    /// and `retryStartEditing()` clears the error on success.
-    @Test
-    func retryStartEditingAfterFailure() async throws {
-        let model = FeatureEditorModel()
-        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
-        defer { monitorGeometryEditorStreamsTask.cancel() }
-        
-        let geodatabaseFile = try await TemporaryGeodatabaseFile()
-        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
-        let geometry = Point(latitude: 2, longitude: 2)
-        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
-        let map = Map(spatialReference: nil)
-        
-        // Simulates map fails to load by creating a map with nil spatial reference.
-        await model.startEditingFeature(feature, on: map)
-        let error = #expect(throws: MappingError.self) {
-            try #require(model.loadResult).get()
-        }
-        #expect(error == .missingSpatialReference(details: ""))
-        await Task.yieldExpect(!model.geometryEditorIsStarted)
-        await Task.yieldExpect(model.geometryEditorGeometry == nil)
-        
-        // Sets the map's spatial reference to a valid value and retries starting the feature editor.
-        map.setSpatialReference(.wgs84)
-        await model.retryStartEditing()
-        
-        try #require(model.loadResult).get()
-        await model.expectIsGeometryEditing()
-        await model.expectIsEditing(geometry: geometry)
     }
     
     /// Verifies `startEditingFeature(_:on:)` using a feature without a geometry.

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -41,7 +41,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
         // Verifies isPresented is true when feature editor starts.
-        await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditingFeature(feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         
         await model.expectIsGeometryEditing()
@@ -91,7 +91,7 @@ struct FeatureEditorModelTests {
         let geometry = Point(latitude: 0, longitude: 0)
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
-        await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditingFeature(feature, on: nil)
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)
         
@@ -104,7 +104,7 @@ struct FeatureEditorModelTests {
         await model.expectIsEditing(geometry: newGeometry)
     }
     
-    /// Verifies `startEditing(rootFeature:on:)` and `startEditing(newFeatureForm:)` using
+    /// Verifies `startEditingFeature(_:on:)` and `startEditing(newFeatureForm:)` using
     /// features with geometries.
     @Test
     func startEditing() async throws {
@@ -115,14 +115,14 @@ struct FeatureEditorModelTests {
         let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         
-        // Verifies startEditing(rootFeature:on:) starts the feature editor and geometry editor.
+        // Verifies startEditingFeature(_:on:) starts the feature editor and geometry editor.
         do {
             let geometry = Point(latitude: 0, longitude: 0)
             let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
             let map = Map(spatialReference: .wgs84)
             
             // Verifies feature editor is started using the feature instance.
-            await model.startEditing(rootFeature: feature, on: map)
+            await model.startEditingFeature(feature, on: map)
             model.expectIsEditing(rootFeature: feature)
             
             // Verifies geometry editor is started using the feature's geometry.
@@ -169,7 +169,7 @@ struct FeatureEditorModelTests {
         let map = Map(spatialReference: nil)
         
         // Simulates map fails to load by creating a map with nil spatial reference.
-        await model.startEditing(rootFeature: feature, on: map)
+        await model.startEditingFeature(feature, on: map)
         let error = #expect(throws: MappingError.self) {
             try #require(model.loadResult).get()
         }
@@ -186,7 +186,7 @@ struct FeatureEditorModelTests {
         await model.expectIsEditing(geometry: geometry)
     }
     
-    /// Verifies `startEditing(rootFeature:on:)` using a feature without a geometry.
+    /// Verifies `startEditingFeature(_:on:)` using a feature without a geometry.
     @Test
     func startEditingFeatureWithoutGeometry() async throws {
         let model = FeatureEditorModel()
@@ -199,7 +199,7 @@ struct FeatureEditorModelTests {
         #expect(feature.geometry == nil)
         
         // Verifies feature editor and geometry editor are started.
-        await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditingFeature(feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         await model.expectIsGeometryEditing()
         
@@ -210,7 +210,7 @@ struct FeatureEditorModelTests {
         #expect(model.viewpointGeometry == nil)
     }
     
-    /// Verifies `startEditing(rootFeature:on:)` using a non-spatial feature.
+    /// Verifies `startEditingFeature(_:on:)` using a non-spatial feature.
     @Test
     func startEditingNonSpatialFeature() async throws {
         let model = FeatureEditorModel()
@@ -226,7 +226,7 @@ struct FeatureEditorModelTests {
         #expect(!feature.canUpdateGeometry)
         
         // Verifies feature editor is started using the feature instance.
-        await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditingFeature(feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         
         // Geometry editor is not started.
@@ -250,7 +250,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
         // Verifies feature editor and geometry editor are started.
-        await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditingFeature(feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -154,6 +154,36 @@ struct FeatureEditorModelTests {
         }
     }
     
+    /// Verifies setup failure records `startEditingError`, blocks editing,
+    /// and `retryStartEditing()` clears the error on success.
+    @Test
+    func startEditingErrorAndRetry() async throws {
+        let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
+        
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        let geometry = Point(latitude: 2, longitude: 2)
+        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+        let map = Map(spatialReference: nil)
+        
+        // Simulates map fails to load by creating a map with nil spatial reference.
+        await model.startEditing(rootFeature: feature, on: map)
+        
+        #expect(model.startEditingError != nil)
+        await Task.yieldExpect(!model.geometryEditorIsStarted)
+        await Task.yieldExpect(model.geometryEditorGeometry == nil)
+        
+        // Sets the map's spatial reference to a valid value and retries starting the feature editor.
+        map.setSpatialReference(.wgs84)
+        await model.retryStartEditing()
+        
+        #expect(model.startEditingError == nil)
+        await model.expectIsGeometryEditing()
+        await model.expectIsEditing(geometry: geometry)
+    }
+    
     /// Verifies `startEditing(rootFeature:on:)` using a feature without a geometry.
     @Test
     func startEditingFeatureWithoutGeometry() async throws {

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -104,7 +104,7 @@ struct FeatureEditorModelTests {
         await model.expectIsEditing(geometry: newGeometry)
     }
     
-    /// Verifies `startEditingFeature(_:on:)` and `startEditing(newFeatureForm:)` using
+    /// Verifies `startEditingFeature(_:on:)` and `startEditingFeatureForm(_:)` using
     /// features with geometries.
     @Test
     func startEditing() async throws {
@@ -133,14 +133,14 @@ struct FeatureEditorModelTests {
             #expect(map.loadStatus == .loaded)
         }
         
-        // Verifies startEditing(newFeatureForm:) updates the correct model properties.
+        // Verifies startEditingFeatureForm(_:) updates the correct model properties.
         do {
             let geometry = Point(latitude: 1, longitude: 1)
             let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
             let featureForm = FeatureForm(feature: feature)
             
             // Verifies feature editor uses the new feature instance.
-            await model.startEditing(newFeatureForm: featureForm)
+            await model.startEditingFeatureForm(featureForm)
             #expect(model.feature === feature)
             
             // Verifies rootFeatureForm does not update.

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -267,6 +267,7 @@ private extension FeatureEditorModel {
         #expect(feature == nil, sourceLocation: sourceLocation)
         #expect(!isPresented, sourceLocation: sourceLocation)
         #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)
+        #expect(startEditingError == nil, sourceLocation: sourceLocation)
         #expect(!snapSettingsSheetIsPresented, sourceLocation: sourceLocation)
         #expect(viewpointGeometry == nil, sourceLocation: sourceLocation)
         

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -41,7 +41,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
         // Verifies isPresented is true when feature editor starts.
-        try await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditing(rootFeature: feature, on: nil)
         model.expectIsEditing(rootFeature: feature)
         
         await model.expectIsGeometryEditing()
@@ -91,7 +91,7 @@ struct FeatureEditorModelTests {
         let geometry = Point(latitude: 0, longitude: 0)
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
-        try await model.startEditing(rootFeature: feature, on: nil)
+        await model.startEditing(rootFeature: feature, on: nil)
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)
         
@@ -122,7 +122,7 @@ struct FeatureEditorModelTests {
             let map = Map(spatialReference: .wgs84)
             
             // Verifies feature editor is started using the feature instance.
-            try await model.startEditing(rootFeature: feature, on: map)
+            await model.startEditing(rootFeature: feature, on: map)
             model.expectIsEditing(rootFeature: feature)
             
             // Verifies geometry editor is started using the feature's geometry.
@@ -140,7 +140,7 @@ struct FeatureEditorModelTests {
             let featureForm = FeatureForm(feature: feature)
             
             // Verifies feature editor uses the new feature instance.
-            try await model.startEditing(newFeatureForm: featureForm)
+            await model.startEditing(newFeatureForm: featureForm)
             #expect(model.feature === feature)
             
             // Verifies rootFeatureForm does not update.


### PR DESCRIPTION
## Description

- Show a `ContentUnavailableView` in the inspector/sheet when the feature editor fails to set up.

<img width="320" height="695" alt="cuv" src="https://github.com/user-attachments/assets/ae6e711d-3dbd-4a5b-9261-b9f6d329e865" />

- Added a `retryStartEditing` method for the "Try Again" button, and made subsequent adjustments to the model and tests.

- Added a unit test for the `retryStartEditing` method.

## Error Origin Synopsis

There are 4 main origins of errors for the editing workflow:

1. Setting up the geometry editing environment.
  - This involves loading the feature and its feature table. This is to ensure that the geometry editor can start.
  - If this step fails, we cannot edit the feature's geometry, which makes the feature editor useless. Thus, we block the user from using the feature editor.

2. Setting up snap rules when a `Map` is passed in. 
  - This involves loading the map, and loading the utility networks from the map. If either of these steps fails, snap rules cannot be set.
  - Because the expectation is that when a `Map` is passed to the feature editor, the snap rules will be created for the feature. Thus, if snap rules setup fails, we block the user from using the feature editor.

3. Syncing snap sources.
  - If the geometry editor on the map view is not the same instance being passed into the feature editor, syncing snap source will fail.
  - Because passing which geometry editor instance to the feature editor is an intentional decision, I didn't provide a "Try Again" for this error, and kept the current implementation, which shows no snap sources when it fails to sync snap sources.

4. When save edits in the feature form, `InvalidGeometryError` could be thrown. This error is presented in an alert by the feature form, so feature editor doesn't need to handle it.

## How To Ad-Hoc Test

Anywhere in the edited code, call `throw CancellationError()` and see if the `ContentUnavailableView` shows up as expected. Tap "Try Again" to see if the feature editor starts correctly.
