### PR TITLE
`FeatureEditor`: Viewpoint centering improvements

### DIFF
--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -31,7 +31,7 @@ struct ExampleMapView: View {
         // Enables full resolution feature tiling to improve snapping accuracy.
         map.loadSettings.featureTilingMode = .enabledWithFullResolutionWhenSupported
         
-        let initialExtent = Envelope(xRange: -9815340 ... -9815040, yRange: 5129550 ... 5130070)
+        let initialExtent = Envelope(xRange: -9812750 ... -9812387, yRange: 5131332 ... 5131965)
         map.initialViewpoint = Viewpoint(boundingGeometry: initialExtent)
         
         return map

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -131,19 +131,19 @@ public struct FeatureEditor: View {
     /// Sets the viewpoint using `model.viewpointGeometry` and the `mapViewProxy`.
     private func setViewpoint() async {
         guard let viewpointGeometry = model.viewpointGeometry else { return }
-        guard let mapViewProxy else {
+        if let mapViewProxy {
+            let expandedGeometry = viewpointGeometry.extent.withBuilder { $0.expand(by: 2) }
+            let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)
+            await mapViewProxy.setViewpoint(viewpoint, duration: 0.5)
+            
+            // Prevents canceling an animation started while this task was running.
+            if !Task.isCancelled {
+                model.viewpointGeometry = nil
+            }
+        } else {
             // Clears viewpointGeometry to prevent setting the viewpoint if the proxy is set later.
             model.viewpointGeometry = nil
-            return
         }
-        
-        let expandedGeometry = viewpointGeometry.extent.withBuilder { $0.expand(by: 2) }
-        let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)
-        await mapViewProxy.setViewpoint(viewpoint, duration: 0.5)
-        
-        // Prevents canceling an animation started while this task was running.
-        guard !Task.isCancelled else { return }
-        model.viewpointGeometry = nil
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -131,12 +131,19 @@ public struct FeatureEditor: View {
     /// Sets the viewpoint using `model.viewpointGeometry` and the `mapViewProxy`.
     private func setViewpoint() async {
         guard let viewpointGeometry = model.viewpointGeometry else { return }
-        defer { model.viewpointGeometry = nil }
-        guard let mapViewProxy else { return }
+        guard let mapViewProxy else {
+            // Clears viewpointGeometry to prevent setting the viewpoint if the proxy later is set.
+            model.viewpointGeometry = nil
+            return
+        }
         
         let expandedGeometry = viewpointGeometry.extent.withBuilder { $0.expand(by: 2) }
         let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)
         await mapViewProxy.setViewpoint(viewpoint, duration: 0.5)
+        
+        // Prevents cancelling an animation started while this task was running.
+        guard !Task.isCancelled else { return }
+        model.viewpointGeometry = nil
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -132,7 +132,7 @@ public struct FeatureEditor: View {
     private func setViewpoint() async {
         guard let viewpointGeometry = model.viewpointGeometry else { return }
         guard let mapViewProxy else {
-            // Clears viewpointGeometry to prevent setting the viewpoint if the proxy later is set.
+            // Clears viewpointGeometry to prevent setting the viewpoint if the proxy is set later.
             model.viewpointGeometry = nil
             return
         }
@@ -141,7 +141,7 @@ public struct FeatureEditor: View {
         let viewpoint = Viewpoint(boundingGeometry: expandedGeometry)
         await mapViewProxy.setViewpoint(viewpoint, duration: 0.5)
         
-        // Prevents cancelling an animation started while this task was running.
+        // Prevents canceling an animation started while this task was running.
         guard !Task.isCancelled else { return }
         model.viewpointGeometry = nil
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -25,8 +25,14 @@ struct FeatureEditorFormView: View {
     /// the geometry editor.
     @Environment(FeatureEditorModel.self) private var model
     
+    /// The current editing event from the form view. This is non-`nil` while
+    /// the event is being processed by this view.
+    @State private var editingEvent: EquatableEditingEvent?
     /// The form currently presented in the `FeatureFormView`.
     @State private var presentedFeatureForm: FeatureForm?
+    /// The feature currently selected on the map. This is non-`nil` when
+    /// adding an association or "Show on Map" is pressed in the form view.
+    @State private var selectedFeature: ArcGISFeature?
     
     /// A closure that saves geometry edits to the form's feature. This is
     /// non-`nil` only when there are edits, so the `FeatureFormView`
@@ -48,37 +54,136 @@ struct FeatureEditorFormView: View {
             FeatureFormView(root: rootFeatureForm, isPresented: $model.isPresented)
                 .editingButtons(isMinimized ? .hidden : .automatic)
                 .onFeatureFormChanged { presentedFeatureForm = $0 }
-                .onFormEditingEvent(perform: handleFormEditingEvent)
+                .onFormEditingEvent { editingEvent = EquatableEditingEvent(event: $0) }
                 .environment(\.externalSaveAction, saveGeometryEditsAction)
+                .task(id: editingEvent) {
+                    guard let editingEvent else { return }
+                    defer { self.editingEvent = nil }
+                    
+                    await handleEditingEvent(editingEvent.event)
+                }
                 .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
                     guard let presentedFeatureForm else { return }
                     defer { self.presentedFeatureForm = nil }
                     await model.startEditingFeatureForm(presentedFeatureForm)
                 }
+                .onDisappear(perform: clearSelectedFeature)
         }
     }
     
-    /// Handles events from the `FeatureFormView.onFormEditingEvent(perform:)` modifier.
+    /// Clears `selectedFeature` and unselects it on its layer.
+    private func clearSelectedFeature() {
+        guard let selectedFeature = selectedFeature.take(),
+              let featureLayer = selectedFeature.table?.layer as? FeatureLayer else {
+            return
+        }
+        
+        featureLayer.unselectFeature(selectedFeature)
+    }
+    
+    /// Performs an action associated with a form editing event.
     /// - Parameter event: The form editing event to handle.
-    private func handleFormEditingEvent(_ event: FeatureFormView.EditingEvent) {
+    private func handleEditingEvent(_ event: FeatureFormView.EditingEvent) async {
         switch event {
         case .discardedEdits(let willNavigate):
             // Restarts the geometry editor when the form footer discard button is pressed.
             guard !willNavigate else { break }
             model.restartGeometryEditor()
+        case .navigationChanged(let view):
+            switch view {
+            case .utilityAssociationCreationView(_, _, _, let candidate):
+                await showCandidateOnMap(candidate)
+            default:
+                clearSelectedFeature()
+            }
         case .savedEdits(let willNavigate):
             // Closes the inspector when the form footer save button is pressed.
             guard !willNavigate else { break }
             model.isPresented = false
         case .showOnMapRequested(let feature):
-            model.viewpointGeometry = feature.geometry
-        default:
-            break
+            await showFeatureOnMap(feature)
         }
+    }
+    
+    /// Zooms to and selects an association candidate feature on the map.
+    /// - Parameter candidate: The `UtilityAssociationFeatureCandidate` to show.
+    private func showCandidateOnMap(_ candidate: UtilityAssociationFeatureCandidate) async {
+        guard let candidateGeometry = candidate.feature.geometry,
+              !candidateGeometry.isEmpty,
+              let geometryEditorGeometry = model.geometryEditorGeometry else {
+            return
+        }
+        
+        // Sets viewpoint to include the candidate feature and geometry editor geometry,
+        // so the user can see what feature they are using to add an association.
+        model.viewpointGeometry = GeometryEngine.combineExtents(
+            candidateGeometry,
+            geometryEditorGeometry
+        )
+        
+        try? await selectFeature(candidate.feature)
+    }
+    
+    /// Zooms to and briefly selects a feature on the map.
+    /// - Parameter feature: The `ArcGISFeature` to show.
+    private func showFeatureOnMap(_ feature: ArcGISFeature) async {
+        model.viewpointGeometry = feature.geometry
+        
+        do {
+            try await selectFeature(feature)
+        } catch {
+            // Sleeps if the geometry editor wasn't hidden so there is still a
+            // delay before the selection is cleared.
+            try? await Task.sleep(for: .seconds(1))
+        }
+        clearSelectedFeature()
+    }
+    
+    /// Selects a feature on the map and briefly hides the geometry editor's symbology.
+    /// - Parameter feature: The feature to select.
+    /// - Throws: If the geometry editor does not have a valid geometry to hide.
+    private func selectFeature(_ feature: ArcGISFeature) async throws {
+        guard let featureLayer = feature.table?.layer as? FeatureLayer else { return }
+        
+        featureLayer.selectFeature(feature)
+        selectedFeature = feature
+        
+        // Briefly hides the geometry editor so the user can still locate the
+        // selected feature when it's covered by the geometry editor symbology.
+        guard let geometryEditorGeometry = model.geometryEditorGeometry,
+              !geometryEditorGeometry.isEmpty else {
+            throw InvalidGeometryError()
+        }
+        
+        model.geometryEditor.clearSelection()
+        model.geometryEditor.tool.style.opacity = 0.1
+        try? await Task.sleep(for: .seconds(1))
+        model.geometryEditor.tool.style.opacity = 1
     }
 }
 
 // MARK: - Helper Types
+
+/// A wrapper for `FeatureFormView.EditingEvent` that conforms to `Equatable`.
+private struct EquatableEditingEvent: Equatable {
+    /// The form editing event.
+    let event: FeatureFormView.EditingEvent
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return switch (lhs.event, rhs.event) {
+        case let (.discardedEdits(lhsWillNavigate), .discardedEdits(rhsWillNavigate)):
+            lhsWillNavigate == rhsWillNavigate
+        case let (.navigationChanged(lhsView), .navigationChanged(rhsView)):
+            lhsView == rhsView
+        case let (.savedEdits(lhsWillNavigate), .savedEdits(rhsWillNavigate)):
+            lhsWillNavigate == rhsWillNavigate
+        case let (.showOnMapRequested(lhsFeature), .showOnMapRequested(rhsFeature)):
+            lhsFeature === rhsFeature
+        default:
+            false
+        }
+    }
+}
 
 /// An error indicating that the geometry is invalid and must be corrected before saving.
 private struct InvalidGeometryError: LocalizedError {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -29,7 +29,7 @@ struct FeatureEditorFormView: View {
     
     /// The current editing event from the form view. This is non-`nil` while
     /// the event is being processed by this view.
-    @State private var editingEvent: EquatableEditingEvent?
+    @State private var editingEvent: FeatureFormView.EditingEvent?
     /// The opacity of the geometry editor tool's symbology. This is used to
     /// animate changes to the geometry editor's opacity.
     @State private var geometryEditorOpacity: Float = 1
@@ -58,7 +58,7 @@ struct FeatureEditorFormView: View {
         FeatureFormView(root: rootFeatureForm, isPresented: $model.isPresented)
             .editingButtons(isMinimized ? .hidden : .automatic)
             .onFeatureFormChanged { presentedFeatureForm = $0 }
-            .onFormEditingEvent { editingEvent = EquatableEditingEvent(event: $0) }
+            .onFormEditingEvent { editingEvent = $0 }
             .environment(\.externalSaveAction, saveGeometryEditsAction)
             .onAnimationChange(of: geometryEditorOpacity) { newOpacity in
                 model.geometryEditor.tool.style.opacity = newOpacity
@@ -66,7 +66,7 @@ struct FeatureEditorFormView: View {
             .animation(.default, value: geometryEditorOpacity)
             .task(id: editingEvent) {
                 guard let editingEvent else { return }
-                await handleEditingEvent(editingEvent.event)
+                await handleEditingEvent(editingEvent)
                 
                 // Prevents clearing editingEvent if it was set while this
                 // task was running.
@@ -196,27 +196,6 @@ struct FeatureEditorFormView: View {
 private extension Duration {
     /// The duration before a feature highlight (selection and geometry editor opacity) is cleared.
     static let featureHighlightDelay = Self.seconds(1)
-}
-
-/// A wrapper for `FeatureFormView.EditingEvent` that conforms to `Equatable`.
-private struct EquatableEditingEvent: Equatable {
-    /// The form editing event.
-    let event: FeatureFormView.EditingEvent
-    
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        return switch (lhs.event, rhs.event) {
-        case let (.discardedEdits(lhsWillNavigate), .discardedEdits(rhsWillNavigate)):
-            lhsWillNavigate == rhsWillNavigate
-        case let (.navigationChanged(lhsView), .navigationChanged(rhsView)):
-            lhsView == rhsView
-        case let (.savedEdits(lhsWillNavigate), .savedEdits(rhsWillNavigate)):
-            lhsWillNavigate == rhsWillNavigate
-        case let (.showOnMapRequested(lhsFeature), .showOnMapRequested(rhsFeature)):
-            lhsFeature === rhsFeature
-        default:
-            false
-        }
-    }
 }
 
 /// An error relating to the geometry editor.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -78,7 +78,7 @@ struct FeatureEditorFormView: View {
                 }
                 .onDisappear {
                     clearSelectedFeature()
-                    model.geometryEditor.tool.style.opacity = 0
+                    model.geometryEditor.tool.style.opacity = 1
                 }
         }
     }
@@ -140,6 +140,8 @@ struct FeatureEditorFormView: View {
     /// Zooms to and briefly selects a feature on the map.
     /// - Parameter feature: The `ArcGISFeature` to show.
     private func showFeatureOnMap(_ feature: ArcGISFeature) async {
+        guard feature.geometry?.isEmpty == false else { return }
+        
         model.viewpointGeometry = feature.geometry
         
         do {
@@ -168,8 +170,12 @@ struct FeatureEditorFormView: View {
         
         // Briefly hides the geometry editor so the user can still locate the
         // selected feature when it's covered by the geometry editor symbology.
-        guard let geometryEditorGeometry = model.geometryEditorGeometry,
-              !geometryEditorGeometry.isEmpty else {
+        guard let editorGeometry = model.geometryEditorGeometry,
+              !editorGeometry.isEmpty,
+              let featureGeometry = feature.geometry,
+              // Editor geometry is buffered to account for the vertex and line symbols.
+              let bufferedGeometry = GeometryEngine.buffer(around: editorGeometry, distance: 10),
+              GeometryEngine.isGeometry(featureGeometry, intersecting: bufferedGeometry) else {
             throw InvalidGeometryError()
         }
         

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -224,7 +224,7 @@ private enum GeometryEditorError: LocalizedError {
                 bundle: .toolkitModule,
                 comment: "An error message shown when trying to save an invalid geometry."
             )
-        default:
+        case .notHidden:
             nil
         }
     }
@@ -247,7 +247,7 @@ extension OrientedImageryLayer: FeatureSelectableLayer {}
 // MARK: On Animation Change Modifier
 
 /// A view modifier that performs an action when the animation data of a given value changes.
-private struct OnAnimationChangeModifier<Value: VectorArithmetic>: @MainActor AnimatableModifier {
+private struct OnAnimationChangeModifier<Value: VectorArithmetic>: @MainActor Animatable & ViewModifier {
     /// The value to observe for changes in its animation data.
     let value: Value
     /// The action to perform when the animation data changes.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -44,7 +44,7 @@ struct FeatureEditorFormView: View {
         guard model.geometryEditorCanUndo else { return nil }
         return {
             guard let geometry = model.geometryEditorGeometry, geometry.sketchIsValid else {
-                throw InvalidGeometryError()
+                throw GeometryEditorError.invalidGeometry
             }
             model.feature?.geometry = geometry
         }
@@ -159,7 +159,7 @@ struct FeatureEditorFormView: View {
     
     /// Selects a feature on the map and briefly hides the geometry editor's symbology.
     /// - Parameter feature: The feature to select.
-    /// - Throws: If the geometry editor does not have a valid geometry to hide.
+    /// - Throws: If the geometry editor was not hidden.
     private func selectFeature(_ feature: ArcGISFeature) async throws {
         clearSelectedFeature()
         
@@ -176,7 +176,7 @@ struct FeatureEditorFormView: View {
               // Editor geometry is buffered to account for the vertex and line symbols.
               let bufferedGeometry = GeometryEngine.buffer(around: editorGeometry, distance: 10),
               GeometryEngine.isGeometry(featureGeometry, intersecting: bufferedGeometry) else {
-            throw InvalidGeometryError()
+            throw GeometryEditorError.notHidden
         }
         
         model.geometryEditor.clearSelection()
@@ -209,13 +209,25 @@ private struct EquatableEditingEvent: Equatable {
     }
 }
 
-/// An error indicating that the geometry is invalid and must be corrected before saving.
-private struct InvalidGeometryError: LocalizedError {
-    let errorDescription: String? = String(
-        localized: "The geometry is invalid. It must be corrected before saving.",
-        bundle: .toolkitModule,
-        comment: "An error message shown when trying to save an invalid geometry."
-    )
+/// An error relating to the geometry editor.
+private enum GeometryEditorError: LocalizedError {
+    /// The geometry editor's geometry is invalid and must be corrected before saving.
+    case invalidGeometry
+    /// The geometry editor was not hidden when selecting a feature.
+    case notHidden
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidGeometry:
+            String(
+                localized: "The geometry is invalid. It must be corrected before saving.",
+                bundle: .toolkitModule,
+                comment: "An error message shown when trying to save an invalid geometry."
+            )
+        default:
+            nil
+        }
+    }
 }
 
 // MARK: Feature Selectable Layer

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -104,7 +104,7 @@ struct FeatureEditorFormView: View {
         case .navigationChanged(let view):
             switch view {
             case .utilityAssociationCreationView(_, _, _, let candidate):
-                await showCandidateOnMap(candidate)
+                await showCandidate(candidate)
             default:
                 // Clears selection when the user navigates away from the current view.
                 clearSelectedFeature()
@@ -114,13 +114,13 @@ struct FeatureEditorFormView: View {
             guard !willNavigate else { break }
             model.isPresented = false
         case .showOnMapRequested(let feature):
-            await showFeatureOnMap(feature)
+            await showFeature(feature)
         }
     }
     
     /// Zooms to and selects an association candidate feature on the map.
     /// - Parameter candidate: The `UtilityAssociationFeatureCandidate` to show.
-    private func showCandidateOnMap(_ candidate: UtilityAssociationFeatureCandidate) async {
+    private func showCandidate(_ candidate: UtilityAssociationFeatureCandidate) async {
         guard let candidateGeometry = candidate.feature.geometry,
               !candidateGeometry.isEmpty,
               let geometryEditorGeometry = model.geometryEditorGeometry else {
@@ -139,7 +139,7 @@ struct FeatureEditorFormView: View {
     
     /// Zooms to and briefly selects a feature on the map.
     /// - Parameter feature: The `ArcGISFeature` to show.
-    private func showFeatureOnMap(_ feature: ArcGISFeature) async {
+    private func showFeature(_ feature: ArcGISFeature) async {
         guard feature.geometry?.isEmpty == false else { return }
         
         model.viewpointGeometry = feature.geometry

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -18,6 +18,8 @@ import SwiftUI
 
 /// A view that contains the `FeatureFormView` for the feature editor.
 struct FeatureEditorFormView: View {
+    /// The root feature form to display in form view.
+    let rootFeatureForm: FeatureForm
     /// A Boolean value indicating whether the parent presentation is minimized.
     let isMinimized: Bool
     
@@ -51,41 +53,39 @@ struct FeatureEditorFormView: View {
     }
     
     var body: some View {
-        if let rootFeatureForm = model.rootFeatureForm {
-            @Bindable var model = model
-            
-            FeatureFormView(root: rootFeatureForm, isPresented: $model.isPresented)
-                .editingButtons(isMinimized ? .hidden : .automatic)
-                .onFeatureFormChanged { presentedFeatureForm = $0 }
-                .onFormEditingEvent { editingEvent = EquatableEditingEvent(event: $0) }
-                .environment(\.externalSaveAction, saveGeometryEditsAction)
-                .onAnimationChange(of: geometryEditorOpacity) { newOpacity in
-                    model.geometryEditor.tool.style.opacity = newOpacity
-                }
-                .animation(.default, value: geometryEditorOpacity)
-                .task(id: editingEvent) {
-                    guard let editingEvent else { return }
-                    await handleEditingEvent(editingEvent.event)
-                    
-                    // Prevents clearing editingEvent if it was set while this
-                    // task was running.
-                    guard !Task.isCancelled else { return }
-                    self.editingEvent = nil
-                }
-                .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
-                    guard let presentedFeatureForm else { return }
-                    await model.startEditingFeatureForm(presentedFeatureForm)
-                    
-                    // Prevents clearing presentedFeatureForm if it was set
-                    // while this task was running.
-                    guard !Task.isCancelled else { return }
-                    self.presentedFeatureForm = nil
-                }
-                .onDisappear {
-                    clearSelectedFeature()
-                    model.geometryEditor.tool.style.opacity = 1
-                }
-        }
+        @Bindable var model = model
+        
+        FeatureFormView(root: rootFeatureForm, isPresented: $model.isPresented)
+            .editingButtons(isMinimized ? .hidden : .automatic)
+            .onFeatureFormChanged { presentedFeatureForm = $0 }
+            .onFormEditingEvent { editingEvent = EquatableEditingEvent(event: $0) }
+            .environment(\.externalSaveAction, saveGeometryEditsAction)
+            .onAnimationChange(of: geometryEditorOpacity) { newOpacity in
+                model.geometryEditor.tool.style.opacity = newOpacity
+            }
+            .animation(.default, value: geometryEditorOpacity)
+            .task(id: editingEvent) {
+                guard let editingEvent else { return }
+                await handleEditingEvent(editingEvent.event)
+                
+                // Prevents clearing editingEvent if it was set while this
+                // task was running.
+                guard !Task.isCancelled else { return }
+                self.editingEvent = nil
+            }
+            .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
+                guard let presentedFeatureForm else { return }
+                await model.startEditingFeatureForm(presentedFeatureForm)
+                
+                // Prevents clearing presentedFeatureForm if it was set
+                // while this task was running.
+                guard !Task.isCancelled else { return }
+                self.presentedFeatureForm = nil
+            }
+            .onDisappear {
+                clearSelectedFeature()
+                model.geometryEditor.tool.style.opacity = 1
+            }
     }
     
     /// Clears `selectedFeature` and unselects it on its layer.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -74,11 +74,11 @@ struct FeatureEditorFormView: View {
     /// Clears `selectedFeature` and unselects it on its layer.
     private func clearSelectedFeature() {
         guard let selectedFeature = selectedFeature.take(),
-              let featureLayer = selectedFeature.table?.layer as? FeatureLayer else {
+              let layer = selectedFeature.table?.layer as? FeatureSelectableLayer else {
             return
         }
         
-        featureLayer.unselectFeature(selectedFeature)
+        layer.unselectFeature(selectedFeature)
     }
     
     /// Performs an action associated with a form editing event.
@@ -143,9 +143,9 @@ struct FeatureEditorFormView: View {
     /// - Parameter feature: The feature to select.
     /// - Throws: If the geometry editor does not have a valid geometry to hide.
     private func selectFeature(_ feature: ArcGISFeature) async throws {
-        guard let featureLayer = feature.table?.layer as? FeatureLayer else { return }
+        guard let layer = feature.table?.layer as? FeatureSelectableLayer else { return }
         
-        featureLayer.selectFeature(feature)
+        layer.selectFeature(feature)
         selectedFeature = feature
         
         // Briefly hides the geometry editor so the user can still locate the
@@ -193,3 +193,17 @@ private struct InvalidGeometryError: LocalizedError {
         comment: "An error message shown when trying to save an invalid geometry."
     )
 }
+
+// MARK: Feature Selectable Layer
+
+/// A layer that can select and unselect a feature.
+private protocol FeatureSelectableLayer {
+    func selectFeature(_ feature: Feature)
+    func unselectFeature(_ feature: Feature)
+}
+
+// Only 2D layers are extended since the Feature Editor is map specific.
+extension AnnotationLayer: FeatureSelectableLayer {}
+extension DimensionLayer: FeatureSelectableLayer {}
+extension FeatureLayer: FeatureSelectableLayer {}
+extension OrientedImageryLayer: FeatureSelectableLayer {}

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -154,7 +154,7 @@ struct FeatureEditorFormView: View {
         } catch {
             // Sleeps if the geometry editor wasn't hidden so there is still a
             // delay before the selection is cleared.
-            try? await Task.sleep(for: .seconds(1))
+            try? await Task.sleep(for: .featureHighlightDelay)
         }
         
         // Prevents clearing a selection made by another task while this one was still running.
@@ -186,12 +186,17 @@ struct FeatureEditorFormView: View {
         
         model.geometryEditor.clearSelection()
         geometryEditorOpacity = 0.1
-        try? await Task.sleep(for: .seconds(1))
+        try? await Task.sleep(for: .featureHighlightDelay)
         geometryEditorOpacity = 1
     }
 }
 
 // MARK: - Helpers
+
+private extension Duration {
+    /// The duration before a feature highlight (selection and geometry editor opacity) is cleared.
+    static let featureHighlightDelay = Self.seconds(1)
+}
 
 /// A wrapper for `FeatureFormView.EditingEvent` that conforms to `Equatable`.
 private struct EquatableEditingEvent: Equatable {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -251,18 +251,14 @@ extension OrientedImageryLayer: FeatureSelectableLayer {}
 
 // MARK: On Animation Change Modifier
 
-/// A view modifier that performs an action when the animation data of a given value changes.
-private struct OnAnimationChangeModifier<Value: VectorArithmetic>: @MainActor Animatable & ViewModifier {
-    /// The value to observe for changes in its animation data.
-    let value: Value
-    /// The action to perform when the animation data changes.
-    let action: (_ animatableData: Value) -> Void
-    
-    /// The value's animation data that is observed for changes.
-    var animatableData: Value {
-        get { value }
-        set { action(newValue) }
+/// A view modifier that performs an action when animatable data changes.
+private struct OnAnimationChangeModifier<Data: Sendable & VectorArithmetic>: Animatable & ViewModifier {
+    /// The data to animate.
+    var animatableData: Data {
+        didSet { action(animatableData) }
     }
+    /// The action to perform when the animatable data changes.
+    let action: (_ animatableData: Data) -> Void
     
     func body(content: Content) -> some View {
         content
@@ -270,15 +266,15 @@ private struct OnAnimationChangeModifier<Value: VectorArithmetic>: @MainActor An
 }
 
 private extension View {
-    /// Performs an action when the animation data of a given value changes.
+    /// Performs an action when animatable data changes.
     /// - Parameters:
-    ///   - value: The value to observe for changes in its animation data.
-    ///   - action: The action to perform when the animation data changes.
-    ///   The new animation data is passed as a parameter.
-    func onAnimationChange<Value: VectorArithmetic>(
-        of value: Value,
-        perform action: @escaping (_ animatableData: Value) -> Void
+    ///   - animatableData: The data to animate.
+    ///   - action: The action to perform when the animatable data changes.
+    ///   The new animatable data is passed as a parameter.
+    func onAnimationChange<Data: Sendable & VectorArithmetic>(
+        of animatableData: Data,
+        perform action: @escaping (_ animatableData: Data) -> Void
     ) -> some View {
-        modifier(OnAnimationChangeModifier(value: value, action: action))
+        modifier(OnAnimationChangeModifier(animatableData: animatableData, action: action))
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -142,7 +142,7 @@ struct FeatureEditorFormView: View {
         try? await selectFeature(candidate.feature)
     }
     
-    /// Zooms to and briefly selects a feature on the map.
+    /// Zooms to and selects a feature on the map for 1 second.
     /// - Parameter feature: The `ArcGISFeature` to show.
     private func showFeature(_ feature: ArcGISFeature) async {
         guard feature.geometry?.isEmpty == false else { return }
@@ -150,10 +150,13 @@ struct FeatureEditorFormView: View {
         model.viewpointGeometry = feature.geometry
         
         do {
+            // Selects the feature and delays for 1 sec while the geometry editor is hidden.
             try await selectFeature(feature)
         } catch {
-            // Sleeps if the geometry editor wasn't hidden so there is still a
-            // delay before the selection is cleared.
+            // If selectFeature(_:) throws, the feature was selected, but a 1
+            // sec delay was not performed since the geometry editor couldn't
+            // be hidden. This performs the delay if that happens so that the
+            // feature is still selected for one 1 sec.
             try? await Task.sleep(for: .featureHighlightDelay)
         }
         
@@ -162,7 +165,7 @@ struct FeatureEditorFormView: View {
         clearSelectedFeature()
     }
     
-    /// Selects a feature on the map and briefly hides the geometry editor's symbology.
+    /// Selects a feature on the map and hides the geometry editor's symbology for 1 second.
     /// - Parameter feature: The feature to select.
     /// - Throws: If the geometry editor was not hidden.
     private func selectFeature(_ feature: ArcGISFeature) async throws {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -74,7 +74,10 @@ struct FeatureEditorFormView: View {
                     defer { self.presentedFeatureForm = nil }
                     await model.startEditingFeatureForm(presentedFeatureForm)
                 }
-                .onDisappear(perform: clearSelectedFeature)
+                .onDisappear {
+                    clearSelectedFeature()
+                    model.geometryEditor.tool.style.opacity = 0
+                }
         }
     }
     
@@ -169,7 +172,7 @@ struct FeatureEditorFormView: View {
     }
 }
 
-// MARK: - Helper
+// MARK: - Helpers
 
 /// A wrapper for `FeatureFormView.EditingEvent` that conforms to `Equatable`.
 private struct EquatableEditingEvent: Equatable {
@@ -209,7 +212,7 @@ private protocol FeatureSelectableLayer {
     func unselectFeature(_ feature: Feature)
 }
 
-// Only 2D layers are extended since the Feature Editor is map specific.
+// Only 2D layers are extended since the Feature Editor is map-specific.
 extension AnnotationLayer: FeatureSelectableLayer {}
 extension DimensionLayer: FeatureSelectableLayer {}
 extension FeatureLayer: FeatureSelectableLayer {}

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -28,6 +28,9 @@ struct FeatureEditorFormView: View {
     /// The current editing event from the form view. This is non-`nil` while
     /// the event is being processed by this view.
     @State private var editingEvent: EquatableEditingEvent?
+    /// The opacity of the geometry editor tool's symbology. This is used to
+    /// animate changes to the geometry editor's opacity.
+    @State private var geometryEditorOpacity: Float = 1
     /// The form currently presented in the `FeatureFormView`.
     @State private var presentedFeatureForm: FeatureForm?
     /// The feature currently selected on the map. This is non-`nil` when
@@ -56,6 +59,10 @@ struct FeatureEditorFormView: View {
                 .onFeatureFormChanged { presentedFeatureForm = $0 }
                 .onFormEditingEvent { editingEvent = EquatableEditingEvent(event: $0) }
                 .environment(\.externalSaveAction, saveGeometryEditsAction)
+                .onAnimationChange(of: geometryEditorOpacity) { newOpacity in
+                    model.geometryEditor.tool.style.opacity = newOpacity
+                }
+                .animation(.default, value: geometryEditorOpacity)
                 .task(id: editingEvent) {
                     guard let editingEvent else { return }
                     defer { self.editingEvent = nil }
@@ -156,13 +163,13 @@ struct FeatureEditorFormView: View {
         }
         
         model.geometryEditor.clearSelection()
-        model.geometryEditor.tool.style.opacity = 0.1
+        geometryEditorOpacity = 0.1
         try? await Task.sleep(for: .seconds(1))
-        model.geometryEditor.tool.style.opacity = 1
+        geometryEditorOpacity = 1
     }
 }
 
-// MARK: - Helper Types
+// MARK: - Helper
 
 /// A wrapper for `FeatureFormView.EditingEvent` that conforms to `Equatable`.
 private struct EquatableEditingEvent: Equatable {
@@ -207,3 +214,37 @@ extension AnnotationLayer: FeatureSelectableLayer {}
 extension DimensionLayer: FeatureSelectableLayer {}
 extension FeatureLayer: FeatureSelectableLayer {}
 extension OrientedImageryLayer: FeatureSelectableLayer {}
+
+// MARK: On Animation Change Modifier
+
+/// A view modifier that performs an action when the animation data of a given value changes.
+private struct OnAnimationChangeModifier<Value: VectorArithmetic>: @MainActor AnimatableModifier {
+    /// The value to observe for changes in its animation data.
+    let value: Value
+    /// The action to perform when the animation data changes.
+    let action: (_ animatableData: Value) -> Void
+    
+    /// The value's animation data that is observed for changes.
+    var animatableData: Value {
+        get { value }
+        set { action(newValue) }
+    }
+    
+    func body(content: Content) -> some View {
+        content
+    }
+}
+
+private extension View {
+    /// Performs an action when the animation data of a given value changes.
+    /// - Parameters:
+    ///   - value: The value to observe for changes in its animation data.
+    ///   - action: The action to perform when the animation data changes.
+    ///   The new animation data is passed as a parameter.
+    func onAnimationChange<Value: VectorArithmetic>(
+        of value: Value,
+        perform action: @escaping (_ animatableData: Value) -> Void
+    ) -> some View {
+        modifier(OnAnimationChangeModifier(value: value, action: action))
+    }
+}

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -67,14 +67,19 @@ struct FeatureEditorFormView: View {
                     guard let editingEvent else { return }
                     await handleEditingEvent(editingEvent.event)
                     
-                    // Prevents clearing an editing event set while this task was running.
+                    // Prevents clearing editingEvent if it was set while this
+                    // task was running.
                     guard !Task.isCancelled else { return }
                     self.editingEvent = nil
                 }
                 .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
                     guard let presentedFeatureForm else { return }
-                    defer { self.presentedFeatureForm = nil }
                     await model.startEditingFeatureForm(presentedFeatureForm)
+                    
+                    // Prevents clearing presentedFeatureForm if it was set
+                    // while this task was running.
+                    guard !Task.isCancelled else { return }
+                    self.presentedFeatureForm = nil
                 }
                 .onDisappear {
                     clearSelectedFeature()

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -233,7 +233,7 @@ private enum GeometryEditorError: LocalizedError {
 // MARK: Feature Selectable Layer
 
 /// A layer that can select and unselect a feature.
-private protocol FeatureSelectableLayer {
+private protocol FeatureSelectableLayer: Layer {
     func selectFeature(_ feature: Feature)
     func unselectFeature(_ feature: Feature)
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -1,0 +1,90 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArcGIS
+internal import os
+import SwiftUI
+
+/// A view that contains the `FeatureFormView` for the feature editor.
+struct FeatureEditorFormView: View {
+    /// A Boolean value indicating whether the parent presentation is minimized.
+    let isMinimized: Bool
+    
+    /// The feature editor model from the environment. This is needed to access
+    /// the geometry editor.
+    @Environment(FeatureEditorModel.self) private var model
+    
+    /// The form currently presented in the `FeatureFormView`.
+    @State private var presentedFeatureForm: FeatureForm?
+    
+    /// A closure that saves geometry edits to the form's feature. This is
+    /// non-`nil` only when there are edits, so the `FeatureFormView`
+    /// knows when to show the editing buttons and block navigation.
+    private var saveGeometryEditsAction: (() throws -> Void)? {
+        guard model.geometryEditorCanUndo else { return nil }
+        return {
+            guard let geometry = model.geometryEditorGeometry, geometry.sketchIsValid else {
+                throw InvalidGeometryError()
+            }
+            model.feature?.geometry = geometry
+        }
+    }
+    
+    var body: some View {
+        if let rootFeatureForm = model.rootFeatureForm {
+            @Bindable var model = model
+            
+            FeatureFormView(root: rootFeatureForm, isPresented: $model.isPresented)
+                .editingButtons(isMinimized ? .hidden : .automatic)
+                .onFeatureFormChanged { presentedFeatureForm = $0 }
+                .onFormEditingEvent(perform: handleFormEditingEvent)
+                .environment(\.externalSaveAction, saveGeometryEditsAction)
+                .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
+                    guard let presentedFeatureForm else { return }
+                    defer { self.presentedFeatureForm = nil }
+                    await model.startEditingFeatureForm(presentedFeatureForm)
+                }
+        }
+    }
+    
+    /// Handles events from the `FeatureFormView.onFormEditingEvent(perform:)` modifier.
+    /// - Parameter event: The form editing event to handle.
+    private func handleFormEditingEvent(_ event: FeatureFormView.EditingEvent) {
+        switch event {
+        case .discardedEdits(let willNavigate):
+            // Restarts the geometry editor when the form footer discard button is pressed.
+            guard !willNavigate else { break }
+            model.restartGeometryEditor()
+        case .savedEdits(let willNavigate):
+            // Closes the inspector when the form footer save button is pressed.
+            guard !willNavigate else { break }
+            model.isPresented = false
+        case .showOnMapRequested(let feature):
+            model.viewpointGeometry = feature.geometry
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - Helper Types
+
+/// An error indicating that the geometry is invalid and must be corrected before saving.
+private struct InvalidGeometryError: LocalizedError {
+    let errorDescription: String? = String(
+        localized: "The geometry is invalid. It must be corrected before saving.",
+        bundle: .toolkitModule,
+        comment: "An error message shown when trying to save an invalid geometry."
+    )
+}

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -65,9 +65,11 @@ struct FeatureEditorFormView: View {
                 .animation(.default, value: geometryEditorOpacity)
                 .task(id: editingEvent) {
                     guard let editingEvent else { return }
-                    defer { self.editingEvent = nil }
-                    
                     await handleEditingEvent(editingEvent.event)
+                    
+                    // Prevents clearing an editing event set while this task was running.
+                    guard !Task.isCancelled else { return }
+                    self.editingEvent = nil
                 }
                 .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
                     guard let presentedFeatureForm else { return }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -104,6 +104,7 @@ struct FeatureEditorFormView: View {
             case .utilityAssociationCreationView(_, _, _, let candidate):
                 await showCandidateOnMap(candidate)
             default:
+                // Clears selection when the user navigates away from the current view.
                 clearSelectedFeature()
             }
         case .savedEdits(let willNavigate):
@@ -146,6 +147,9 @@ struct FeatureEditorFormView: View {
             // delay before the selection is cleared.
             try? await Task.sleep(for: .seconds(1))
         }
+        
+        // Prevents clearing a selection made by another task while this one was still running.
+        guard !Task.isCancelled else { return }
         clearSelectedFeature()
     }
     
@@ -153,6 +157,8 @@ struct FeatureEditorFormView: View {
     /// - Parameter feature: The feature to select.
     /// - Throws: If the geometry editor does not have a valid geometry to hide.
     private func selectFeature(_ feature: ArcGISFeature) async throws {
+        clearSelectedFeature()
+        
         guard let layer = feature.table?.layer as? FeatureSelectableLayer else { return }
         
         layer.selectFeature(feature)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ArcGIS
-internal import os
 import SwiftUI
 
 public extension View {
@@ -128,68 +126,6 @@ private struct FeatureEditorModifier: ViewModifier {
     }
 }
 
-/// A view that contains the `FeatureFormView` for the feature editor.
-private struct FeatureEditorFormView: View {
-    /// A Boolean value indicating whether the parent presentation is minimized.
-    let isMinimized: Bool
-    
-    /// The feature editor model from the environment. This is needed to access
-    /// the geometry editor.
-    @Environment(FeatureEditorModel.self) private var model
-    
-    /// The form currently presented in the `FeatureFormView`.
-    @State private var presentedFeatureForm: FeatureForm?
-    
-    /// A closure that saves geometry edits to the form's feature. This is
-    /// non-`nil` only when there are edits, so the `FeatureFormView`
-    /// knows when to show the editing buttons and block navigation.
-    private var saveGeometryEditsAction: (() throws -> Void)? {
-        guard model.geometryEditorCanUndo else { return nil }
-        return {
-            guard let geometry = model.geometryEditorGeometry, geometry.sketchIsValid else {
-                throw InvalidGeometryError()
-            }
-            model.feature?.geometry = geometry
-        }
-    }
-    
-    var body: some View {
-        if let rootFeatureForm = model.rootFeatureForm {
-            @Bindable var model = model
-            
-            FeatureFormView(root: rootFeatureForm, isPresented: $model.isPresented)
-                .editingButtons(isMinimized ? .hidden : .automatic)
-                .onFeatureFormChanged { presentedFeatureForm = $0 }
-                .onFormEditingEvent(perform: handleFormEditingEvent)
-                .environment(\.externalSaveAction, saveGeometryEditsAction)
-                .task(id: presentedFeatureForm.map(ObjectIdentifier.init)) {
-                    guard let presentedFeatureForm else { return }
-                    defer { self.presentedFeatureForm = nil }
-                    await model.startEditingFeatureForm(presentedFeatureForm)
-                }
-        }
-    }
-    
-    /// Handles events from the `FeatureFormView.onFormEditingEvent(perform:)` modifier.
-    /// - Parameter event: The form editing event to handle.
-    private func handleFormEditingEvent(_ event: FeatureFormView.EditingEvent) {
-        switch event {
-        case .discardedEdits(let willNavigate):
-            // Restarts the geometry editor when the form footer discard button is pressed.
-            guard !willNavigate else { break }
-            model.restartGeometryEditor()
-        case .savedEdits(let willNavigate):
-            // Closes the inspector when the form footer save button is pressed.
-            guard !willNavigate else { break }
-            model.isPresented = false
-        case .showOnMapRequested(let feature):
-            model.viewpointGeometry = feature.geometry
-        default:
-            break
-        }
-    }
-}
-
 // MARK: - Helper Types
 
 /// A custom presentation detent that sizes to the approximate height of a top system toolbar.
@@ -199,15 +135,6 @@ private struct BarDetent: CustomPresentationDetent {
         // https://developer.apple.com/documentation/swiftui/custompresentationdetent#overview
         return max(44, context.maxDetentValue * 0.1)
     }
-}
-
-/// An error indicating that the geometry is invalid and must be corrected before saving.
-private struct InvalidGeometryError: LocalizedError {
-    let errorDescription: String? = String(
-        localized: "The geometry is invalid. It must be corrected before saving.",
-        bundle: .toolkitModule,
-        comment: "An error message shown when trying to save an invalid geometry."
-    )
 }
 
 // MARK: - Extensions

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -42,7 +42,12 @@ private struct FeatureEditorModifier: ViewModifier {
                 VStack(spacing: 0) {
                     switch model.loadResult {
                     case .success:
-                        FeatureEditorFormView(isMinimized: selectedPresentationDetent == .bar)
+                        if let rootFeatureForm = model.rootFeatureForm {
+                            FeatureEditorFormView(
+                                rootFeatureForm: rootFeatureForm,
+                                isMinimized: selectedPresentationDetent == .bar
+                            )
+                        }
                     case .failure(let error):
                         NavigationStack {
                             makeContentUnavailableView(error: error)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/ToolPicker.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/ToolPicker.swift
@@ -109,7 +109,6 @@ private enum Tool: Hashable {
         // Makes the fill symbol semi-transparent to avoid obscuring the map beneath polygons.
         if let fillSymbol = tool.style.fillSymbol as? FillSymbol {
             fillSymbol.color = fillSymbol.color.withAlphaComponent(0.5)
-            tool.style.fillSymbol = fillSymbol
         }
         
         return tool

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/ToolPicker.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/ToolPicker.swift
@@ -91,19 +91,28 @@ private enum Tool: Hashable {
     
     /// The geometry editor tool associated with the tool.
     var geometryEditorTool: GeometryEditorTool {
+        let tool: GeometryEditorTool
         switch self {
         case .freehand:
-            return FreehandTool()
+            tool = FreehandTool()
         case .shape(let kind):
             let shapeTool = ShapeTool(kind: kind)
             // Allows the shape tool to be used when there is an existing geometry.
             shapeTool.configuration.allowsPartCreation = true
-            return shapeTool
+            tool = shapeTool
         case .vertex:
-            return VertexTool()
+            tool = VertexTool()
         case .vertexReticle:
-            return ReticleVertexTool()
+            tool = ReticleVertexTool()
         }
+        
+        // Makes the fill symbol semi-transparent to avoid obscuring the map beneath polygons.
+        if let fillSymbol = tool.style.fillSymbol as? FillSymbol {
+            fillSymbol.color = fillSymbol.color.withAlphaComponent(0.5)
+            tool.style.fillSymbol = fillSymbol
+        }
+        
+        return tool
     }
     
     /// A localized, user-friendly label for the tool.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -374,6 +374,22 @@ public extension FeatureFormView {
     }
 }
 
+extension FeatureFormView.EditingEvent: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return switch (lhs, rhs) {
+        case let (.discardedEdits(lhsWillNavigate), .discardedEdits(rhsWillNavigate)),
+            let (.savedEdits(lhsWillNavigate), .savedEdits(rhsWillNavigate)):
+            lhsWillNavigate == rhsWillNavigate
+        case let (.navigationChanged(lhsPathItem), .navigationChanged(rhsPathItem)):
+            lhsPathItem == rhsPathItem
+        case let (.showOnMapRequested(lhsFeature), .showOnMapRequested(rhsFeature)):
+            lhsFeature === rhsFeature
+        default:
+            false
+        }
+    }
+}
+
 extension FeatureFormView {
     /// A Boolean value indicating whether the finish editing error alert is presented.
     var alertForFinishEditingErrorsIsPresented: Binding<Bool> {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
@@ -23,7 +23,7 @@ extension FeatureFormView {
         let feature: ArcGISFeature
         
         var body: some View {
-            if let geometry = feature.geometry, !geometry.isEmpty {
+            if feature.geometry != nil {
                 Button {
                     onFormEditingEventAction?(.showOnMapRequested(feature))
                 } label: {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/ShowOnMapButton.swift
@@ -23,7 +23,7 @@ extension FeatureFormView {
         let feature: ArcGISFeature
         
         var body: some View {
-            if feature.geometry != nil {
+            if let geometry = feature.geometry, !geometry.isEmpty {
                 Button {
                     onFormEditingEventAction?(.showOnMapRequested(feature))
                 } label: {


### PR DESCRIPTION
## Description

This PR makes some improvements related to viewpoint centering in the Feature Editor. Closes `swift/issues/8341` & `swift/issues/7722`.

### Behavior Changes

- "Show on Map" features are briefly selected.
- Candidate features are selected while association creation view is showing.
- Viewpoint zooms to include the candidate feature and geometry editor geometry when association creation view appears.
- Geometry editor briefly hides whenever it's geometry intersects a selected feature. 
- Geometry editor fill symbol is semi-transparent.

### Other Changes

- Example viewpoint was updated to include a polygon for easier testing.
- `FeatureEditorFormView` was moved to its own file.
  - Actual `FeatureEditorFormView` changes can be seen in: https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/compare/5526539..Caleb/FE-ViewpointImprovements


## How To Test

- Run `FeatureEditorExample` and tap on a feature to start editing.
- Try using "Show on Map" and adding an association. (Follow workflow in videos below.)


## Screenshots

### Show on Map / Add Association

|Before|After|
|:-:|:-:|
| https://github.com/user-attachments/assets/f160636e-630a-4e58-b012-9137853be709 | https://github.com/user-attachments/assets/1af97c9f-b073-4211-b5f1-657bc0c514e9 |

### Example Viewpoint

|Before|After|
|:-:|:-:|
| <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-07-16 at 15 22 19" src="https://github.com/user-attachments/assets/07fb89d2-900a-498b-a55b-9ad0e2fecc94" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-07-16 at 15 21 52" src="https://github.com/user-attachments/assets/259b1b46-2d6a-4507-8fa3-87432443b575" /> |
