### PR TITLE
Offline: Fix flakey test failures

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandMapModel.swift
@@ -154,19 +154,19 @@ class OnDemandMapModel: ObservableObject, Identifiable {
     private func loadAndUpdateMobileMapPackage(mmpk: MobileMapPackage) async {
         do {
             try await mmpk.load()
-            // Set status to downloaded if not already set.
-            switch status {
-            case .downloaded:
-                break
-            default:
-                status = .downloaded
-            }
             mobileMapPackage = mmpk
             sizeInBytes = FileManager.default.sizeOfDirectory(at: mmpkDirectoryURL)
             map = mmpk.maps.first
             if thumbnail == nil, let loadable = mmpk.item?.thumbnail {
                 try? await loadable.load()
                 thumbnail = loadable.image
+            }
+            // Set status to downloaded if not already set.
+            switch status {
+            case .downloaded:
+                break
+            default:
+                status = .downloaded
             }
         } catch {
             status = .mmpkLoadFailure(error)

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
@@ -123,10 +123,10 @@ class PreplannedMapModel: ObservableObject, Identifiable {
     private func loadAndUpdateMobileMapPackage(mmpk: MobileMapPackage) async {
         do {
             try await mmpk.load()
-            status = .downloaded
             mobileMapPackage = mmpk
             sizeInBytes = FileManager.default.sizeOfDirectory(at: mmpkDirectoryURL)
             map = mmpk.maps.first
+            status = .downloaded
         } catch {
             status = .mmpkLoadFailure(error)
             mobileMapPackage = nil


### PR DESCRIPTION
Fixes flakey test failures for testLoadMobileMapPackage() in `PreplannedMapModelTests` and `OnDemandMapModelTests` by setting the `.downloaded` status _after_ the map is set in `loadAndUpdateMobileMapPackage(mmpk:)`. This test occasionally fails after verifying the status is `.downloaded` and then fails when checking that the map is not nil due to a race condition where the map has not yet been set. Verified that the tests pass locally and that the component works as expected.