### PR TITLE
`FeatureFormView` - Fix `RadioButtonsInput` refocus on discard

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/RadioButtonsInput.swift
@@ -80,7 +80,7 @@ struct RadioButtonsInput: View {
                 }
             }
             .onChange(of: selectedValue) {
-                guard selectedValue?.name != element.formattedValue else { return }
+                guard selectedValue?.name ?? "" != element.formattedValue else { return }
                 embeddedFeatureFormViewModel.focusedElement = element
                 element.updateValue(selectedValue?.code)
                 embeddedFeatureFormViewModel.evaluateExpressions()


### PR DESCRIPTION
Apollo 1820

Fixes a small bug where a `RadioButtonsInput` will re-focus itself upon a discard if its inital value was empty.

This is reproducible at least back to 200.8.0 when the Save and Discard buttons were first introduced.

Release test run # 15, 16

| Before | After |
|---|---|
| https://github.com/user-attachments/assets/85ef6ad7-37bf-4a1e-b508-f7f82354feea | https://github.com/user-attachments/assets/f04a1499-8593-4cbe-9fe9-a37c85170ef3 |

Note that the discard button re-appearing is a seperate known issue: Apollo 1691