### PR TITLE
`FeatureFormView` - Fix `GroupFormElement` headers on visionOS

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -34,18 +34,15 @@ struct GroupFormElementView<Content>: View where Content: View {
     }
     
     var body: some View {
-        // Using a Section ensures that consecutive collapsed GroupFormElements
+        // An empty Section ensures that consecutive collapsed GroupFormElements
         // have spacing consistent with other form elements.
-        Section {
-            if UIDevice.current.userInterfaceIdiom == .mac {
-                // Mac Catalyst using the "Optimized for Mac" interface only.
-                labelOptimizedForMac
-            } else {
-                DisclosureGroup(isExpanded: $isExpanded) {} label: {
-                    label
-                }
-            }
+        Section {}
+        DisclosureGroup(isExpanded: $isExpanded) {} label: {
+            label
         }
+        .disclosureGroupStyleOptimizedForMac()
+        // Group element headers shouldn't have a darkened background.
+        .listRowBackground(Color.clear)
         .task {
             await withTaskGroup { group in
                 for element in element.elements {
@@ -59,11 +56,9 @@ struct GroupFormElementView<Content>: View where Content: View {
             }
         }
         
-        // GroupFormElement content is placed outside the Section above for the
-        // following reasons:
-        // 1. Avoids indentation introduced by components like a DisclosureGroup.
-        // 2. Avoids unwanted impacts on appearance from nested Sections.
-        // 3. Avoids the header receiving a pill-shaped background.
+        // GroupFormElement content is placed outside the DisclosureGroup to
+        // avoid indentation and other unwanted visual impacts from nesting
+        // elements within the group.
         if isExpanded {
             ForEach(visibleElements, id: \.self) { element in
                 Section {
@@ -73,7 +68,6 @@ struct GroupFormElementView<Content>: View where Content: View {
                 } footer: {
                     FormElementFooter(element: element)
                 }
-                .textCase(nil)
             }
         }
     }
@@ -81,55 +75,18 @@ struct GroupFormElementView<Content>: View where Content: View {
     /// The label for the group element.
     private var label: some View {
         VStack(alignment: .leading) {
-            titleLine1
-            titleLine2
-        }
-        .foregroundStyle(.secondary)
-        .textCase(nil)
-    }
-    
-    /// The label for the group element on Mac Catalyst apps.
-    ///
-    /// For Mac Catalyst apps using the "Optimize for Mac" interface, a DisclosureGroup's indicator
-    /// is scrunched up against its label so a special label replaces the DisclosureGroup here.
-    private var labelOptimizedForMac: some View {
-        Button {
-            withAnimation {
-                isExpanded.toggle()
+            Text(element.label)
+                .font(.title3)
+                .fontWeight(.semibold)
+            if !element.description.isEmpty {
+                Text(element.description)
+                    .accessibilityIdentifier("\(element.label) Description")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
             }
-        } label: {
-            HStack {
-                VStack(alignment: .leading) {
-                    titleLine1
-                    titleLine2
-                }
-                .foregroundStyle(.secondary)
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .fontWeight(.bold)
-                    .foregroundStyle(.primary)
-                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
-            }
-            .contentShape(.rect)
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
         .textCase(nil)
-    }
-    
-    private var titleLine1: some View {
-        Text(element.label)
-            .font(.title3)
-            .fontWeight(.semibold)
-    }
-    
-    @ViewBuilder private var titleLine2: some View {
-        if !element.description.isEmpty {
-            Text(element.description)
-                .accessibilityIdentifier("\(element.label) Description")
-                .font(.footnote)
-                .multilineTextAlignment(.leading)
-        }
     }
     
     /// The list of visible group elements.
@@ -137,5 +94,48 @@ struct GroupFormElementView<Content>: View where Content: View {
         element
             .elements
             .filter { elementVisibility[$0] == true }
+    }
+}
+
+extension DisclosureGroup {
+    /// Applies a style to the DisclosureGroup in apps running on Mac Catalyst with the "Optimized
+    /// for Mac" interface that keeps the header visually consistent with other platforms.
+    @MainActor
+    @ViewBuilder
+    func disclosureGroupStyleOptimizedForMac() -> some View {
+        if UIDevice.current.userInterfaceIdiom == .mac {
+            self.disclosureGroupStyle(OptimizedForMac())
+        } else {
+            self
+        }
+    }
+}
+
+/// A style that places the disclosure arrow to the right of the label similar to
+/// `AutomaticDisclosureGroupStyle`.
+///
+/// This is intended for Mac Catalyst apps using the "Optimized for Mac" interface where the
+/// disclosure arrow is squished to the left of the content.
+struct OptimizedForMac: DisclosureGroupStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button {
+            withAnimation {
+                configuration.isExpanded.toggle()
+            }
+        } label: {
+            HStack {
+                configuration.label
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .fontWeight(.bold)
+                    .foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(configuration.isExpanded ? 90 : 0))
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        if configuration.isExpanded {
+            configuration.content
+        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -34,11 +34,17 @@ struct GroupFormElementView<Content>: View where Content: View {
     }
     
     var body: some View {
-        // Placing the DisclosureGroup inside a Section ensures that consecutive
-        // collapsed GroupFormElements have spacing consistent with other form elements.
+        // Placing the label inside a Section ensures that consecutive
+        // collapsed GroupFormElements have spacing consistent with other
+        // form elements.
         Section {
-            DisclosureGroup(isExpanded: $isExpanded) {} label: {
-                label
+            if UIDevice.current.userInterfaceIdiom == .mac {
+                // Mac Catalyst using the "Optimized for Mac" interface only.
+                labelOptimizedForMac
+            } else {
+                DisclosureGroup(isExpanded: $isExpanded) {} label: {
+                    label
+                }
             }
         }
         .task {
@@ -73,20 +79,55 @@ struct GroupFormElementView<Content>: View where Content: View {
         }
     }
     
+    @ViewBuilder private var commonDescription: some View {
+        if !element.description.isEmpty {
+            Text(element.description)
+                .accessibilityIdentifier("\(element.label) Description")
+                .font(.footnote)
+                .multilineTextAlignment(.leading)
+        }
+    }
+    
+    private var commonLabel: some View {
+        Text(element.label)
+            .font(.title3)
+            .fontWeight(.semibold)
+            .foregroundStyle(.primary)
+    }
+    
     /// The label for the group element.
     private var label: some View {
         VStack(alignment: .leading) {
-            Text(element.label)
-                .font(.title3)
-                .fontWeight(.semibold)
-                .foregroundStyle(.primary)
-            if !element.description.isEmpty {
-                Text(element.description)
-                    .accessibilityIdentifier("\(element.label) Description")
-                    .font(.footnote)
-                    .multilineTextAlignment(.leading)
+            commonLabel
+            commonDescription
+        }
+        .foregroundStyle(.secondary)
+        .textCase(nil)
+    }
+    
+    /// The label for the group element on Mac Catalyst apps.
+    ///
+    /// For Mac Catalyst apps using the "Optimize for Mac" interface, a DisclosureGroup's indicator
+    /// is scrunched up against its label so a special label replaces the DisclosureGroup here.
+    private var labelOptimizedForMac: some View {
+        Button {
+            withAnimation {
+                isExpanded.toggle()
+            }
+        } label: {
+            VStack(alignment: .leading) {
+                HStack {
+                    commonLabel
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .fontWeight(.bold)
+                        .foregroundStyle(.tertiary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                commonDescription
             }
         }
+        .buttonStyle(.plain)
         .foregroundStyle(.secondary)
         .textCase(nil)
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -34,10 +34,12 @@ struct GroupFormElementView<Content>: View where Content: View {
     }
     
     var body: some View {
-        // Using the header of an empty Section ensures that consecutive collapsed
-        // GroupFormElements have spacing consistent with other form elements.
-        Section {} header: {
-            label
+        // Placing the DisclosureGroup inside a Section ensures that consecutive
+        // collapsed GroupFormElements have spacing consistent with other form elements.
+        Section {
+            DisclosureGroup(isExpanded: $isExpanded) {} label: {
+                label
+            }
         }
         .task {
             await withTaskGroup { group in
@@ -52,8 +54,8 @@ struct GroupFormElementView<Content>: View where Content: View {
             }
         }
         
-        // GroupFormElement content is placed outside the Section above for the
-        // following reasons:
+        // GroupFormElement content is placed outside the DisclosureGroup above
+        // for the following reasons:
         // 1. Avoids indentation introduced by components like a DisclosureGroup.
         // 2. Avoids unwanted impacts on appearance from nested Sections.
         // 3. Avoids the header receiving a pill-shaped background.
@@ -73,32 +75,18 @@ struct GroupFormElementView<Content>: View where Content: View {
     
     /// The label for the group element.
     private var label: some View {
-        Button {
-            withAnimation {
-                isExpanded.toggle()
-            }
-        } label: {
-            VStack(alignment: .leading) {
-                HStack {
-                    Text(element.label)
-                        .font(.title3)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.primary)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .fontWeight(.bold)
-                        .foregroundStyle(.tertiary)
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                }
-                if !element.description.isEmpty {
-                    Text(element.description)
-                        .accessibilityIdentifier("\(element.label) Description")
-                        .font(.footnote)
-                        .multilineTextAlignment(.leading)
-                }
+        VStack(alignment: .leading) {
+            Text(element.label)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundStyle(.primary)
+            if !element.description.isEmpty {
+                Text(element.description)
+                    .accessibilityIdentifier("\(element.label) Description")
+                    .font(.footnote)
+                    .multilineTextAlignment(.leading)
             }
         }
-        .buttonStyle(.plain)
         .foregroundStyle(.secondary)
         .textCase(nil)
     }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -34,15 +34,13 @@ struct GroupFormElementView<Content>: View where Content: View {
     }
     
     var body: some View {
-        // An empty Section ensures that consecutive collapsed GroupFormElements
-        // have spacing consistent with other form elements.
-        Section {}
         DisclosureGroup(isExpanded: $isExpanded) {} label: {
             label
         }
         .disclosureGroupStyleOptimizedForMac()
         // Group element headers shouldn't have a darkened background.
         .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
         .task {
             await withTaskGroup { group in
                 for element in element.elements {
@@ -94,48 +92,5 @@ struct GroupFormElementView<Content>: View where Content: View {
         element
             .elements
             .filter { elementVisibility[$0] == true }
-    }
-}
-
-extension DisclosureGroup {
-    /// Applies a style to the DisclosureGroup in apps running on Mac Catalyst with the "Optimized
-    /// for Mac" interface that keeps the header visually consistent with other platforms.
-    @MainActor
-    @ViewBuilder
-    func disclosureGroupStyleOptimizedForMac() -> some View {
-        if UIDevice.current.userInterfaceIdiom == .mac {
-            self.disclosureGroupStyle(OptimizedForMac())
-        } else {
-            self
-        }
-    }
-}
-
-/// A style that places the disclosure arrow to the right of the label similar to
-/// `AutomaticDisclosureGroupStyle`.
-///
-/// This is intended for Mac Catalyst apps using the "Optimized for Mac" interface where the
-/// disclosure arrow is squished to the left of the content.
-struct OptimizedForMac: DisclosureGroupStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        Button {
-            withAnimation {
-                configuration.isExpanded.toggle()
-            }
-        } label: {
-            HStack {
-                configuration.label
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .fontWeight(.bold)
-                    .foregroundStyle(.tertiary)
-                    .rotationEffect(.degrees(configuration.isExpanded ? 90 : 0))
-            }
-            .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-        if configuration.isExpanded {
-            configuration.content
-        }
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -34,6 +34,11 @@ struct GroupFormElementView<Content>: View where Content: View {
     }
     
     var body: some View {
+#if os(visionOS)
+        // An empty section prevents visual grouping in the hover effect with
+        // sequential GroupFormElements.
+        Section {}
+#endif
         DisclosureGroup(isExpanded: $isExpanded) {} label: {
             label
         }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -60,7 +60,7 @@ struct GroupFormElementView<Content>: View where Content: View {
             }
         }
         
-        // GroupFormElement content is placed outside the DisclosureGroup above
+        // GroupFormElement content is placed outside the Section above
         // for the following reasons:
         // 1. Avoids indentation introduced by components like a DisclosureGroup.
         // 2. Avoids unwanted impacts on appearance from nested Sections.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -98,17 +98,19 @@ struct GroupFormElementView<Content>: View where Content: View {
                 isExpanded.toggle()
             }
         } label: {
-            VStack(alignment: .leading) {
-                HStack {
+            HStack {
+                VStack(alignment: .leading) {
                     titleLine1
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .fontWeight(.bold)
-                        .foregroundStyle(.tertiary)
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    titleLine2
                 }
-                titleLine2
+                .foregroundStyle(.secondary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .fontWeight(.bold)
+                    .foregroundStyle(.primary)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
             }
+            .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)
@@ -119,7 +121,6 @@ struct GroupFormElementView<Content>: View where Content: View {
         Text(element.label)
             .font(.title3)
             .fontWeight(.semibold)
-            .foregroundStyle(.primary)
     }
     
     @ViewBuilder private var titleLine2: some View {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -34,9 +34,8 @@ struct GroupFormElementView<Content>: View where Content: View {
     }
     
     var body: some View {
-        // Placing the label inside a Section ensures that consecutive
-        // collapsed GroupFormElements have spacing consistent with other
-        // form elements.
+        // Using a Section ensures that consecutive collapsed GroupFormElements
+        // have spacing consistent with other form elements.
         Section {
             if UIDevice.current.userInterfaceIdiom == .mac {
                 // Mac Catalyst using the "Optimized for Mac" interface only.
@@ -79,27 +78,11 @@ struct GroupFormElementView<Content>: View where Content: View {
         }
     }
     
-    @ViewBuilder private var commonDescription: some View {
-        if !element.description.isEmpty {
-            Text(element.description)
-                .accessibilityIdentifier("\(element.label) Description")
-                .font(.footnote)
-                .multilineTextAlignment(.leading)
-        }
-    }
-    
-    private var commonLabel: some View {
-        Text(element.label)
-            .font(.title3)
-            .fontWeight(.semibold)
-            .foregroundStyle(.primary)
-    }
-    
     /// The label for the group element.
     private var label: some View {
         VStack(alignment: .leading) {
-            commonLabel
-            commonDescription
+            titleLine1
+            titleLine2
         }
         .foregroundStyle(.secondary)
         .textCase(nil)
@@ -117,19 +100,35 @@ struct GroupFormElementView<Content>: View where Content: View {
         } label: {
             VStack(alignment: .leading) {
                 HStack {
-                    commonLabel
+                    titleLine1
                     Spacer()
                     Image(systemName: "chevron.right")
                         .fontWeight(.bold)
                         .foregroundStyle(.tertiary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
                 }
-                commonDescription
+                titleLine2
             }
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)
         .textCase(nil)
+    }
+    
+    private var titleLine1: some View {
+        Text(element.label)
+            .font(.title3)
+            .fontWeight(.semibold)
+            .foregroundStyle(.primary)
+    }
+    
+    @ViewBuilder private var titleLine2: some View {
+        if !element.description.isEmpty {
+            Text(element.description)
+                .accessibilityIdentifier("\(element.label) Description")
+                .font(.footnote)
+                .multilineTextAlignment(.leading)
+        }
     }
     
     /// The list of visible group elements.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FormElements/GroupFormElementView.swift
@@ -60,8 +60,8 @@ struct GroupFormElementView<Content>: View where Content: View {
             }
         }
         
-        // GroupFormElement content is placed outside the Section above
-        // for the following reasons:
+        // GroupFormElement content is placed outside the Section above for the
+        // following reasons:
         // 1. Avoids indentation introduced by components like a DisclosureGroup.
         // 2. Avoids unwanted impacts on appearance from nested Sections.
         // 3. Avoids the header receiving a pill-shaped background.

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/DisclosureGroup.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/DisclosureGroup.swift
@@ -14,15 +14,6 @@
 
 import SwiftUI
 
-struct DisclosureGroupPadding: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-#if !targetEnvironment(macCatalyst)
-            .padding(.trailing, 2)
-#endif
-    }
-}
-
 extension DisclosureGroup {
     /// Adds a marginal amount of trailing padding to the view to keep the right edge of the arrow from
     /// being clipped.
@@ -31,5 +22,55 @@ extension DisclosureGroup {
     /// - Bug: https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/528
     func disclosureGroupPadding() -> some View {
         modifier(DisclosureGroupPadding())
+    }
+    
+    /// Applies a style to the DisclosureGroup in apps running on Mac Catalyst with the "Optimized
+    /// for Mac" interface that keeps the header visually consistent with other platforms.
+    @MainActor
+    @ViewBuilder
+    func disclosureGroupStyleOptimizedForMac() -> some View {
+        if UIDevice.current.userInterfaceIdiom == .mac {
+            self.disclosureGroupStyle(OptimizedForMac())
+        } else {
+            self
+        }
+    }
+}
+
+private struct DisclosureGroupPadding: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+#if !targetEnvironment(macCatalyst)
+            .padding(.trailing, 2)
+#endif
+    }
+}
+
+/// A style that places the disclosure arrow to the right of the label similar to
+/// `AutomaticDisclosureGroupStyle`.
+///
+/// This is intended for Mac Catalyst apps using the "Optimized for Mac" interface where the
+/// disclosure arrow is squished to the left of the content.
+private struct OptimizedForMac: DisclosureGroupStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button {
+            withAnimation {
+                configuration.isExpanded.toggle()
+            }
+        } label: {
+            HStack {
+                configuration.label
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .fontWeight(.bold)
+                    .foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(configuration.isExpanded ? 90 : 0))
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        if configuration.isExpanded {
+            configuration.content
+        }
     }
 }


### PR DESCRIPTION
Closes #1513 

Release test run # 22

|   | Before | After |
|---|---|---|
| Catalyst (Optimized for Mac) | <img width="1136" height="880" alt="Screenshot 2026-07-29 at 16 11 14" src="https://github.com/user-attachments/assets/c16df4f9-dd7e-41d3-a040-34fc0948c972" /> | <img width="1136" height="880" alt="CatOptimized" src="https://github.com/user-attachments/assets/cb226458-a559-4adc-a865-d972a11188d1" /> |
| Catalyst (Scaled to Match iPad) | <img width="1136" height="880" alt="Screenshot 2026-07-29 at 16 10 09" src="https://github.com/user-attachments/assets/5426c63f-8358-473f-b250-d6efe348397e" /> | <img width="1136" height="880" alt="CatScaled" src="https://github.com/user-attachments/assets/8d6118cd-5dca-4d7c-ab8c-28117940be05" /> |
| iOS | <img width="1206" height="2622" alt="simulator_screenshot_51D094A0-E0AF-40A5-842C-62BF6F279411" src="https://github.com/user-attachments/assets/09577abe-9ba7-4855-88fb-d7725de32ec1" /> | <img width="1206" height="2622" alt="iOS" src="https://github.com/user-attachments/assets/0d60ae84-1936-4ec7-8f8f-04b21a84a4f2" /> |
| iPadOS | <img width="1640" height="2360" alt="Simulator Screenshot - swift-test-ipad (26 1) - 2026-07-29 at 16 05 30" src="https://github.com/user-attachments/assets/14de28da-8f9f-4759-9ecd-41204364bfcd" /> | <img width="1640" height="2360" alt="iPadOS" src="https://github.com/user-attachments/assets/629308b4-9b9b-4b81-a80b-2d8c5c11834e" /> |
| visionOS | <img width="3840" height="2160" alt="simulator_screenshot_BC17D7D8-52BE-4B77-98F0-B6D9F6D385AA" src="https://github.com/user-attachments/assets/3e3fe194-49a6-435b-911f-89e5ccb02ad2" /> | <img width="3840" height="2160" alt="visionOS" src="https://github.com/user-attachments/assets/69fb55c0-2124-426f-95a8-0d964562fd83" /> |