### PR TITLE
Add accessibility labels to icon-only buttons

### DIFF
--- a/Sources/ArcGISToolkit/Common/AttachmentList.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentList.swift
@@ -105,12 +105,42 @@ struct AttachmentLoadButton: View  {
             .frame(width: 24, height: 24)
             .padding(.leading)
         }
+        .accessibilityLabel(attachmentButtonLabel)
         .alert(String.emptyAttachmentDownloadErrorMessage, isPresented: $downloadAlertIsPresented) { }
         .disabled(isLoading)
         .task(id: isLoading) {
             guard isLoading else { return }
             defer { isLoading = false }
             await attachmentModel.load()
+        }
+    }
+    
+    private var attachmentButtonLabel: String {
+        switch attachmentModel.loadStatus {
+        case .notLoaded:
+            String(
+                localized: "Download Attachment",
+                bundle: .toolkitModule,
+                comment: "A label for a button that downloads an attachment."
+            )
+        case .loading:
+            String(
+                localized: "Loading Attachment",
+                bundle: .toolkitModule,
+                comment: "A label for a button indicating an attachment is loading."
+            )
+        case .loaded:
+            String(
+                localized: "Attachment Loaded",
+                bundle: .toolkitModule,
+                comment: "A label for a button indicating an attachment has loaded."
+            )
+        case .failed:
+            String(
+                localized: "Attachment Failed to Load",
+                bundle: .toolkitModule,
+                comment: "A label for a button indicating an attachment has failed to load."
+            )
         }
     }
 }

--- a/Sources/ArcGISToolkit/Common/FlashlightButton.swift
+++ b/Sources/ArcGISToolkit/Common/FlashlightButton.swift
@@ -42,6 +42,29 @@ struct FlashlightButton: View {
         }
     }
     
+    var flashlightButtonLabel: String {
+        switch (hasTorch, torchIsOn) {
+        case (false, _):
+            String(
+                localized: "Flashlight Unavailable",
+                bundle: .toolkitModule,
+                comment: "A label for a button indicating the flashlight is unavailable."
+            )
+        case (_, true):
+            String(
+                localized: "Turn Off Flashlight",
+                bundle: .toolkitModule,
+                comment: "A label for a button that turns off the flashlight."
+            )
+        case (_, false):
+            String(
+                localized: "Turn On Flashlight",
+                bundle: .toolkitModule,
+                comment: "A label for a button that turns on the flashlight."
+            )
+        }
+    }
+    
     var isHiddenIfUnavailable = false
     
     var body: some View {
@@ -58,6 +81,7 @@ struct FlashlightButton: View {
                     .background(.tint)
                     .clipShape(.circle)
             }
+            .accessibilityLabel(flashlightButtonLabel)
             .buttonStyle(.plain)
             .disabled(!hasTorch)
             .onDisappear {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -72,33 +72,24 @@ struct AttachmentImportMenu: View {
     
     @available(visionOS, unavailable)
     private func takePhotoOrVideoButton() -> Button<some View> {
-        Button {
+        Button(cameraButtonLabel, systemImage: "camera") {
             if cameraRequester.authorizationStatus == .authorized {
                 cameraControllerIsPresented = true
             } else {
                 cameraRequester.request()
             }
-        } label: {
-            Text(cameraButtonLabel)
-            Image(systemName: "camera")
         }
     }
     
     private func chooseFromLibraryButton() -> Button<some View> {
-        Button {
+        Button(libraryButtonLabel, systemImage: "photo") {
             photoPickerIsPresented = true
-        } label: {
-            Text(libraryButtonLabel)
-            Image(systemName: "photo")
         }
     }
     
     private func chooseFromFilesButton() -> Button<some View> {
-        Button {
+        Button(filesButtonLabel, systemImage: "folder") {
             fileImporterIsPresented = true
-        } label: {
-            Text(filesButtonLabel)
-            Image(systemName: "folder")
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/FilterView.swift
@@ -411,7 +411,7 @@ private struct FieldView: View {
     
     /// The button that allows a user to switch the numeric value between positive and negative.
     var positiveNegativeButton: some View {
-        Button {
+        Button(positiveNegativeButtonLabel, systemImage: "plus.forwardslash.minus") {
             if let value = Int(fieldFilter.value) {
                 fieldFilter.value = String(value * -1)
             } else if let value = Float(fieldFilter.value) {
@@ -419,9 +419,8 @@ private struct FieldView: View {
             } else if let value = Double(fieldFilter.value) {
                 fieldFilter.value = String(value * -1)
             }
-        } label: {
-            Image(systemName: "plus.forwardslash.minus")
         }
+        .labelStyle(.iconOnly)
         .tint(.blue)
     }
 }
@@ -450,5 +449,15 @@ extension Field {
     /// - Returns: A string representing the display title for the `Field`.
     var title: String {
         alias.isEmpty ? name : alias
+    }
+}
+
+private extension FieldView {
+    var positiveNegativeButtonLabel: String {
+        .init(
+            localized: "Toggle Sign",
+            bundle: .toolkitModule,
+            comment: "A label for a button that toggles a numeric value between negative and positive sign."
+        )
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -169,18 +169,17 @@ private extension TextInput {
             }
 #if !os(visionOS)
             if isBarcodeScanner {
-                Button {
+                Button(scanBarcodeButtonLabel, systemImage: "barcode.viewfinder") {
                     embeddedFeatureFormViewModel.focusedElement = element
                     if cameraRequester.authorizationStatus == .authorized {
                         scannerIsPresented = true
                     } else {
                         cameraRequester.request()
                     }
-                } label: {
-                    Image(systemName: "barcode.viewfinder")
-                        .font(.title2)
-                        .foregroundStyle(Color.accentColor)
                 }
+                .labelStyle(.iconOnly)
+                .font(.title2)
+                .foregroundStyle(Color.accentColor)
                 .disabled(cameraIsDisabled)
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("\(element.label) Scan Button")
@@ -285,5 +284,15 @@ private extension TextInput {
 private extension TextInput {
     private var isBarcodeScanner: Bool {
         element.input is BarcodeScannerFormInput
+    }
+}
+
+private extension TextInput {
+    var scanBarcodeButtonLabel: String {
+        .init(
+            localized: "Scan Barcode",
+            bundle: .toolkitModule,
+            comment: "A label for a button that initiates a barcode scan."
+        )
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -215,7 +215,7 @@ private extension TextInput {
     
     /// The button that allows a user to switch the numeric value between positive and negative.
     var positiveNegativeButton: some View {
-        Button {
+        Button(positiveNegativeButtonLabel, systemImage: "plus.forwardslash.minus") {
             if let value = Int(text) {
                 text = String(value * -1)
             } else if let value = Float(text) {
@@ -223,10 +223,17 @@ private extension TextInput {
             } else if let value = Double(text) {
                 text = String(value * -1)
             }
-        } label: {
-            Image(systemName: "plus.forwardslash.minus")
         }
+        .labelStyle(.iconOnly)
         .inspectorTint(.blue)
+    }
+    
+    var positiveNegativeButtonLabel: String {
+        .init(
+            localized: "Toggle Sign",
+            bundle: .toolkitModule,
+            comment: "A label for a button that toggles a numeric value between negative and positive sign."
+        )
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -293,6 +293,7 @@ private struct LevelSelector: View {
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier("FloorFilter.collapseButton")
+            .accessibilityLabel(collapseButtonLabel)
         }
     }
     
@@ -417,5 +418,21 @@ private extension FloorFilterBody {
             bundle: .toolkitModule,
             comment: "A label for a button that presents a site selector."
         )
+    }
+}
+
+private extension LevelSelector {
+    var collapseButtonLabel: String {
+        isCollapsed
+            ? String(
+                localized: "Expand Level List",
+                bundle: .toolkitModule,
+                comment: "A label for a button that expands the level selector."
+            )
+            : String(
+                localized: "Collapse Level List",
+                bundle: .toolkitModule,
+                comment: "A label for a button that collapses the level selector."
+            )
     }
 }

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -243,6 +243,7 @@ private struct FloorFilterBody: View {
                 .font(.system(size: FloorFilterBody.fontSize))
                 .contentShape(FloorFilterBody.buttonShape)
         }
+        .accessibilityLabel(siteSelectorButtonLabel)
         .accessibilityIdentifier("FloorFilter.siteSelectorButton")
         .buttonStyle(.plain)
         .popover(isPresented: $isSiteSelectorPresented) {
@@ -406,5 +407,15 @@ private struct LevelButton: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("FloorFilter.levelButton.\(level.shortName)")
+    }
+}
+
+private extension FloorFilterBody {
+    var siteSelectorButtonLabel: String {
+        .init(
+            localized: "Select Site",
+            bundle: .toolkitModule,
+            comment: "A label for a button that presents a site selector."
+        )
     }
 }

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
@@ -225,18 +225,25 @@ struct DownloadOfflineMapAreaButton<Model: OfflineMapAreaListItemInfo>: View {
     @ObservedObject var model: Model
     
     var body: some View {
-        Button {
+        Button(downloadButtonLabel, systemImage: "arrow.down.circle") {
             model.startDownload()
-        } label: {
-            Image(systemName: "arrow.down.circle")
-                .imageScale(.large)
         }
+        .labelStyle(.iconOnly)
+        .imageScale(.large)
         // Have to apply a style or it won't be tappable.
         .buttonStyle(.borderless)
         .disabled(!model.allowsDownload)
     }
+    
+    private var downloadButtonLabel: String {
+        .init(
+            localized: "Download Map Area",
+            bundle: .toolkitModule,
+            comment: "A label for a button that downloads a map area."
+        )
+    }
 }
-
+    
 /// A view for displaying the progress of an offline job.
 /// This button is meant to be used in the `OfflineMapAreaListItemView`.
 struct OfflineJobProgressView<Model: OfflineMapAreaListItemInfo>: View {

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreaListItemView.swift
@@ -260,6 +260,16 @@ struct OfflineJobProgressView<Model: OfflineMapAreaListItemInfo>: View {
             }
             // Have to apply a style or it won't be tappable.
             .buttonStyle(.plain)
+            .accessibilityLabel(cancelJobButtonLabel)
         }
     }
+    private var cancelJobButtonLabel: String {
+        String(
+            localized: "Cancel Download",
+            bundle: .toolkitModule,
+            comment: "A label for a button that cancels a map area download."
+        )
+    }
 }
+
+

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandListItemView.swift
@@ -57,12 +57,11 @@ struct OnDemandListItemView: View {
     }
     
     @ViewBuilder private var removeDownloadButton: some View {
-        Button {
+        Button(removeDownloadButtonLabel, systemImage: "xmark.circle") {
             model.removeDownloadedArea()
-        } label: {
-            Image(systemName: "xmark.circle")
-                .imageScale(.large)
         }
+        .labelStyle(.iconOnly)
+        .imageScale(.large)
         // Have to apply a style or it won't be tappable.
         .buttonStyle(.borderless)
     }
@@ -118,6 +117,16 @@ private extension LocalizedStringResource {
             "Cancelled",
             bundle: .toolkit,
             comment: "The status text when a map area download is cancelled."
+        )
+    }
+}
+
+private extension OnDemandListItemView {
+    var removeDownloadButtonLabel: String {
+        .init(
+            localized: "Remove Downloaded Area",
+            bundle: .toolkitModule,
+            comment: "A label for a button that removes a downloaded map area."
         )
     }
 }

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -642,10 +642,8 @@ public struct UtilityNetworkTrace: View {
                 }
             }
             .swipeActions {
-                Button(role: .destructive) {
+                Button(deleteStartingPointLabel, systemImage: "trash", role: .destructive) {
                     viewModel.deleteStartingPoint(startingPoint)
-                } label: {
-                    Image(systemName: "trash")
                 }
             }
         }
@@ -782,7 +780,16 @@ public struct UtilityNetworkTrace: View {
             comment: "A label indicating the index of the trace being viewed out of the total number of traces completed."
         )
     }
-    
+
+    /// A label for the button that deletes a starting point.
+    private var deleteStartingPointLabel: String {
+        String(
+            localized: "Delete Starting Point",
+            bundle: .toolkitModule,
+            comment: "A label for a button that deletes a utility network trace starting point."
+        )
+    }
+
     /// The name of the selected utility element asset group.
     private var selectedAssetGroupName: String? {
         if case let .viewingTraces(activity) = currentActivity,

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -388,26 +388,24 @@ public struct UtilityNetworkTrace: View {
         if viewModel.completedTraces.count > 1 {
             HStack {
                 if viewModel.completedTraces.count > 1 {
-                    Button {
+                    Button(String.previousTraceButtonLabel, systemImage: "chevron.backward") {
                         viewModel.selectPreviousTrace()
                         if let extent = viewModel.selectedTrace?.resultExtent {
                             updateViewpoint(to: extent)
                         }
-                    } label: {
-                        Image(systemName: "chevron.backward")
                     }
+                    .labelStyle(.iconOnly)
                 }
                 Text(currentTraceLabel)
                     .padding(.horizontal)
                 if viewModel.completedTraces.count > 1 {
-                    Button {
+                    Button(String.nextTraceButtonLabel, systemImage: "chevron.forward") {
                         viewModel.selectNextTrace()
                         if let extent = viewModel.selectedTrace?.resultExtent {
                             updateViewpoint(to: extent)
                         }
-                    } label: {
-                        Image(systemName: "chevron.forward")
                     }
+                    .labelStyle(.iconOnly)
                 }
             }
         }
@@ -974,11 +972,27 @@ private extension String {
         )
     }
     
+    static var nextTraceButtonLabel: Self {
+        .init(
+            localized: "Next Trace",
+            bundle: .toolkitModule,
+            comment: "A label for a button to view the next completed trace result."
+        )
+    }
+    
     static var noConfigurationsAvailable: Self {
         .init(
             localized: "No configurations available.",
             bundle: .toolkitModule,
             comment: "A statement that no utility trace configurations are available."
+        )
+    }
+    
+    static var previousTraceButtonLabel: Self {
+        .init(
+            localized: "Previous Trace",
+            bundle: .toolkitModule,
+            comment: "A label for a button to view the previous completed trace result."
         )
     }
     

--- a/Sources/ArcGISToolkit/Utility/SearchField.swift
+++ b/Sources/ArcGISToolkit/Utility/SearchField.swift
@@ -88,23 +88,33 @@ public struct SearchField: View {
             
             // Show Results button
             if !isResultsButtonHidden {
-                Button {
+                Button(
+                    resultsButtonLabel,
+                    systemImage: (isResultListHidden?.wrappedValue ?? false) ? "chevron.down" : "chevron.up"
+                ) {
                     isResultListHidden?.wrappedValue.toggle()
-                } label: {
-                    Image(
-                        systemName: (isResultListHidden?.wrappedValue ?? false) ?
-                        "chevron.down" :
-                            "chevron.up"
-                    )
-#if !os(visionOS)
-                    .foregroundStyle(Color.secondary)
-#endif
                 }
+                .labelStyle(.iconOnly)
 #if !os(visionOS)
+                .foregroundStyle(Color.secondary)
                 .buttonStyle(.plain)
 #endif
             }
         }
         .esriBorder()
+    }
+
+    private var resultsButtonLabel: String {
+        (isResultListHidden?.wrappedValue ?? false)
+        ? String(
+            localized: "Show Results",
+            bundle: .toolkitModule,
+            comment: "A label for a button that shows search results."
+        )
+        : String(
+            localized: "Hide Results",
+            bundle: .toolkitModule,
+            comment: "A label for a button that hides search results."
+        )
     }
 }


### PR DESCRIPTION
Best effort to add missing labels to buttons missing icons.
Rewrote to use the convention example in the issue where possible, simply added accessibility labels when not.

Tests all pass, and verified visually where possible!

Should address issue #942, at least partially!