### PR TITLE
Add a common settings button

### DIFF
--- a/Sources/ArcGISToolkit/Common/CameraRequester.swift
+++ b/Sources/ArcGISToolkit/Common/CameraRequester.swift
@@ -46,9 +46,7 @@ private struct CameraRequesterModifier: ViewModifier {
         content
             .alert(cameraAccessAlertTitle, isPresented: $requester.alertIsPresented) {
 #if !targetEnvironment(macCatalyst)
-                Button(String.settings) {
-                    Task { await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!) }
-                }
+                Button.settings
 #endif
                 Button.cancel {}
             } message: {

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/AttachmentHelpers/AttachmentImportMenu.swift
@@ -402,7 +402,7 @@ struct AttachmentImportMenu: View {
             }
 #endif // !targetEnvironment(macCatalyst) && !targetEnvironment(simulator)
             .alert(microphoneAccessWarningMessage, isPresented: $microphoneAccessAlertIsPresented) {
-                appSettingsButton
+                Button.settings
                 Button(role: .cancel) {} label: {
                     Text(
                         "Record video only",
@@ -422,13 +422,6 @@ struct AttachmentImportMenu: View {
 }
 
 private extension AttachmentImportMenu {
-    /// A button that redirects the user to the application's entry in the iOS system Settings application.
-    var appSettingsButton: some View {
-        Button(String.settings) {
-            Task { await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!) }
-        }
-    }
-    
     /// An error message indicating the selected attachment is an empty file and not supported.
     var emptyFilesNotSupportedAlertMessage: Text {
         .init(

--- a/Sources/ArcGISToolkit/Extensions/Swift/String.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/String.swift
@@ -68,13 +68,4 @@ extension String {
             comment: "A string indicating that no value has been set for a form field."
         )
     }
-    
-    /// A label for a button to take the user to a contextually inferred settings page.
-    static var settings: String {
-        .init(
-            localized: "Settings",
-            bundle: .toolkitModule,
-            comment: "A label for a button to take the user to a contextually inferred settings page."
-        )
-    }
 }

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
@@ -78,7 +78,7 @@ extension Button<Text> {
     }
 }
 
-/// A button that opens that provided URL. The button is disabled when the URL is `nil`.
+/// A button that opens the provided URL. The button is disabled when the URL is `nil`.
 @MainActor
 private struct OpenURLButton<T>: View where T: View {
     @Environment(\.openURL) private var openURL

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/Button.swift
@@ -65,4 +65,35 @@ extension Button<Text> {
             Text(LocalizedStringResource.ok)
         }
     }
+    
+    /// A button that redirects the user to the application's entry in the system settings.
+    @MainActor static var settings: some View {
+        OpenURLButton(url: URL(string: UIApplication.openSettingsURLString)) {
+            Text(
+                "Settings",
+                bundle: .toolkitModule,
+                comment: "A label for a button to take the user to a contextually inferred settings page."
+            )
+        }
+    }
+}
+
+/// A button that opens that provided URL. The button is disabled when the URL is `nil`.
+@MainActor
+private struct OpenURLButton<T>: View where T: View {
+    @Environment(\.openURL) private var openURL
+    
+    let url: URL?
+    let label: () -> T
+    
+    var body: some View {
+        Button {
+            if let url {
+                openURL(url)
+            }
+        } label: {
+            label()
+        }
+        .disabled(url == nil)
+    }
 }


### PR DESCRIPTION
Adds a common settings button and replaces the current unstructured tasks with the openURL environment value.

Test run 4994

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>