### PR TITLE
Remove unused `View.onReceive(_:perform:)`

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/View.swift
@@ -80,32 +80,6 @@ extension View {
         self.tint(tint)
     }
     
-    /// Adds an action to perform when this view detects data emitted by the
-    /// given async sequence. If `action` is `nil`, then the async sequence is not observed.
-    /// The `action` closure is captured the first time the view appears.
-    /// - Parameters:
-    ///   - sequence: The async sequence to observe.
-    ///   - action: The action to perform when a value is emitted by `sequence`.
-    ///   The value emitted by `sequence` is passed as a parameter to `action`.
-    ///   The `action` is called on the `MainActor`.
-    /// - Returns: A view that triggers `action` when `sequence` emits a value.
-    @MainActor @ViewBuilder func onReceive<S>(
-        _ sequence: S,
-        perform action: ((S.Element) -> Void)?
-    ) -> some View where S: AsyncSequence, S.Element: Sendable {
-        if let action {
-            task {
-                do {
-                    for try await element in sequence {
-                        action(element)
-                    }
-                } catch {}
-            }
-        } else {
-            self
-        }
-    }
-    
     /// Modifies this view in a closure. This is useful for using an `if` statement
     /// to determine what modifier, if any, should be applied.
     @ViewBuilder


### PR DESCRIPTION
Removes the unused `View.onReceive(_:perform:)` extension.

Test run 5003, 5016

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>