### PR TITLE
Deprecate `Result.init(awaiting:)` for Xcode 27.0+

### DIFF
--- a/Sources/ArcGISToolkit/Extensions/Swift/Result.swift
+++ b/Sources/ArcGISToolkit/Extensions/Swift/Result.swift
@@ -16,6 +16,10 @@ public extension Result where Failure == Error {
     /// Creates a result based on the outcome of the given task. If the task
     /// succeeds, the result is `success`. If the task fails, the result is
     /// `failure`.
+#if swift(>=6.4)
+    @available(*, deprecated, renamed: "init(catching:)")
+    @_disfavoredOverload
+#endif
     init(awaiting task: @Sendable () async throws -> Success) async {
         do {
             self = .success(try await task())


### PR DESCRIPTION
Closes #732

Xcode 27.0+ (Swift 6.4) includes SE-0530, making our custom implementation no longer necessary. This deprecates the custom implementation starting at Swift 6.4 and marks it disfavored. 

See also: [SE-0530](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0530-async-result-support.md)

Test run # 5030, 5033, 5041

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>