### PR TITLE
Offline: Refactor set download status

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandMapModel.swift
@@ -238,10 +238,14 @@ class OnDemandMapModel: ObservableObject, Identifiable {
         Task { [weak self, job] in
             let result = await job.result
             guard let self else { return }
-            self.updateDownloadStatus(for: result)
-            if let mmpk = try? result.get().mobileMapPackage {
-                await loadAndUpdateMobileMapPackage(mmpk: mmpk)
+            
+            switch result {
+            case .success(let downloadResult):
+                await loadAndUpdateMobileMapPackage(mmpk: downloadResult.mobileMapPackage)
+            case .failure(let error):
+                updateDownloadFailureStatus(for: error)
             }
+            
             self.job = nil
         }
     }
@@ -256,23 +260,17 @@ class OnDemandMapModel: ObservableObject, Identifiable {
         }
     }
     
-    /// Updates the status based on the download result of the mobile map package.
-    private func updateDownloadStatus(for downloadResult: Result<GenerateOfflineMapResult, any Error>) {
-        switch downloadResult {
-        case .success:
-            Logger.offlineManager.info("GenerateOfflineMap job succeeded.")
-            status = .downloaded
-        case .failure(let error):
-            if error is CancellationError {
-                Logger.offlineManager.info("GenerateOfflineMap job cancelled.")
-                status = .downloadCancelled
-            } else {
-                Logger.offlineManager.error("GenerateOfflineMap job failed with error: \(error).")
-                status = .downloadFailure(error)
-            }
-            // Remove contents of mmpk directory when download fails.
-            try? FileManager.default.removeItem(at: mmpkDirectoryURL)
+    /// Updates the status based on a failed download result error.
+    private func updateDownloadFailureStatus(for error: any Error) {
+        if error is CancellationError {
+            Logger.offlineManager.info("GenerateOfflineMap job cancelled.")
+            status = .downloadCancelled
+        } else {
+            Logger.offlineManager.error("GenerateOfflineMap job failed with error: \(error).")
+            status = .downloadFailure(error)
         }
+        // Remove contents of mmpk directory when download fails.
+        try? FileManager.default.removeItem(at: mmpkDirectoryURL)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
@@ -205,31 +205,30 @@ class PreplannedMapModel: ObservableObject, Identifiable {
         Task { [weak self, job] in
             let result = await job.result
             guard let self else { return }
-            self.updateDownloadStatus(for: result)
-            if let mmpk = try? result.get().mobileMapPackage {
-                await loadAndUpdateMobileMapPackage(mmpk: mmpk)
+            
+            switch result {
+            case .success(let downloadResult):
+                await loadAndUpdateMobileMapPackage(mmpk: downloadResult.mobileMapPackage)
+            case .failure(let error):
+                updateDownloadFailureStatus(for: error)
             }
+            
             self.job = nil
         }
     }
     
-    /// Updates the status based on the download result of the mobile map package.
-    private func updateDownloadStatus(for downloadResult: Result<DownloadPreplannedOfflineMapResult, any Error>) {
-        switch downloadResult {
-        case .success:
-            status = .downloaded
-        case .failure(let error):
-            if error is CancellationError {
-                // Reset status to packaged if the job was cancelled.
-                Logger.offlineManager.info("DownloadPreplannedOfflineMapJob job cancelled.")
-                status = .packaged
-            } else {
-                Logger.offlineManager.error("DownloadPreplannedOfflineMapJob job failed with error: \(error).")
-                status = .downloadFailure(error)
-            }
-            // Remove contents of mmpk directory when download fails.
-            try? FileManager.default.removeItem(at: mmpkDirectoryURL)
+    /// Updates the status based on a failed download result error.
+    private func updateDownloadFailureStatus(for error: any Error) {
+        if error is CancellationError {
+            // Reset status to packaged if the job was cancelled.
+            Logger.offlineManager.info("DownloadPreplannedOfflineMapJob job cancelled.")
+            status = .packaged
+        } else {
+            Logger.offlineManager.error("DownloadPreplannedOfflineMapJob job failed with error: \(error).")
+            status = .downloadFailure(error)
         }
+        // Remove contents of mmpk directory when download fails.
+        try? FileManager.default.removeItem(at: mmpkDirectoryURL)
     }
     
     /// Cancels the in-progress job.


### PR DESCRIPTION
Related to `swift/8438`.

Refactors how the `.downloaded` status is set. Previously the status could be set to `.downloaded` in both methods `updateDownloadStatus(for:)` and `loadAndUpdateMobileMapPackage(mmpk:)`, causing a race condition occasionally in the tests that verify the map is not nil once the model status is `.downloaded` since `updateDownloadStatus(for:)` sets the download status and `loadAndUpdateMobileMapPackage(mmpk:)` sets the map value after.

Verified the offline component download status works as expected with this change and the tests pass locally. This PR should be merged after the release to verify this PR fixes the flakey tests.