### PR TITLE
`FloorFilter`: Fix UI bugs

### DIFF
--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -37,7 +37,7 @@ struct SiteAndFacilitySelector: View {
     var body: some View {
         NavigationStack(path: $navigationPath) {
             if readyToPresent {
-                VStack {
+                Group {
                     if model.sites.count > 1 {
                         SiteList(isPresented: $isPresented)
                     } else {
@@ -62,7 +62,7 @@ struct SiteAndFacilitySelector: View {
         .onAppear {
             readyToPresent = true
         }
-        .frame(minWidth: 360, minHeight: 500)
+        .frame(idealWidth: 360, idealHeight: 500)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -85,7 +85,7 @@ private struct SiteList: View {
     }
     
     var body: some View {
-        VStack {
+        Group {
             if sites.isEmpty {
                 ContentUnavailableView(String.noMatchesFound, systemImage: "building.2")
             } else {
@@ -100,16 +100,16 @@ private struct SiteList: View {
                             .lineLimit(1)
                     }
                 }
-                .searchable(
-                    text: $searchText,
-                    placement: .navigationBarDrawer(displayMode: .always),
-                    prompt: String.filterSites
-                )
 #if !os(visionOS)
                 .listStyle(.plain)
 #endif
             }
         }
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: String.filterSites
+        )
         .navigationTitle(String.sites)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -166,7 +166,7 @@ private struct FacilityList: View {
     }
     
     var body: some View {
-        VStack {
+        Group {
             if facilities.isEmpty {
                 ContentUnavailableView(String.noMatchesFound, systemImage: "building.2")
             } else {
@@ -198,11 +198,6 @@ private struct FacilityList: View {
                         .buttonStyle(.plain)
 #endif
                     }
-                    .searchable(
-                        text: $searchText,
-                        placement: .navigationBarDrawer(displayMode: .always),
-                        prompt: String.filterFacilities
-                    )
 #if !os(visionOS)
                     .listStyle(.plain)
 #endif
@@ -215,6 +210,11 @@ private struct FacilityList: View {
                 }
             }
         }
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: String.filterFacilities
+        )
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 DismissButton(kind: .cancel) {

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -52,7 +52,9 @@ struct SiteAndFacilitySelector: View {
                 }
                 .onAppear {
                     // If there not multiple sites, then we go straight to the facilities list.
-                    guard model.sites.count > 1, let facility = model.selection?.facility else {
+                    guard navigationPath.isEmpty,
+                          model.sites.count > 1,
+                          let facility = model.selection?.facility else {
                         return
                     }
                     navigationPath.append(facility)

--- a/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/SiteAndFacilitySelector.swift
@@ -90,6 +90,7 @@ private struct SiteList: View {
         Group {
             if sites.isEmpty {
                 ContentUnavailableView(String.noMatchesFound, systemImage: "building.2")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(sites) { site in
                     NavigationLink {
@@ -107,6 +108,8 @@ private struct SiteList: View {
 #endif
             }
         }
+        // Prevents background flicker when navigating back from FacilityList.
+        .background(Color(.systemBackground))
         .searchable(
             text: $searchText,
             placement: .navigationBarDrawer(displayMode: .always),


### PR DESCRIPTION
## Description

This PR fixes some issues with the `FloorFilter` UI:
- 6bd5dd5: A bug where entering an invalid search would hide the search bar.
- 290c300: A bug where the search bar would be cut off when focused on iPhone in landscape mode.
- f81758a: A bug where navigating back from `FacilityList` with a selected site would sometimes result in another `FacilityList` instead of `SiteList`. 
- 0f4cd53: A bug where navigating back from `FacilityList` would cause the `SiteList` background color to jump when the navigation animation completed.

Closes https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/1443.


## How To Test

Open the "Floor Filter" example and ensure the `FloorFilter` still works as expected.


## Screenshots

|Before|After|
|:-:|:-:|
| <img height="596" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-30 at 16 44 16" src="https://github.com/user-attachments/assets/b6f7cc27-3a27-42e3-96fe-c76861fa2ea8" /> | <img height="596" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-31 at 14 00 39" src="https://github.com/user-attachments/assets/6ae4efed-644e-4e60-98a3-721cde1330d0" /> |
| <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-31 at 13 20 36" src="https://github.com/user-attachments/assets/c0165171-255d-498f-bcb6-891c72036a7d" /> | <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-31 at 14 00 48" src="https://github.com/user-attachments/assets/048bc05d-b952-4ac8-8c87-589231bcee1f" /> |
