### PR TITLE
`FeatureFormView`: Fix text input focus

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/TextInput.swift
@@ -126,12 +126,19 @@ private extension TextInput {
                     .focused($isFocused)
                     .keyboardType(keyboardType)
                     .onChange(of: isFocused) {
-                        embeddedFeatureFormViewModel.focusedElement = isFocused ? element : nil
+                        if isFocused {
+                            embeddedFeatureFormViewModel.focusedElement = element
+                        } else if embeddedFeatureFormViewModel.focusedElement == element {
+                            // Only clears focusedElement if it matches the input's
+                            // element to prevent unfocusing another text input
+                            // that received focus while this one was still focused.
+                            embeddedFeatureFormViewModel.focusedElement = nil
+                        }
                     }
                     .onChange(of: embeddedFeatureFormViewModel.focusedElement) {
                         // Another form input took focus.
                         if embeddedFeatureFormViewModel.focusedElement != element {
-                            isFocused  = false
+                            isFocused = false
                         }
                     }
                 }


### PR DESCRIPTION
## Description

This PR fixes a `FeatureFormView` bug where if a text input (1) is focused and another text input (2) is tapped on, text input 1 would simply unfocus, instead of immediately focusing text input 2. `FeatureFormViewTests` remain passing.
Closes https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/issues/1328.

## How To Test

- Open the "Feature Form" example and tap on a feature to edit.
- Tap on a text input, such as "Enter a name for this place".
- Tap on another text input, such as "Website Address",  and ensure it is focused without having to tap again.

## Screenshots

|Before|After|
|:-:|:-:|
| <img width="230" height="500" alt="Before" src="https://github.com/user-attachments/assets/f3ad2871-a2db-4618-b77d-0ab6a2377e35" /> | <img width="230" height="500" alt="After" src="https://github.com/user-attachments/assets/7cd4aaeb-8b9c-4dda-9479-06b216624bbc" /> |
