### PR TITLE
Offline: Update UI for failed load status

### DIFF
--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -46,8 +46,10 @@ struct PreplannedListItemView: View {
     
     @ViewBuilder private var trailingButton: some View {
         switch model.status {
-        case .notLoaded, .loadFailure, .packaging, .packageFailure, .mmpkLoadFailure:
+        case .notLoaded, .loadFailure, .packaging, .packageFailure:
             EmptyView()
+        case .mmpkLoadFailure:
+            removeDownloadButton
         case .loading:
             ProgressView()
         case .packaged, .downloadFailure:
@@ -62,6 +64,17 @@ struct PreplannedListItemView: View {
                 dismiss: shouldDismiss ? dismiss : nil
             )
         }
+    }
+    
+    @ViewBuilder private var removeDownloadButton: some View {
+        Button {
+            model.removeDownloadedArea()
+        } label: {
+            Image(systemName: "xmark.circle")
+                .imageScale(.large)
+        }
+        // Have to apply a style or it won't be tappable.
+        .buttonStyle(.borderless)
     }
 }
 

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -67,9 +67,7 @@ struct PreplannedListItemView: View {
     }
     
     @ViewBuilder private var removeDownloadButton: some View {
-        Button {
-            model.removeDownloadedArea()
-        } label: {
+        Button(action: model.removeDownloadedArea) {
             Image(systemName: "xmark.circle")
                 .imageScale(.large)
         }

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedListItemView.swift
@@ -73,7 +73,7 @@ struct PreplannedListItemView: View {
             Image(systemName: "xmark.circle")
                 .imageScale(.large)
         }
-        // Have to apply a style or it won't be tappable.
+        // Apply a style to make it tappable.
         .buttonStyle(.borderless)
     }
 }

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
@@ -288,7 +288,12 @@ extension PreplannedMapModel {
         
         /// A Boolean value indicating whether the preplanned map area is downloaded.
         var isDownloaded: Bool {
-            if case .downloaded = self { true } else { false }
+            switch self {
+            case .downloaded, .mmpkLoadFailure:
+                true
+            default:
+                false
+            }
         }
     }
 }

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelStatusTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelStatusTests.swift
@@ -55,6 +55,6 @@ class PreplannedMapModelStatusTests: XCTestCase {
         XCTAssertFalse(Status.downloading.isDownloaded)
         XCTAssertTrue(Status.downloaded.isDownloaded)
         XCTAssertFalse(Status.downloadFailure(CancellationError()).isDownloaded)
-        XCTAssertFalse(Status.mmpkLoadFailure(CancellationError()).isDownloaded)
+        XCTAssertTrue(Status.mmpkLoadFailure(CancellationError()).isDownloaded)
     }
 }


### PR DESCRIPTION
Related to `swift/8428`

Updates the UI for the preplanned workflow in the `OfflineMapAreasView` component to allow removing a downloaded mmpk that fails to load. The on-demand workflow UI already supports this use-case.

Implements the following UI changes:

- Displays an "xmark.circle" button in the preplanned list item view to remove the download when it fails to load.

Before | After
<img width="300" alt="c811bbdf-1746-4658-8367-b7635e3d403e" src="https://github.com/user-attachments/assets/09b370fb-eb48-4791-8094-c54e7ada7432" /> <img width="300" alt="IMG_0402" src="https://github.com/user-attachments/assets/e3a8477a-49ce-47c2-9b7b-693f7b3bf4d4" />


- Displays the "Remove download" button when the model status is `.mmpkLoadFailure`.

Before | After
<img width="300" alt="3c9c81cc-ad59-4ea1-bc1d-44e72a31598b" src="https://github.com/user-attachments/assets/51e9e862-19d6-4d40-8c36-1ebd82504fc3" /> <img width="300" alt="IMG_0403" src="https://github.com/user-attachments/assets/0a147a69-442f-431b-b12b-c7dd2e024126" />



Test using the `OfflineMapAreasExample` project. To repro the `.mmpkLoadFailure` status, start a download and then close the app in the app switcher before the download succeeds. Verify that the download can be removed and downloaded successfully.

