### PR TITLE
Revert "Enable `InternalImportsByDefault`" in the toolkit package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,7 +59,6 @@ let package = Package(
 
 for target in package.targets where target.type != .plugin {
     target.swiftSettings = (target.swiftSettings ?? []) + [
-        .enableUpcomingFeature("InternalImportsByDefault"),
         .enableUpcomingFeature("MemberImportVisibility")
     ]
 }

--- a/Sources/ArcGISToolkit/Common/AttachmentModel.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentModel.swift
@@ -14,9 +14,10 @@
 
 import ArcGIS
 import Combine
-import os
 @preconcurrency import QuickLook
 import SwiftUI
+
+internal import os
 
 /// A view model representing the combination of a `FeatureAttachment` and
 /// an associated `UIImage` used as a thumbnail.

--- a/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
+++ b/Sources/ArcGISToolkit/Common/AttachmentsFeatureElementView.swift
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 import ArcGIS
-import os
 import QuickLook
 import SwiftUI
+
+internal import os
 
 /// A view displaying an `AttachmentsFeatureElement`.
 struct AttachmentsFeatureElementView: View {

--- a/Sources/ArcGISToolkit/Common/FilterView/FilterView.swift
+++ b/Sources/ArcGISToolkit/Common/FilterView/FilterView.swift
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
-
 import ArcGIS
+import SwiftUI
 
 /// A view allowing the user to assemble a list of `FieldFilter` objects used to filter a list of features.
 @_spi(Experimental)

--- a/Sources/ArcGISToolkit/Common/FilterView/FilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Common/FilterView/FilterViewModel.swift
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Observation
-
+import ArcGIS
 import Foundation
 import SwiftUI
 

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Apple World Tracking/AppleWorldTracking.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Apple World Tracking/AppleWorldTracking.swift
@@ -14,9 +14,10 @@
 
 #if os(iOS)
 public import ArcGIS
-public import ARKit
 public import Observation
 public import RealityKit
+
+import ARKit
 
 /// A world-tracking provider that supports system-provided geo tracking and
 /// world tracking.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Apple World Tracking/AppleWorldTrackingCameraFeedView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Apple World Tracking/AppleWorldTrackingCameraFeedView.swift
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 #if os(iOS)
-public import ARKit
-public import SwiftUI
-
 import ArcGIS
+import ARKit
 import CoreLocation
+import SwiftUI
 
 /// The camera scene view corresponding to `AppleWorldTracking`.
 @available(macCatalyst, unavailable)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/FlyoverSceneView.swift
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
-
+import ArcGIS
 import ARKit
 import Combine
+import SwiftUI
 
 /// A scene view that provides an augmented reality fly over experience.
 @available(macCatalyst, unavailable)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/TableTopSceneView.swift
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
-
 import ARKit
+import SwiftUI
+import ArcGIS
 import RealityKit
 
 /// A scene view that provides an augmented reality table top experience.

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/SwiftUIARView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/Utilities/SwiftUIARView.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #if os(iOS)
-public import ArcGIS
-public import ARKit
-public import RealityKit
-public import SwiftUI
+import ArcGIS
+import ARKit
+import RealityKit
+import SwiftUI
 
 /// A SwiftUI version of an AR view.
 public struct SwiftUIARView {

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldScaleSceneView.swift
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 #if os(iOS)
-public import ArcGIS
-public import ARKit
-public import SwiftUI
-
+import ArcGIS
+import ARKit
 import Combine
+import SwiftUI
 
 /// A scene view that provides an augmented reality world scale experience.
 @available(macCatalyst, unavailable)

--- a/Sources/ArcGISToolkit/Components/Augmented Reality/WorldTrackingProvider.swift
+++ b/Sources/ArcGISToolkit/Components/Augmented Reality/WorldTrackingProvider.swift
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #if os(iOS)
-public import ARKit
-public import RealityKit
-public import SwiftUI
+import ArcGIS
+import ARKit
+import RealityKit
+import SwiftUI
 
 /// A type that provides AR world-tracking behavior.
 @available(macCatalyst, unavailable)

--- a/Sources/ArcGISToolkit/Components/Authentication/AuthenticationManager.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/AuthenticationManager.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
+import ArcGIS
 
 public extension AuthenticationManager {
     /// Sets up authenticator as ArcGIS and Network challenge handlers to handle authentication

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -22,7 +22,7 @@ import CryptoTokenKit
 /// ![image](https://user-images.githubusercontent.com/3998072/203615041-c887d5e3-bb64-469a-a76b-126059329e92.png)
 ///
 /// **Features**
-/// 
+///
 /// The `Authenticator` has a view modifier that will display a prompt when the `Authenticator` is
 /// asked to handle an authentication challenge. This will handle many different types of
 /// authentication, for example:

--- a/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/Authenticator.swift
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Combine
-
+import ArcGIS
+import Combine
 import CryptoTokenKit
 
 /// The `Authenticator` is a configurable object that handles authentication challenges. It will
@@ -23,7 +22,7 @@ import CryptoTokenKit
 /// ![image](https://user-images.githubusercontent.com/3998072/203615041-c887d5e3-bb64-469a-a76b-126059329e92.png)
 ///
 /// **Features**
-///
+/// 
 /// The `Authenticator` has a view modifier that will display a prompt when the `Authenticator` is
 /// asked to handle an authentication challenge. This will handle many different types of
 /// authentication, for example:

--- a/Sources/ArcGISToolkit/Components/Authentication/AuthenticatorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/AuthenticatorModifier.swift
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
-
+import SwiftUI
 import ArcGIS
 
 public extension View {

--- a/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
+++ b/Sources/ArcGISToolkit/Components/Authentication/CertificatePickerViewModifier.swift
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Foundation
-
+import ArcGIS
 import Combine
-import os
 import SwiftUI
 import UniformTypeIdentifiers
+
+internal import os
 
 /// An object that provides the business logic for the workflow of prompting the user for a
 /// certificate and a password.

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGallery.swift
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
-
+import ArcGIS
 import Combine
+import SwiftUI
 
 /// The `BasemapGallery` displays a collection of basemaps from ArcGIS Online, a user-defined
 /// portal, or an array of ``BasemapGalleryItem`` objects. When a new basemap is selected from the

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
@@ -77,10 +77,10 @@ public final class BasemapGalleryItem: ObservableObject, Sendable {
     
     /// A Boolean value indicating whether the `basemap` or it's base layers are being loaded.
     @Published private(set) var isBasemapLoading = true
-
+    
     /// The error generated loading the basemap, if any.
     @Published private(set) var loadBasemapError: Error? = nil
-
+    
     /// The spatial reference of ``basemap``. This will be `nil` until the
     /// basemap's base layers have been loaded by
     /// ``updateSpatialReferenceStatus(_:)``.

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
@@ -70,7 +70,7 @@ public final class BasemapGalleryItem: ObservableObject, Sendable {
     
     /// The thumbnail used to represent the `basemap`.
     @Published public private(set) var thumbnail: UIImage?
-
+    
     /// The spatial reference status of the item. This is set via a call to
     /// ``updateSpatialReferenceStatus(_:)``.
     @Published public private(set) var spatialReferenceStatus: SpatialReferenceStatus = .unknown

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryItem.swift
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Combine
-public import UIKit
+import ArcGIS
+import Combine
+import UIKit
 
 ///  The `BasemapGalleryItem` encompasses an element in a `BasemapGallery`.
 @MainActor
@@ -70,17 +70,17 @@ public final class BasemapGalleryItem: ObservableObject, Sendable {
     
     /// The thumbnail used to represent the `basemap`.
     @Published public private(set) var thumbnail: UIImage?
-    
+
     /// The spatial reference status of the item. This is set via a call to
     /// ``updateSpatialReferenceStatus(_:)``.
     @Published public private(set) var spatialReferenceStatus: SpatialReferenceStatus = .unknown
     
     /// A Boolean value indicating whether the `basemap` or it's base layers are being loaded.
     @Published private(set) var isBasemapLoading = true
-    
+
     /// The error generated loading the basemap, if any.
     @Published private(set) var loadBasemapError: Error? = nil
-    
+
     /// The spatial reference of ``basemap``. This will be `nil` until the
     /// basemap's base layers have been loaded by
     /// ``updateSpatialReferenceStatus(_:)``.

--- a/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/BasemapGallery/BasemapGalleryViewModel.swift
@@ -15,7 +15,8 @@
 import ArcGIS
 import Combine
 import Foundation
-import os
+
+internal import os
 
 /// Manages the state for a `BasemapGallery`.
 @MainActor class BasemapGalleryViewModel: ObservableObject {

--- a/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
+++ b/Sources/ArcGISToolkit/Components/Bookmarks/Bookmarks.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import ArcGIS
+import SwiftUI
 
 /// The `Bookmarks` component displays a list of bookmarks and allows the user to make a selection.
 /// You can initialize the component with an array of bookmarks or with a `GeoModel`

--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorer.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorer.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import ArcGIS
+import SwiftUI
 
 /// The building explorer component enables a user to explore a building model
 /// in a `BuildingSceneLayer`.

--- a/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerItem.swift
+++ b/Sources/ArcGISToolkit/Components/BuildingExplorer/BuildingExplorerItem.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Observation
+import ArcGIS
+import Observation
 
 /// An item that can be shown in the ``BuildingExplorer``.
 ///- Since: 300.0

--- a/Sources/ArcGISToolkit/Components/Compass/Compass.swift
+++ b/Sources/ArcGISToolkit/Components/Compass/Compass.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import ArcGIS
+import SwiftUI
 
 /// A `Compass` (alias North arrow) shows where north is in a `MapView` or `SceneView`.
 ///

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/FeatureFormView.swift
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import ArcGIS
+import SwiftUI
 
-import os
+internal import os
 
 /// The `FeatureFormView` component enables users to edit field values of a feature using
 /// pre-configured forms, either from the Web Map Viewer or the Fields Maps Designer.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/NavigationPathItem.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/NavigationPathItem.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
+import ArcGIS
 
 extension FeatureFormView {
     /// Describes the items in feature form view's navigation stack.

--- a/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureFormView/Subviews/Inputs/ComboBoxInput.swift
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-
+import ArcGIS
 import SwiftUI
 
 /// A view for numerical value input.

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelDetent.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelDetent.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import Foundation
+import Foundation
 
 /// A value that represents a height where a sheet naturally rests.
 public enum FloatingPanelDetent: Equatable, Sendable {

--- a/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FloatingPanel/FloatingPanelModifier.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
+import SwiftUI
 
 public extension View {
     /// A floating panel is a view that overlays a view and supplies view-related

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilter.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import ArcGIS
+import SwiftUI
 
 /// The `FloorFilter` component simplifies visualization of GIS data for a specific floor of a
 /// building in your application. It allows you to filter the floor plan data displayed in your map

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterSelection.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterSelection.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
+import ArcGIS
 
 ///  A selected site, facility, or level.
 public enum FloorFilterSelection: Hashable, Sendable {

--- a/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/FloorFilter/FloorFilterViewModel.swift
@@ -14,8 +14,9 @@
 
 import ArcGIS
 import Combine
-import os
 import SwiftUI
+
+internal import os
 
 /// Manages the state for a `FloorFilter`.
 @MainActor

--- a/Sources/ArcGISToolkit/Components/JobManager/JobManager.swift
+++ b/Sources/ArcGISToolkit/Components/JobManager/JobManager.swift
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Combine
-public import Foundation
-
+import ArcGIS
 import BackgroundTasks
-import os
+import Combine
+import Foundation
 import UIKit
+
+internal import os
 
 /// An object that manages saving and loading jobs so that they can continue to run if the
 /// app is backgrounded or even terminated.

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -47,7 +47,7 @@ public struct LocationButton: View {
     var buttonIsDisabled: Bool {
         status == .starting || status == .stopping || isPerformingButtonAction
     }
-
+    
 #if os(visionOS)
     /// The auto-pan modes that are selectable by the user.
     private(set) var autoPanModes: [LocationDisplay.AutoPanMode] = [

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
-
+import ArcGIS
 import CoreLocation
-import os
+import SwiftUI
+
+internal import os
 
 /// A button that allows a user to control their location display on a map view.
 /// Gives the user a variety of options to set the auto-pan mode or stop the
@@ -47,7 +47,7 @@ public struct LocationButton: View {
     var buttonIsDisabled: Bool {
         status == .starting || status == .stopping || isPerformingButtonAction
     }
-    
+
 #if os(visionOS)
     /// The auto-pan modes that are selectable by the user.
     private(set) var autoPanModes: [LocationDisplay.AutoPanMode] = [

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineManager.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineManager.swift
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Combine
-public import SwiftUI
-
+import ArcGIS
 import BackgroundTasks
-import os
+import Combine
+import SwiftUI
+
+internal import os
 
 /// A utility object that maintains the state of offline map areas and their
 /// storage on the device.

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapAreasView.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import SwiftUI
+import ArcGIS
 
 /// The `OfflineMapAreasView` allows users to take a web map offline by
 /// downloading map areas.

--- a/Sources/ArcGISToolkit/Components/Offline/OfflineMapInfo.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OfflineMapInfo.swift
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import UIKit.UIImage
-
+import ArcGIS
 import Foundation
-import os
+import UIKit.UIImage
+
+internal import os
 
 /// Information for an online map that has been taken offline.
 ///

--- a/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/OnDemand/OnDemandMapModel.swift
@@ -15,8 +15,8 @@
 import ArcGIS
 import Combine
 import Foundation
-import os
 import UIKit
+internal import os
 
 @MainActor
 class OnDemandMapModel: ObservableObject, Identifiable {

--- a/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
+++ b/Sources/ArcGISToolkit/Components/Offline/Preplanned/PreplannedMapModel.swift
@@ -15,7 +15,8 @@
 import ArcGIS
 import Combine
 import Foundation
-import os
+
+internal import os
 
 /// An object that encapsulates state about a preplanned map.
 @MainActor

--- a/Sources/ArcGISToolkit/Components/OverviewMap.swift
+++ b/Sources/ArcGISToolkit/Components/OverviewMap.swift
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
-
+import ArcGIS
 import Combine
+import SwiftUI
 
 /// `OverviewMap` is a small, secondary `MapView` (sometimes called an "inset map"), superimposed
 /// on an existing `GeoView`, which shows a representation of the current `visibleArea` (for a `MapView`) or `viewpoint` (for a `SceneView`).

--- a/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/EmbeddedPopupView.swift
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import ArcGIS
-import os
 import SwiftUI
+
+internal import os
 
 /// A view that display a `Popup` and its evaluated elements.
 ///

--- a/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
+++ b/Sources/ArcGISToolkit/Components/Popups/PopupView.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import SwiftUI
+import ArcGIS
 
 /// The `PopupView` component will display a popup for an individual feature. This includes showing
 /// the feature's title, attributes, custom description, media, and attachments. The new online Map

--- a/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/Scalebar.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import ArcGIS
+import SwiftUI
 
 /// A scalebar displays the representation of an accurate linear measurement on the map. It provides
 /// a visual indication through which users can determine the size of features or the distance

--- a/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
+++ b/Sources/ArcGISToolkit/Components/Scalebar/ScalebarSettings.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
+import SwiftUI
 
 extension Scalebar {
     /// Customizes scalebar appearance and behavior.

--- a/Sources/ArcGISToolkit/Components/Search/LocatorSearchSource.swift
+++ b/Sources/ArcGISToolkit/Components/Search/LocatorSearchSource.swift
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Combine
-public import Foundation
+import ArcGIS
+import Combine
+import Foundation
 
 /// Uses a Locator to provide search and suggest results. Most configuration should be done on the
 /// `GeocodeParameters` directly.

--- a/Sources/ArcGISToolkit/Components/Search/SearchResult.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchResult.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import UIKit.UIImage
+import UIKit.UIImage
+import ArcGIS
 
 /// Wraps a search result for display.
 public struct SearchResult: @unchecked Sendable {

--- a/Sources/ArcGISToolkit/Components/Search/SearchSource.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchSource.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
+import ArcGIS
 
 /// Defines the contract for a search result provider.
 @MainActor

--- a/Sources/ArcGISToolkit/Components/Search/SearchSuggestion.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchSuggestion.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import Foundation
+import Foundation
+import ArcGIS
 
 /// Wraps a suggestion for display.
 public struct SearchSuggestion: @unchecked Sendable {

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -88,7 +88,7 @@ public struct SearchView: View {
     /// activity of searching. The view observes `SearchViewModel` for changes in state. The view
     /// calls methods on `SearchViewModel` in response to user action.
     @StateObject private var viewModel: SearchViewModel
-
+    
     /// Tracks the current user-entered query. This property drives both suggestions and searches.
     var currentQuery = ""
 

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -91,14 +91,14 @@ public struct SearchView: View {
     
     /// Tracks the current user-entered query. This property drives both suggestions and searches.
     var currentQuery = ""
-
+    
     /// Tracks the current user-entered query. This property drives both suggestions and searches.
     var resultMode: SearchResultMode = .automatic
-
+    
     /// The search area to be used for the current query. If `nil`, then there is no limiting of the
     /// search results to a given area.
     @Binding var queryArea: Geometry?
-
+    
     /// Defines the center for the search. Defaults to `nil`.
     ///
     /// If `nil`, does not prioritize the search results around any point.
@@ -115,7 +115,7 @@ public struct SearchView: View {
     
     /// Determines whether the `geoView` is navigating in response to user interaction.
     @Binding private var isGeoViewNavigating: Bool
-
+    
     /// The `GraphicsOverlay` used to display results. If `nil`, no results will be displayed.
     var resultsOverlay: GraphicsOverlay? = nil
     
@@ -477,7 +477,7 @@ extension ResultRow {
                  Image(systemName: "magnifyingglass") :
                     Image("pin", bundle: .toolkitModule)
                 )
-                    .foregroundStyle(.secondary)
+                 .foregroundStyle(.secondary)
             )
         )
     }

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -477,7 +477,7 @@ extension ResultRow {
                  Image(systemName: "magnifyingglass") :
                     Image("pin", bundle: .toolkitModule)
                 )
-                 .foregroundStyle(.secondary)
+                .foregroundStyle(.secondary)
             )
         )
     }

--- a/Sources/ArcGISToolkit/Components/Search/SearchView.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SearchView.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import SwiftUI
+import ArcGIS
 
 /// `SearchView` enables searching using one or more locators, with support for suggestions,
 /// automatic zooming, and custom search sources.
@@ -88,17 +88,17 @@ public struct SearchView: View {
     /// activity of searching. The view observes `SearchViewModel` for changes in state. The view
     /// calls methods on `SearchViewModel` in response to user action.
     @StateObject private var viewModel: SearchViewModel
-    
+
     /// Tracks the current user-entered query. This property drives both suggestions and searches.
     var currentQuery = ""
-    
+
     /// Tracks the current user-entered query. This property drives both suggestions and searches.
     var resultMode: SearchResultMode = .automatic
-    
+
     /// The search area to be used for the current query. If `nil`, then there is no limiting of the
     /// search results to a given area.
     @Binding var queryArea: Geometry?
-    
+
     /// Defines the center for the search. Defaults to `nil`.
     ///
     /// If `nil`, does not prioritize the search results around any point.
@@ -115,7 +115,7 @@ public struct SearchView: View {
     
     /// Determines whether the `geoView` is navigating in response to user interaction.
     @Binding private var isGeoViewNavigating: Bool
-    
+
     /// The `GraphicsOverlay` used to display results. If `nil`, no results will be displayed.
     var resultsOverlay: GraphicsOverlay? = nil
     
@@ -477,7 +477,7 @@ extension ResultRow {
                  Image(systemName: "magnifyingglass") :
                     Image("pin", bundle: .toolkitModule)
                 )
-                .foregroundStyle(.secondary)
+                    .foregroundStyle(.secondary)
             )
         )
     }

--- a/Sources/ArcGISToolkit/Components/Search/SmartLocatorSearchSource.swift
+++ b/Sources/ArcGISToolkit/Components/Search/SmartLocatorSearchSource.swift
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-
 import SwiftUI
+import ArcGIS
 
 /// Extends `LocatorSearchSource` with intelligent search behaviors; adds support for features like
 /// type-specific placemarks, repeated search, and more on the world geocode service.

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTrace.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import ArcGIS
+import SwiftUI
 
 /// `UtilityNetworkTrace` runs traces on a webmap published with a utility network and trace configurations.
 ///

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceStartingPoint.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceStartingPoint.swift
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-
+import ArcGIS
 import UIKit
 
 /// A starting point of a utility network trace.

--- a/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
+++ b/Sources/ArcGISToolkit/Components/UtilityNetworkTrace/UtilityNetworkTraceViewModel.swift
@@ -15,8 +15,9 @@
 import ArcGIS
 import Combine
 import Foundation
-import os
 import SwiftUI
+
+internal import os
 
 @MainActor final class UtilityNetworkTraceViewModel: ObservableObject {
     // MARK: Published Properties

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/FloorFacility.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/FloorFacility.swift
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-
 import SwiftUI
+import ArcGIS
 
 extension FloorFacility {
     /// - Returns: The default level for the facility, which is the level with vertical order 0.

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/FloorLevel.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/FloorLevel.swift
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-
+import ArcGIS
 import SwiftUI
 
 extension ArcGIS.FloorLevel: Swift.Equatable {

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/FloorSite.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/FloorSite.swift
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-
+import ArcGIS
 import SwiftUI
 
 extension ArcGIS.FloorSite: Swift.Equatable {

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/FormElement.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/FormElement.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
+import ArcGIS
 
 extension FormElement {
     /// The id of the element.

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if os(iOS)
-public import ArcGIS
-public import ARKit
-public import SwiftUI
-
+import ArcGIS
+import ARKit
 import Foundation
+import SwiftUI
 
+#if os(iOS)
 public extension SceneViewProxy {
     /// Updates the scene view's camera for a given augmented reality camera.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/SceneViewProxy.swift
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if os(iOS)
 import ArcGIS
 import ARKit
 import Foundation
 import SwiftUI
 
-#if os(iOS)
 public extension SceneViewProxy {
     /// Updates the scene view's camera for a given augmented reality camera.
     /// - Parameters:

--- a/Sources/ArcGISToolkit/Extensions/ArcGIS/Viewpoint.swift
+++ b/Sources/ArcGISToolkit/Extensions/ArcGIS/Viewpoint.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
+import ArcGIS
 
 public extension Viewpoint {
     /// Creates a new viewpoint with the same target geometry and scale but with a new rotation.

--- a/Sources/ArcGISToolkit/Extensions/OS/Logger.swift
+++ b/Sources/ArcGISToolkit/Extensions/OS/Logger.swift
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import os
 import Foundation
+
+internal import os
 
 extension Logger {
     /// A logger for the common `AttachmentsFeatureElementView` view.

--- a/Sources/ArcGISToolkit/Extensions/SwiftUI/EdgeInsets.swift
+++ b/Sources/ArcGISToolkit/Extensions/SwiftUI/EdgeInsets.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
+import SwiftUI
 
 public extension EdgeInsets {
     /// A reusable set of edge insets for use across toolkit components.

--- a/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
+++ b/Sources/ArcGISToolkit/Utility/AsyncImageView.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import ArcGIS
-public import SwiftUI
+import SwiftUI
+import ArcGIS
 
 /// A view displaying an async image, with error display and progress view.
 public struct AsyncImageView: View {

--- a/Sources/ArcGISToolkit/Utility/EsriBorderViewModifier.swift
+++ b/Sources/ArcGISToolkit/Utility/EsriBorderViewModifier.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
+import SwiftUI
 
 /// A modifier which displays a 2 point width border and a shadow around a view.
 struct EsriBorderViewModifier: ViewModifier {

--- a/Sources/ArcGISToolkit/Utility/InterfaceOrientationObserverView.swift
+++ b/Sources/ArcGISToolkit/Utility/InterfaceOrientationObserverView.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
+import SwiftUI
 
 public extension View {
     /// Observes interface orientation changes for a given view.

--- a/Sources/ArcGISToolkit/Utility/MarkdownView.swift
+++ b/Sources/ArcGISToolkit/Utility/MarkdownView.swift
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Markdown
 import SwiftUI
+
+internal import Markdown
 
 /// Rendered Markdown text content.
 ///

--- a/Sources/ArcGISToolkit/Utility/SearchField.swift
+++ b/Sources/ArcGISToolkit/Utility/SearchField.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public import SwiftUI
+import SwiftUI
 
 /// A custom view implementing a SearchField. It contains a search button, text field, delete text button,
 /// and a button to allow users to hide/show the search results list.

--- a/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
@@ -309,7 +309,7 @@ class OnDemandMapModelTests: XCTestCase {
 }
 
 extension OnDemandMapModel.Status: Equatable {
-    public static func == (lhs: OnDemandMapModel.Status, rhs: OnDemandMapModel.Status) -> Bool {
+    static func == (lhs: OnDemandMapModel.Status, rhs: OnDemandMapModel.Status) -> Bool {
         return switch (lhs, rhs) {
         case (.initialized, .initialized),
             (.downloading, .downloading),

--- a/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
@@ -309,7 +309,7 @@ class OnDemandMapModelTests: XCTestCase {
 }
 
 extension OnDemandMapModel.Status: Equatable {
-    static func == (lhs: OnDemandMapModel.Status, rhs: OnDemandMapModel.Status) -> Bool {
+    public static func == (lhs: OnDemandMapModel.Status, rhs: OnDemandMapModel.Status) -> Bool {
         return switch (lhs, rhs) {
         case (.initialized, .initialized),
             (.downloading, .downloading),

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -414,7 +414,7 @@ class PreplannedMapModelTests: XCTestCase {
         let areas = try await task.preplannedMapAreas
         let area = try XCTUnwrap(areas.first { $0.title == "Country Commons Area" })
         let areaID = try XCTUnwrap(area.portalItem.id)
-        
+
         let model = PreplannedMapModel(
             offlineMapTask: task,
             mapArea: area,
@@ -432,7 +432,7 @@ class PreplannedMapModelTests: XCTestCase {
 }
 
 extension PreplannedMapModel.Status: Equatable {
-    static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
+    public static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
         return switch (lhs, rhs) {
         case (.notLoaded, .notLoaded),
             (.loading, .loading),

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -414,7 +414,7 @@ class PreplannedMapModelTests: XCTestCase {
         let areas = try await task.preplannedMapAreas
         let area = try XCTUnwrap(areas.first { $0.title == "Country Commons Area" })
         let areaID = try XCTUnwrap(area.portalItem.id)
-
+        
         let model = PreplannedMapModel(
             offlineMapTask: task,
             mapArea: area,
@@ -432,7 +432,7 @@ class PreplannedMapModelTests: XCTestCase {
 }
 
 extension PreplannedMapModel.Status: Equatable {
-    public static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
+    static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
         return switch (lhs, rhs) {
         case (.notLoaded, .notLoaded),
             (.loading, .loading),


### PR DESCRIPTION
## Description

Reverts Esri/arcgis-maps-sdk-swift-toolkit#1532 . This upcoming feature causes a build problem for the toolkit in Xcode 26, while works in Xcode 27, so we pull it out for now until we bump the toolchain version.

I only reverted the changes in the toolkit package, 97b8662 , and not the changes in the example projects as they aren't built by `ArcGISBuild`.

## How to Test

Make sure the package and example project still build with no warnings.