### PR TITLE
Fix build error in ArcGISToolkitTests

### DIFF
--- a/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/OnDemandMapModelTests.swift
@@ -309,7 +309,7 @@ class OnDemandMapModelTests: XCTestCase {
 }
 
 extension OnDemandMapModel.Status: Equatable {
-    static func == (lhs: OnDemandMapModel.Status, rhs: OnDemandMapModel.Status) -> Bool {
+    public static func == (lhs: OnDemandMapModel.Status, rhs: OnDemandMapModel.Status) -> Bool {
         return switch (lhs, rhs) {
         case (.initialized, .initialized),
             (.downloading, .downloading),

--- a/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
+++ b/Tests/ArcGISToolkitTests/PreplannedMapModelTests.swift
@@ -432,7 +432,7 @@ class PreplannedMapModelTests: XCTestCase {
 }
 
 extension PreplannedMapModel.Status: Equatable {
-    static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
+    public static func == (lhs: PreplannedMapModel.Status, rhs: PreplannedMapModel.Status) -> Bool {
         return switch (lhs, rhs) {
         case (.notLoaded, .notLoaded),
             (.loading, .loading),


### PR DESCRIPTION
Reverts a change from #1532 that was missing in #1535

Broken test run on v.next: # 5034
Fixed test run: # ~~5035~~ 5036