### PR TITLE
`FeatureEditor`: Support geometry-dependant forms

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -107,7 +107,7 @@ public struct FeatureEditor: View {
         FeatureEditorToolbar(style: toolbarStyle)
             .task(id: ObjectIdentifier(geometryEditor)) {
                 model.geometryEditor = geometryEditor
-                model.restartGeometryEditor()
+                await model.restartGeometryEditor()
                 await model.monitorGeometryEditorStreams()
             }
             .task(id: startEditingIDs) {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -82,6 +82,10 @@ struct FeatureEditorFormView: View {
                 guard !Task.isCancelled else { return }
                 self.presentedFeatureForm = nil
             }
+            .task(id: model.geometryEditorGeometry) {
+                guard model.geometryEditorIsStarted else { return }
+                await model.setFormGeometry(to: model.geometryEditorGeometry)
+            }
             .onDisappear {
                 clearSelectedFeature()
                 model.geometryEditor.tool.style.opacity = 1
@@ -105,7 +109,7 @@ struct FeatureEditorFormView: View {
         case .discardedEdits(let willNavigate):
             // Restarts the geometry editor when the form footer discard button is pressed.
             guard !willNavigate else { break }
-            model.restartGeometryEditor()
+            await model.restartGeometryEditor()
         case .navigationChanged(let view):
             switch view {
             case .utilityAssociationCreationView(_, _, _, let candidate):

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -82,7 +82,15 @@ struct FeatureEditorFormView: View {
                 guard !Task.isCancelled else { return }
                 self.presentedFeatureForm = nil
             }
-            .task(id: model.geometryEditorGeometry, model.updateFormGeometry)
+            .task(id: model.geometryEditorGeometry) {
+                do {
+                    try await model.updateFormGeometry()
+                } catch {
+                    Logger.featureEditor.error(
+                        "Error updating form geometry: \(error.localizedDescription)"
+                    )
+                }
+            }
             .onDisappear {
                 clearSelectedFeature()
                 model.geometryEditor.tool.style.opacity = 1

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -82,10 +82,7 @@ struct FeatureEditorFormView: View {
                 guard !Task.isCancelled else { return }
                 self.presentedFeatureForm = nil
             }
-            .task(id: model.geometryEditorGeometry) {
-                guard model.geometryEditorIsStarted else { return }
-                await model.setFormGeometry(to: model.geometryEditorGeometry)
-            }
+            .task(id: model.geometryEditorGeometry, model.updateFormGeometry)
             .onDisappear {
                 clearSelectedFeature()
                 model.geometryEditor.tool.style.opacity = 1

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -110,7 +110,13 @@ final class FeatureEditorModel {
     func restartGeometryEditor() async {
         guard geometryEditorIsStarted else { return }
         
-        await setFormGeometry(to: initialGeometry)
+        do {
+            try await setFormGeometry(to: initialGeometry)
+        } catch {
+            Logger.featureEditor.error(
+                "Error updating form geometry: \(error.localizedDescription)"
+            )
+        }
         startGeometryEditor()
     }
     
@@ -201,14 +207,14 @@ final class FeatureEditorModel {
     
     /// Updates the form's feature geometry using the geometry editor's current
     /// geometry to update possible geometry-dependent form elements.
-    func updateFormGeometry() async {
+    func updateFormGeometry() async throws {
         guard geometryEditorIsStarted else { return }
         
         // Uses initialGeometry if the geometry editor has no edits to prevent
         // an empty geometry from being used when the geometry editor was
         // started using a geometryType (when feature.geometry is nil).
         let geometry = geometryEditorCanUndo ? geometryEditorGeometry : initialGeometry
-        await setFormGeometry(to: geometry)
+        try await setFormGeometry(to: geometry)
     }
     
     /// Loads the feature and its table if needed to allow geometry editing.
@@ -231,20 +237,14 @@ final class FeatureEditorModel {
     /// Sets the form's feature geometry and reevaluates expressions to update
     /// possible geometry-dependent form elements.
     /// - Parameter geometry: The new geometry to set on the feature.
-    private func setFormGeometry(to geometry: Geometry?) async {
+    private func setFormGeometry(to geometry: Geometry?) async throws {
         guard let featureForm = presentedFeatureForm ?? rootFeatureForm,
               featureForm.feature.geometry != geometry else {
             return
         }
         
-        do {
-            featureForm.feature.geometry = geometry
-            try await featureForm.evaluateExpressions()
-        } catch {
-            Logger.featureEditor.error(
-                "Error evaluating expressions: \(error.localizedDescription)"
-            )
-        }
+        featureForm.feature.geometry = geometry
+        try await featureForm.evaluateExpressions()
     }
     
     /// Performs setup needed for geometry editing and starts the geometry editor if applicable.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -117,7 +117,7 @@ final class FeatureEditorModel {
     /// Starts editing a new `FeatureForm` that is shown in the feature editor's `FeatureFormView`.
     /// - Parameter featureForm: The new feature form to edit.
     func startEditingFeatureForm(_ featureForm: FeatureForm) async {
-        geometryEditor.stop()
+        stopGeometryEditing()
         presentedFeatureForm = featureForm
         
         loadResult = await Result {
@@ -191,10 +191,7 @@ final class FeatureEditorModel {
         snapSettingsSheetIsPresented = false
         viewpointGeometry = nil
         
-        geometryEditor.stop()
-        geometryEditorCanUndo = false
-        geometryEditorGeometry = nil
-        geometryEditorIsStarted = false
+        stopGeometryEditing()
         
         snapRules = nil
         map = nil
@@ -265,5 +262,13 @@ final class FeatureEditorModel {
             geometryEditor.start(withType: geometryType)
         }
         initialGeometry = feature.geometry
+    }
+    
+    /// Stops the geometry editor and resets the related model properties.
+    private func stopGeometryEditing() {
+        geometryEditor.stop()
+        geometryEditorCanUndo = false
+        geometryEditorGeometry = nil
+        geometryEditorIsStarted = false
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -162,7 +162,7 @@ final class FeatureEditorModel {
     }
     
     /// Sets the form's feature geometry and reevaluates expressions to update
-    /// possible geometry dependent form elements.
+    /// possible geometry-dependent form elements.
     /// - Parameter geometry: The new geometry to set on the feature.
     func setFormGeometry(to geometry: Geometry?) async {
         guard let featureForm = presentedFeatureForm ?? rootFeatureForm,
@@ -175,7 +175,7 @@ final class FeatureEditorModel {
             try await featureForm.evaluateExpressions()
         } catch {
             Logger.featureEditor.error(
-                "Error evaluating expression: \(error.localizedDescription)"
+                "Error evaluating expressions: \(error.localizedDescription)"
             )
         }
     }
@@ -185,9 +185,9 @@ final class FeatureEditorModel {
     /// This is needed to prevent the current state from interfering with
     /// future uses of the `FeatureEditor` view.
     func stopEditing() {
+        initialGeometry = nil
         rootFeatureForm = nil
         presentedFeatureForm = nil
-        initialGeometry = nil
         snapSettingsSheetIsPresented = false
         viewpointGeometry = nil
         

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -161,25 +161,6 @@ final class FeatureEditorModel {
         }
     }
     
-    /// Sets the form's feature geometry and reevaluates expressions to update
-    /// possible geometry-dependent form elements.
-    /// - Parameter geometry: The new geometry to set on the feature.
-    func setFormGeometry(to geometry: Geometry?) async {
-        guard let featureForm = presentedFeatureForm ?? rootFeatureForm,
-              featureForm.feature.geometry != geometry else {
-            return
-        }
-        
-        do {
-            featureForm.feature.geometry = geometry
-            try await featureForm.evaluateExpressions()
-        } catch {
-            Logger.featureEditor.error(
-                "Error evaluating expressions: \(error.localizedDescription)"
-            )
-        }
-    }
-    
     /// Stops the feature editor and resets the model's properties.
     ///
     /// This is needed to prevent the current state from interfering with
@@ -218,6 +199,18 @@ final class FeatureEditorModel {
         }
     }
     
+    /// Updates the form's feature geometry using the geometry editor's current
+    /// geometry to update possible geometry-dependent form elements.
+    func updateFormGeometry() async {
+        guard geometryEditorIsStarted else { return }
+        
+        // Uses initialGeometry if the geometry editor has no edits to prevent
+        // an empty geometry from being used when geometry editor was started
+        // using the table's geometryType (when feature.geometry is nil).
+        let geometry = geometryEditorCanUndo ? geometryEditorGeometry : initialGeometry
+        await setFormGeometry(to: geometry)
+    }
+    
     /// Loads the feature and its table if needed to allow geometry editing.
     private func loadFeature() async throws {
         guard let feature else { return }
@@ -232,6 +225,25 @@ final class FeatureEditorModel {
         // can be accessed. It is always nil otherwise.
         if feature.geometry == nil, let table = feature.table {
             try await table.retryLoad()
+        }
+    }
+    
+    /// Sets the form's feature geometry and reevaluates expressions to update
+    /// possible geometry-dependent form elements.
+    /// - Parameter geometry: The new geometry to set on the feature.
+    private func setFormGeometry(to geometry: Geometry?) async {
+        guard let featureForm = presentedFeatureForm ?? rootFeatureForm,
+              featureForm.feature.geometry != geometry else {
+            return
+        }
+        
+        do {
+            featureForm.feature.geometry = geometry
+            try await featureForm.evaluateExpressions()
+        } catch {
+            Logger.featureEditor.error(
+                "Error evaluating expressions: \(error.localizedDescription)"
+            )
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -205,8 +205,8 @@ final class FeatureEditorModel {
         guard geometryEditorIsStarted else { return }
         
         // Uses initialGeometry if the geometry editor has no edits to prevent
-        // an empty geometry from being used when geometry editor was started
-        // using the table's geometryType (when feature.geometry is nil).
+        // an empty geometry from being used when the geometry editor was
+        // started using a geometryType (when feature.geometry is nil).
         let geometry = geometryEditorCanUndo ? geometryEditorGeometry : initialGeometry
         await setFormGeometry(to: geometry)
     }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -27,6 +27,10 @@ final class FeatureEditorModel {
     var feature: ArcGISFeature? {
         presentedFeatureForm?.feature ?? rootFeatureForm?.feature
     }
+    /// The geometry of the `feature` before editing, used to reset the
+    /// geometry when edits are discarded.
+    @ObservationIgnored
+    private var initialGeometry: Geometry?
     /// A Boolean value that indicates whether the Feature Editor inspector is presented.
     /// This maps `rootFeatureForm` to a Boolean value.
     var isPresented: Bool {
@@ -103,8 +107,10 @@ final class FeatureEditorModel {
     
     /// Restarts the `geometryEditor` if it is started.
     /// This can be used to discard geometry edits or set up a new geometry editor.
-    func restartGeometryEditor() {
+    func restartGeometryEditor() async {
         guard geometryEditorIsStarted else { return }
+        
+        await setFormGeometry(to: initialGeometry)
         startGeometryEditor()
     }
     
@@ -155,6 +161,25 @@ final class FeatureEditorModel {
         }
     }
     
+    /// Sets the form's feature geometry and reevaluates expressions to update
+    /// possible geometry dependent form elements.
+    /// - Parameter geometry: The new geometry to set on the feature.
+    func setFormGeometry(to geometry: Geometry?) async {
+        guard let featureForm = presentedFeatureForm ?? rootFeatureForm,
+              featureForm.feature.geometry != geometry else {
+            return
+        }
+        
+        do {
+            featureForm.feature.geometry = geometry
+            try await featureForm.evaluateExpressions()
+        } catch {
+            Logger.featureEditor.error(
+                "Error evaluating expression: \(error.localizedDescription)"
+            )
+        }
+    }
+    
     /// Stops the feature editor and resets the model's properties.
     ///
     /// This is needed to prevent the current state from interfering with
@@ -162,6 +187,7 @@ final class FeatureEditorModel {
     func stopEditing() {
         rootFeatureForm = nil
         presentedFeatureForm = nil
+        initialGeometry = nil
         snapSettingsSheetIsPresented = false
         viewpointGeometry = nil
         
@@ -238,5 +264,6 @@ final class FeatureEditorModel {
         } else if let geometryType = feature.table?.geometryType {
             geometryEditor.start(withType: geometryType)
         }
+        initialGeometry = feature.geometry
     }
 }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -96,7 +96,7 @@ struct FeatureEditorModelTests {
         await model.expectIsEditing(geometry: initialGeometry)
         
         // Verifies restartGeometryEditor restarts the geometry editor and
-        // resets feature's geometry.
+        // resets the feature's geometry.
         let newGeometry = Point(latitude: 1, longitude: 1)
         feature.geometry = newGeometry
         #expect(feature.geometry == newGeometry)

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -162,7 +162,7 @@ struct FeatureEditorModelTests {
         feature.geometry = newGeometry
         #expect(feature.geometry == newGeometry)
         
-        await model.updateFormGeometry()
+        try await model.updateFormGeometry()
         #expect(feature.geometry == initialGeometry)
         
         // Verifies updateFormGeometry() does nothing if the geometry editor is not started.
@@ -172,7 +172,7 @@ struct FeatureEditorModelTests {
         feature.geometry = newGeometry
         #expect(feature.geometry == newGeometry)
         
-        await model.updateFormGeometry()
+        try await model.updateFormGeometry()
         #expect(feature.geometry == newGeometry)
     }
     

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -82,26 +82,29 @@ struct FeatureEditorModelTests {
         defer { monitorGeometryEditorStreamsTask.cancel() }
         
         // Verifies restartGeometryEditor does nothing if the geometry editor has not started.
-        model.restartGeometryEditor()
+        await model.restartGeometryEditor()
         await model.expectDefaultPropertyValues()
         
         // Starts the feature editor.
         let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
-        let geometry = Point(latitude: 0, longitude: 0)
-        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
+        let initialGeometry = Point(latitude: 0, longitude: 0)
+        let feature = try #require(table.makeFeature(geometry: initialGeometry) as? ArcGISFeature)
         
         await model.startEditingFeature(feature, on: nil)
         await model.expectIsGeometryEditing()
-        await model.expectIsEditing(geometry: geometry)
+        await model.expectIsEditing(geometry: initialGeometry)
         
-        // Verifies restartGeometryEditor restarts the geometry editor when it is started.
+        // Verifies restartGeometryEditor restarts the geometry editor and
+        // resets feature's geometry.
         let newGeometry = Point(latitude: 1, longitude: 1)
         feature.geometry = newGeometry
+        #expect(feature.geometry == newGeometry)
         
-        model.restartGeometryEditor()
+        await model.restartGeometryEditor()
         await model.expectIsGeometryEditing()
-        await model.expectIsEditing(geometry: newGeometry)
+        await model.expectIsEditing(geometry: initialGeometry)
+        #expect(feature.geometry == initialGeometry)
     }
     
     /// Verifies setup failure leads to loadResult failure, blocks editing,
@@ -134,6 +137,24 @@ struct FeatureEditorModelTests {
         try #require(model.loadResult).get()
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)
+    }
+    
+    /// Verifies `setFormGeometry(to:)` updates the feature's geometry.
+    @Test func setFormGeometry() async throws {
+        let model = FeatureEditorModel()
+        
+        let geodatabaseFile = try await TemporaryGeodatabaseFile()
+        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
+        
+        let initialGeometry = Point(latitude: 0, longitude: 0)
+        let feature = try #require(table.makeFeature(geometry: initialGeometry) as? ArcGISFeature)
+        #expect(feature.geometry == initialGeometry)
+        
+        await model.startEditingFeature(feature, on: nil)
+        
+        let newGeometry = Point(latitude: 1, longitude: 1)
+        await model.setFormGeometry(to: newGeometry)
+        #expect(feature.geometry == newGeometry)
     }
     
     /// Verifies `startEditingFeature(_:on:)` and `startEditingFeatureForm(_:)` using

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -139,9 +139,12 @@ struct FeatureEditorModelTests {
         await model.expectIsEditing(geometry: geometry)
     }
     
-    /// Verifies `setFormGeometry(to:)` updates the feature's geometry.
-    @Test func setFormGeometry() async throws {
+    /// Verifies `updateFormGeometry()` sets the `feature` geometry correctly.
+    @Test
+    func updateFormGeometry() async throws {
         let model = FeatureEditorModel()
+        let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
+        defer { monitorGeometryEditorStreamsTask.cancel() }
         
         let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
@@ -151,9 +154,25 @@ struct FeatureEditorModelTests {
         #expect(feature.geometry == initialGeometry)
         
         await model.startEditingFeature(feature, on: nil)
+        await model.expectIsGeometryEditing()
         
+        // Verifies updateFormGeometry() resets the feature's geometry to its
+        // initial value if the geometry editor is started and has no edits.
         let newGeometry = Point(latitude: 1, longitude: 1)
-        await model.setFormGeometry(to: newGeometry)
+        feature.geometry = newGeometry
+        #expect(feature.geometry == newGeometry)
+        
+        await model.updateFormGeometry()
+        #expect(feature.geometry == initialGeometry)
+        
+        // Verifies updateFormGeometry() does nothing if the geometry editor is not started.
+        model.geometryEditor.stop()
+        await Task.yieldExpect(!model.geometryEditorIsStarted)
+        
+        feature.geometry = newGeometry
+        #expect(feature.geometry == newGeometry)
+        
+        await model.updateFormGeometry()
         #expect(feature.geometry == newGeometry)
     }
     


### PR DESCRIPTION
## Description

This PR adds Feature Editor support for geometry-dependent form elements by re-evaluating the form's expressions when geometry is changed. 
- Closes `swift/issues/8275`


## How To Test

- Replace the [`ExampleMapView.map`](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/blob/FeatureEditor/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift#L27-L38) declaration with:
    ```swift
    @State private var map = Map(url: URL(string: "https://www.arcgis.com/home/item.html?id=cc9bd34a82814c82b273a580c116f5af")!)!
    ```
- Run `ExampleMapView` project and tap on a map feature.
- Edit the feature's geometry and observe the `Area (m)` form element update accordingly. 


## Screenshots

|Before|After|
|:-:|:-:|
| <img width="500" height="348" alt="Before" src="https://github.com/user-attachments/assets/bbc71ec0-b90a-43e7-8b20-6c44e980f543" /> | <img width="500" height="348" alt="After" src="https://github.com/user-attachments/assets/71e574d6-4aa7-4ff0-9832-7f1c0797965a" /> |
