### PR TITLE
`FeatureEditor`: Add a button for adding features

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -43,7 +43,8 @@ import SwiftUI
 ///
 /// **Behavior**
 ///
-/// The toolbar is visible only while a feature's geometry is being edited.
+/// When no feature is selected, the toolbar includes a button to add features.
+/// When a feature is selected, the toolbar includes feature editing controls.
 ///
 /// **Associated Types**
 ///

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -21,6 +21,21 @@ internal import os
 @MainActor
 @Observable
 final class FeatureEditorModel {
+    // MARK: State
+    
+    /// The various states of the feature editor.
+    enum State: Equatable {
+        /// The feature editor is adding features.
+        case adding
+        /// The feature editor is editing a feature.
+        case editing
+        /// The feature editor is stopped.
+        case stopped
+    }
+    
+    /// The current state of the feature editor.
+    private(set) var state: State = .stopped
+    
     // MARK: Properties
     
     /// The feature currently being edited by the feature editor.
@@ -34,7 +49,7 @@ final class FeatureEditorModel {
     /// A Boolean value that indicates whether the Feature Editor inspector is presented.
     /// This maps `rootFeatureForm` to a Boolean value.
     var isPresented: Bool {
-        get { rootFeatureForm != nil }
+        get { state != .stopped }
         set {
             guard !newValue else { return }
             stopEditing()
@@ -120,6 +135,20 @@ final class FeatureEditorModel {
         startGeometryEditor()
     }
     
+    // MARK: Adding
+    
+    /// Starts adding new features from templates.
+    func startAddingFeatures() {
+        state = .adding
+    }
+    
+    /// Stops adding new features.
+    func stopAddingFeatures() {
+        state = .stopped
+    }
+    
+    // MARK: Editing
+    
     /// Starts editing a new `FeatureForm` that is shown in the feature editor's `FeatureFormView`.
     /// - Parameter featureForm: The new feature form to edit.
     func startEditingFeatureForm(_ featureForm: FeatureForm) async {
@@ -137,7 +166,8 @@ final class FeatureEditorModel {
     ///   - feature: The root feature to edit.
     ///   - map: The map that `feature` is part of, used to set up rule-based snapping.
     func startEditingFeature(_ feature: ArcGISFeature, on map: Map?) async {
-        stopEditing()
+        state = .editing
+        resetProperties()
         rootFeatureForm = FeatureForm(feature: feature)
         self.map = map
         loadResult = await Result {
@@ -172,6 +202,15 @@ final class FeatureEditorModel {
     /// This is needed to prevent the current state from interfering with
     /// future uses of the `FeatureEditor` view.
     func stopEditing() {
+        state = .stopped
+        resetProperties()
+    }
+    
+    /// Resets the model's properties.
+    ///
+    /// This is needed to prevent the current state from interfering with
+    /// future uses of the `FeatureEditor` view.
+    private func resetProperties() {
         initialGeometry = nil
         rootFeatureForm = nil
         presentedFeatureForm = nil

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -47,7 +47,6 @@ final class FeatureEditorModel {
     @ObservationIgnored
     private var initialGeometry: Geometry?
     /// A Boolean value that indicates whether the Feature Editor inspector is presented.
-    /// This maps `rootFeatureForm` to a Boolean value.
     var isPresented: Bool {
         get { state != .stopped }
         set {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModifier.swift
@@ -40,36 +40,45 @@ private struct FeatureEditorModifier: ViewModifier {
             .safeInspector(isPresented: $model.isPresented) {
                 // VStack is needed for presentation modifiers to be applied.
                 VStack(spacing: 0) {
-                    switch model.loadResult {
-                    case .success:
-                        if let rootFeatureForm = model.rootFeatureForm {
-                            FeatureEditorFormView(
-                                rootFeatureForm: rootFeatureForm,
-                                isMinimized: selectedPresentationDetent == .bar
-                            )
-                        }
-                    case .failure(let error):
+                    switch model.state {
+                    case .adding:
                         NavigationStack {
-                            makeContentUnavailableView(error: error)
-                                .toolbar {
-                                    ToolbarItem(placement: .topBarTrailing) {
-                                        DismissButton(kind: .close) {
-                                            model.isPresented = false
+                            FeatureEditorTemplatePicker()
+                        }
+                    case .editing:
+                        switch model.loadResult {
+                        case .success:
+                            if let rootFeatureForm = model.rootFeatureForm {
+                                FeatureEditorFormView(
+                                    rootFeatureForm: rootFeatureForm,
+                                    isMinimized: selectedPresentationDetent == .bar
+                                )
+                            }
+                        case .failure(let error):
+                            NavigationStack {
+                                makeContentUnavailableView(error: error)
+                                    .toolbar {
+                                        ToolbarItem(placement: .topBarTrailing) {
+                                            DismissButton(kind: .close) {
+                                                model.isPresented = false
+                                            }
                                         }
                                     }
-                                }
-                        }
-                    case .none:
-                        NavigationStack {
-                            ProgressView()
-                                .toolbar {
-                                    ToolbarItem(placement: .topBarTrailing) {
-                                        DismissButton(kind: .close) {
-                                            model.isPresented = false
+                            }
+                        case .none:
+                            NavigationStack {
+                                ProgressView()
+                                    .toolbar {
+                                        ToolbarItem(placement: .topBarTrailing) {
+                                            DismissButton(kind: .close) {
+                                                model.isPresented = false
+                                            }
                                         }
                                     }
-                                }
+                            }
                         }
+                    case .stopped:
+                        EmptyView()
                     }
                 }
                 .task(id: isRetrying) {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Template Picker/FeatureEditorTemplatePicker.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Template Picker/FeatureEditorTemplatePicker.swift
@@ -1,0 +1,40 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+/// A view that displays a list of feature templates.
+struct FeatureEditorTemplatePicker: View {
+    @Environment(FeatureEditorModel.self) private var model
+    
+    var body: some View {
+        ContentUnavailableView("Under Construction", systemImage: "exclamationmark.triangle")
+            .navigationTitle(
+                LocalizedStringResource(
+                    "Templates",
+                    bundle: .toolkit,
+                    comment: "The title of the template picker view"
+                )
+            )
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    DismissButton(kind: .close) {
+                        withAnimation {
+                            model.stopEditing()
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Template Picker/FeatureEditorTemplatePicker.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Template Picker/FeatureEditorTemplatePicker.swift
@@ -24,7 +24,7 @@ struct FeatureEditorTemplatePicker: View {
                 LocalizedStringResource(
                     "Templates",
                     bundle: .toolkit,
-                    comment: "The title of the template picker view"
+                    comment: "The title of the template picker view."
                 )
             )
             .toolbar {

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -49,11 +49,11 @@ struct FeatureEditorToolbar: View {
                     }
                     .padding(.horizontal, stackEdgePadding)
                     .toolbarStyle()
-                case nil:
+                case .none:
                     controls
                 }
             case .stopped:
-                Button(
+                let addButton = Button(
                     LocalizedStringResource(
                         "Add Features",
                         bundle: .toolkitModule,
@@ -62,7 +62,12 @@ struct FeatureEditorToolbar: View {
                     systemImage: "plus",
                     action: model.startAddingFeatures
                 )
-                .toolbarStyle()
+                if style != nil {
+                    addButton
+                        .toolbarStyle()
+                } else {
+                    addButton
+                }
             default:
                 // No controls.
                 EmptyView()

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -34,7 +34,8 @@ struct FeatureEditorToolbar: View {
     
     var body: some View {
         Group {
-            if model.geometryEditorIsStarted {
+            switch model.state {
+            case .editing where model.geometryEditorIsStarted:
                 switch style {
                 case .vertical:
                     VStack(spacing: stackSpacing) {
@@ -51,6 +52,20 @@ struct FeatureEditorToolbar: View {
                 case nil:
                     controls
                 }
+            case .stopped:
+                Button(
+                    LocalizedStringResource(
+                        "Add Features",
+                        bundle: .toolkitModule,
+                        comment: "A label for a button to show a feature template picker."
+                    ),
+                    systemImage: "plus",
+                    action: model.startAddingFeatures
+                )
+                .toolbarStackStyle()
+            default:
+                // No controls.
+                EmptyView()
             }
         }
         .animation(.default, value: model.geometryEditorIsStarted)

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/Toolbar/FeatureEditorToolbar.swift
@@ -42,13 +42,13 @@ struct FeatureEditorToolbar: View {
                         controls
                     }
                     .padding(.vertical, stackEdgePadding)
-                    .toolbarStackStyle()
+                    .toolbarStyle()
                 case .horizontal:
                     HStack(spacing: stackSpacing) {
                         controls
                     }
                     .padding(.horizontal, stackEdgePadding)
-                    .toolbarStackStyle()
+                    .toolbarStyle()
                 case nil:
                     controls
                 }
@@ -62,7 +62,7 @@ struct FeatureEditorToolbar: View {
                     systemImage: "plus",
                     action: model.startAddingFeatures
                 )
-                .toolbarStackStyle()
+                .toolbarStyle()
             default:
                 // No controls.
                 EmptyView()
@@ -188,10 +188,10 @@ private struct SnapSettingsButton: View {
 // MARK: - Helper
 
 private extension View {
-    /// Applies the shared styling used by the vertical and horizontal stacks
-    /// in a `FeatureEditorToolbar`.
+    /// Applies the shared styling used by the feature editor toolbar and its
+    /// controls.
     @ViewBuilder
-    func toolbarStackStyle() -> some View {
+    func toolbarStyle() -> some View {
         // glassEffect is not used because it bases its background color on the content behind it,
         // but the ToolPicker does not, causing the color to jump when the picker menu closes.
         self.fixedSize()

--- a/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
@@ -81,10 +81,10 @@ private extension FeatureEditorTestView {
             try await map.retryLoad()
             
             if let objectID = UserDefaults.standard.objectID,
-                  let layerName = UserDefaults.standard.layerName,
-                  let groupLayer = map.operationalLayers.first as? GroupLayer,
-                  let layer = groupLayer.layers.first(where: { $0.name == layerName }),
-                  let featureLayer = layer as? FeatureLayer {
+               let layerName = UserDefaults.standard.layerName,
+               let groupLayer = map.operationalLayers.first as? GroupLayer,
+               let layer = groupLayer.layers.first(where: { $0.name == layerName }),
+               let featureLayer = layer as? FeatureLayer {
                 try await startEditingFeature(withIdentifier: objectID, on: featureLayer)
             }
         } catch {

--- a/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
@@ -80,16 +80,13 @@ private extension FeatureEditorTestView {
             try await ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(.publicSample)
             try await map.retryLoad()
             
-            guard let objectID = UserDefaults.standard.objectID,
+            if let objectID = UserDefaults.standard.objectID,
                   let layerName = UserDefaults.standard.layerName,
                   let groupLayer = map.operationalLayers.first as? GroupLayer,
                   let layer = groupLayer.layers.first(where: { $0.name == layerName }),
-                  let featureLayer = layer as? FeatureLayer else {
-                errorDescription = "Missing or invalid launch arguments."
-                return
+                  let featureLayer = layer as? FeatureLayer {
+                try await startEditingFeature(withIdentifier: objectID, on: featureLayer)
             }
-            
-            try await startEditingFeature(withIdentifier: objectID, on: featureLayer)
         } catch {
             errorDescription = error.localizedDescription
         }

--- a/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
+++ b/Test Runner/UI Tests/FeatureEditorToolbarTests.swift
@@ -37,6 +37,27 @@ final class FeatureEditorToolbarTests: XCTestCase {
         featureEditorTestsButton.assertExistenceAndTap()
     }
     
+    /// Tests that the template picker can be presented and dismissed.
+    func testAddingFeatures() {
+        let app = XCUIApplication()
+        app.launch()
+        app.openFeatureEditorTestView()
+        
+        let addFeaturesButton = app.buttons["Add Features"]
+        addFeaturesButton.assertExistence()
+        
+        let templates = app.staticTexts["Templates"]
+        addFeaturesButton.tap()
+        templates.assertExistence()
+        XCTAssertFalse(addFeaturesButton.exists)
+        
+        let closeButton = app.buttons["Close"]
+        XCTAssertTrue(closeButton.exists)
+        
+        closeButton.tap()
+        addFeaturesButton.assertExistence()
+    }
+    
     /// Tests the default style for the feature editor toolbar is vertical.
     /// Verifies that the tool button is positioned above the delete button
     /// by comparing their midY values.
@@ -195,6 +216,14 @@ private extension String {
     static let electricDistributionDevice = "Electric Distribution Device"
     static let electricDistributionLine = "Electric Distribution Line"
     static let structureBoundary = "Structure Boundary"
+}
+
+private extension XCUIApplication {
+    /// Opens the feature editor test view without selecting a feature.
+    func openFeatureEditorTestView() {
+        let featureEditorTestsButton = buttons["Feature Editor Tests"]
+        featureEditorTestsButton.assertExistenceAndTap()
+    }
 }
 
 private extension XCUIElement {

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -299,6 +299,14 @@ struct FeatureEditorModelTests {
         model.stopEditing()
         await model.expectDefaultPropertyValues()
     }
+    
+    @Test func startAndStopAddingFeatures() {
+        let model = FeatureEditorModel()
+        model.startAddingFeatures()
+        #expect(model.state == .adding)
+        model.stopAddingFeatures()
+        #expect(model.state == .stopped)
+    }
 }
 
 // MARK: Helper

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -314,6 +314,7 @@ struct FeatureEditorModelTests {
 private extension FeatureEditorModel {
     /// Verifies the model's properties have their default values.
     func expectDefaultPropertyValues(sourceLocation: SourceLocation = #_sourceLocation) async {
+        #expect(state == .stopped, sourceLocation: sourceLocation)
         #expect(feature == nil, sourceLocation: sourceLocation)
         #expect(!isPresented, sourceLocation: sourceLocation)
         #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)


### PR DESCRIPTION
## Description

This PR adds a + button to the feature editor toolbar that is visible when no feature is selected. Tapping it presents a yet-to-be implemented template picker for adding features and the + button goes away. Tapping on the close button dismisses the template picker and brings back the + button, or tapping on a feature replaces the template picker with the feature editor form view.

- Closes `swift/issues/8538`

## How To Test

- Open the example and tap the + button
- Run the new unit test
- Run the new UI test

## Screenshots

https://github.com/user-attachments/assets/77a99f10-97ef-41c4-83aa-2a6cb3ae5ccb