### PR TITLE
Refine LocationButton interactions

### DIFF
--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -331,7 +331,7 @@ extension LocationButton {
     /// The context menu auto-pan mode options.
     ///
     /// The context menu options will be in the order the user specifies
-    /// except the off option, when included, will be first.
+    /// except the off option, which, when included, will be first.
     var contextMenuAutoPanOptions: [LocationDisplay.AutoPanMode] {
         autoPanModes.filter { $0 == .off } +
         autoPanModes.filter { $0 != .off }

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -91,7 +91,7 @@ public struct LocationButton: View {
     
     /// Sets whether the user can hide the location display.
     /// - Parameter isAllowed: A Boolean value indicating whether hiding the
-    ///   location display is included in the context menu.
+    /// location display is included in the context menu.
     /// - Returns: A new location button configured with the given value.
     public func allowsHidingLocationDisplay(_ isAllowed: Bool) -> Self {
         var copy = self

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -44,7 +44,7 @@ public struct LocationButton: View {
     
     /// A Boolean value indicating whether the user can hide the location display.
     private(set) var allowsHidingLocationDisplay = true
-
+    
     /// The action performed when the button is pressed.
     var currentAction: Action? {
         Action(
@@ -53,7 +53,7 @@ public struct LocationButton: View {
             autoPanOptions: autoPanModes
         )
     }
-
+    
     /// A value indicating whether the button is disabled.
     var buttonIsDisabled: Bool {
         status == .starting ||
@@ -98,7 +98,7 @@ public struct LocationButton: View {
         copy.allowsHidingLocationDisplay = isAllowed
         return copy
     }
-
+    
     public var body: some View {
         Button {
             buttonAction()
@@ -322,7 +322,7 @@ extension LocationButton {
     var shouldShowContextMenu: Bool {
         allowsHidingLocationDisplay || autoPanModes.count > 1
     }
-
+    
     /// The initial auto-pan mode to be used.
     var initialAutoPanMode: LocationDisplay.AutoPanMode {
         autoPanModes.first ?? .off

--- a/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
+++ b/Sources/ArcGISToolkit/Components/LocationButton/LocationButton.swift
@@ -22,14 +22,13 @@ internal import os
 /// Gives the user a variety of options to set the auto-pan mode or stop the
 /// location data source.
 ///
-/// The button will cycle through the specified auto-pan modes on tap. The user
-/// can also hide the location display or select the auto-pan mode through a
-/// context menu.
+/// After starting the location display, the button cycles through the specified
+/// auto-pan modes on tap.
 ///
-/// If there are no auto-pan modes specified, or if the only specified mode is
-/// `off`, then:
-/// - the location display is toggled on/off when pressed
-/// - the context menu is not shown when long pressed
+/// By default, a context menu allows the user to hide the location display.
+/// The menu can also be shown when hiding is disabled if at least two auto-pan
+/// modes are specified. Auto-pan mode options appear in the menu only when at
+/// least two modes are specified.
 public struct LocationButton: View {
     /// The location display controlled by the location button.
     let locationDisplay: LocationDisplay
@@ -43,9 +42,24 @@ public struct LocationButton: View {
     /// A Boolean value indicating that the button action is being performed.
     @State private(set) var isPerformingButtonAction = false
     
+    /// A Boolean value indicating whether the user can hide the location display.
+    private(set) var allowsHidingLocationDisplay = true
+
+    /// The action performed when the button is pressed.
+    var currentAction: Action? {
+        Action(
+            status: status,
+            autoPanMode: autoPanMode,
+            autoPanOptions: autoPanModes
+        )
+    }
+
     /// A value indicating whether the button is disabled.
     var buttonIsDisabled: Bool {
-        status == .starting || status == .stopping || isPerformingButtonAction
+        status == .starting ||
+        status == .stopping ||
+        isPerformingButtonAction ||
+        (currentAction == nil && !shouldShowContextMenu)
     }
     
 #if os(visionOS)
@@ -75,6 +89,16 @@ public struct LocationButton: View {
         return copy
     }
     
+    /// Sets whether the user can hide the location display.
+    /// - Parameter isAllowed: A Boolean value indicating whether hiding the
+    ///   location display is included in the context menu.
+    /// - Returns: A new location button configured with the given value.
+    public func allowsHidingLocationDisplay(_ isAllowed: Bool) -> Self {
+        var copy = self
+        copy.allowsHidingLocationDisplay = isAllowed
+        return copy
+    }
+
     public var body: some View {
         Button {
             buttonAction()
@@ -226,44 +250,48 @@ public struct LocationButton: View {
     
     @ViewBuilder
     private var contextMenuItems: some View {
-        // Only show context menu if there are 2 or more auto-pan options and
-        // status of the location display is started.
-        if autoPanModes.count >= 2 && status == .started {
-            Section {
-                ForEach(contextMenuAutoPanOptions, id: \.self) { autoPanMode in
-                    Button {
-                        self.autoPanMode = autoPanMode
-                    } label: {
-                        Label {
-                            autoPanMode.label
-                        } icon: {
-                            Image(systemName: autoPanMode.imageSystemName)
+        if shouldShowContextMenu && status == .started {
+            if autoPanModes.count > 1 {
+                Section {
+                    ForEach(contextMenuAutoPanOptions, id: \.self) { autoPanMode in
+                        Button {
+                            self.autoPanMode = autoPanMode
+                        } label: {
+                            Label {
+                                autoPanMode.label
+                            } icon: {
+                                Image(systemName: autoPanMode.imageSystemName)
+                            }
                         }
+                        .accessibilityHint(autoPanMode.accessibilityHint)
                     }
-                    .accessibilityHint(autoPanMode.accessibilityHint)
+                } header: {
+                    autoPanSectionHeaderLabelText
                 }
-            } header: {
-                autoPanSectionHeaderLabelText
             }
             
-            Button {
-                Task {
-                    await hideLocationDisplay()
+            if allowsHidingLocationDisplay {
+                Button {
+                    isPerformingButtonAction = true
+                    Task {
+                        await hideLocationDisplay()
+                        isPerformingButtonAction = false
+                    }
+                } label: {
+                    Label {
+                        hideLocationLabelText
+                    } icon: {
+                        Image(systemName: "location.slash")
+                    }
                 }
-            } label: {
-                Label {
-                    hideLocationLabelText
-                } icon: {
-                    Image(systemName: "location.slash")
-                }
-            }
-            .accessibilityHint(
-                Text(
-                    "Hide location display",
-                    bundle: .toolkitModule,
-                    comment: "The accessibility hint of the hide location display context menu option."
+                .accessibilityHint(
+                    Text(
+                        "Hide location display",
+                        bundle: .toolkitModule,
+                        comment: "The accessibility hint of the hide location display context menu option."
+                    )
                 )
-            )
+            }
         }
     }
     
@@ -290,6 +318,11 @@ public struct LocationButton: View {
 }
 
 extension LocationButton {
+    /// A Boolean value indicating whether the context menu should be shown.
+    var shouldShowContextMenu: Bool {
+        allowsHidingLocationDisplay || autoPanModes.count > 1
+    }
+
     /// The initial auto-pan mode to be used.
     var initialAutoPanMode: LocationDisplay.AutoPanMode {
         autoPanModes.first ?? .off
@@ -298,9 +331,10 @@ extension LocationButton {
     /// The context menu auto-pan mode options.
     ///
     /// The context menu options will be in the order the user specifies
-    /// except the off option will be first.
+    /// except the off option, when included, will be first.
     var contextMenuAutoPanOptions: [LocationDisplay.AutoPanMode] {
-        [.off] + autoPanModes.filter { $0 != .off }
+        autoPanModes.filter { $0 == .off } +
+        autoPanModes.filter { $0 != .off }
     }
     
     /// Observe the status of the location display datasource.
@@ -321,10 +355,11 @@ extension LocationButton {
     
     /// This should be called when the button is pressed.
     func buttonAction() {
-        isPerformingButtonAction = true
+        guard let currentAction else { return }
         
-        switch Action(status: status, autoPanOptions: autoPanModes) {
+        switch currentAction {
         case .start:
+            isPerformingButtonAction = true
             // If the datasource is a system location datasource, then request authorization.
             if locationDisplay.dataSource is SystemLocationDataSource,
                CLLocationManager.shared.authorizationStatus == .notDetermined {
@@ -340,18 +375,8 @@ extension LocationButton {
                 }
                 isPerformingButtonAction = false
             }
-        case .stop:
-            Task {
-                await hideLocationDisplay()
-                isPerformingButtonAction = false
-            }
         case .autoPanCycle:
-            // Need to use the select method here so that last selected mode
-            // gets set.
             autoPanMode = nextAutoPanMode(current: autoPanMode, initial: initialAutoPanMode)
-            isPerformingButtonAction = false
-        case .none:
-            return
         }
     }
     
@@ -376,14 +401,13 @@ extension LocationButton {
     enum Action {
         /// Start the location display.
         case start
-        /// Stop the location display.
-        case stop
         /// Set the next auto-pan mode for cycling through.
         case autoPanCycle
         
         /// The action that should occur for the specified state.
         init?(
             status: LocationDataSource.Status,
+            autoPanMode: LocationDisplay.AutoPanMode,
             autoPanOptions: [LocationDisplay.AutoPanMode]
         ) {
             // Decide the button behavior based on the status.
@@ -391,13 +415,10 @@ extension LocationButton {
             case .stopped, .failedToStart:
                 self = .start
             case .started:
-                self = if autoPanOptions.count < 2 {
-                    // Since there were no non-off options specified then set it
-                    // to off since the status is started.
-                    .stop
-                } else {
-                    .autoPanCycle
+                guard autoPanOptions.contains(where: { $0 != autoPanMode }) else {
+                    return nil
                 }
+                self = .autoPanCycle
             case .starting, .stopping:
                 return nil
             @unknown default:

--- a/Tests/ArcGISToolkitTests/LocationButtonTests.swift
+++ b/Tests/ArcGISToolkitTests/LocationButtonTests.swift
@@ -28,6 +28,7 @@ struct LocationButtonTests {
         #expect(button.status == .stopped)
         #expect(button.autoPanMode == .off)
         #expect(button.buttonIsDisabled == false)
+        #expect(button.allowsHidingLocationDisplay)
         #expect(button.initialAutoPanMode == .recenter)
 #if os(visionOS)
         #expect(button.autoPanModes == [.recenter, .off])
@@ -66,6 +67,35 @@ struct LocationButtonTests {
     }
     
     @Test
+    func allowsHidingLocationDisplay() {
+        let locationDisplay = LocationDisplay(dataSource: MockLocationDataSource())
+
+        let buttonWithHide = LocationButton(locationDisplay: locationDisplay)
+            .autoPanModes([.navigation])
+        let buttonWithoutHide = LocationButton(locationDisplay: locationDisplay)
+            .autoPanModes([.navigation])
+            .allowsHidingLocationDisplay(false)
+        let buttonWithTwoModes = LocationButton(locationDisplay: locationDisplay)
+            .autoPanModes([.recenter, .navigation])
+            .allowsHidingLocationDisplay(false)
+        let buttonWithNoModes = LocationButton(locationDisplay: locationDisplay)
+            .autoPanModes([])
+        let buttonWithOffOnly = LocationButton(locationDisplay: locationDisplay)
+            .autoPanModes([.off])
+
+        #expect(buttonWithHide.allowsHidingLocationDisplay)
+        #expect(buttonWithHide.shouldShowContextMenu)
+        #expect(buttonWithHide.contextMenuAutoPanOptions == [.navigation])
+        #expect(!buttonWithoutHide.allowsHidingLocationDisplay)
+        #expect(!buttonWithoutHide.shouldShowContextMenu)
+        #expect(buttonWithTwoModes.shouldShowContextMenu)
+        #expect(buttonWithNoModes.shouldShowContextMenu)
+        #expect(buttonWithNoModes.contextMenuAutoPanOptions.isEmpty)
+        #expect(buttonWithOffOnly.shouldShowContextMenu)
+        #expect(buttonWithOffOnly.contextMenuAutoPanOptions == [.off])
+    }
+
+    @Test
     func hideLocationDisplay() async throws {
         let datasource = MockLocationDataSource()
         let locationDisplay = LocationDisplay(dataSource: datasource)
@@ -101,31 +131,74 @@ struct LocationButtonTests {
         @Test
         func initializer() {
             #expect(
-                Action(status: .stopped, autoPanOptions: []) == .start
+                Action(
+                    status: .stopped,
+                    autoPanMode: .off,
+                    autoPanOptions: []
+                ) == .start
             )
             #expect(
-                Action(status: .failedToStart, autoPanOptions: []) == .start
+                Action(
+                    status: .failedToStart,
+                    autoPanMode: .off,
+                    autoPanOptions: []
+                ) == .start
             )
             #expect(
-                Action(status: .started, autoPanOptions: []) == .stop
+                Action(
+                    status: .started,
+                    autoPanMode: .off,
+                    autoPanOptions: []
+                ) == nil
             )
             #expect(
-                Action(status: .started, autoPanOptions: [.off]) == .stop
+                Action(
+                    status: .started,
+                    autoPanMode: .off,
+                    autoPanOptions: [.off]
+                ) == nil
             )
             #expect(
-                Action(status: .started, autoPanOptions: [.recenter]) == .stop
+                Action(
+                    status: .started,
+                    autoPanMode: .off,
+                    autoPanOptions: [.navigation]
+                ) == .autoPanCycle
             )
             #expect(
-                Action(status: .started, autoPanOptions: [.off, .recenter]) == .autoPanCycle
+                Action(
+                    status: .started,
+                    autoPanMode: .navigation,
+                    autoPanOptions: [.navigation]
+                ) == nil
             )
             #expect(
-                Action(status: .started, autoPanOptions: [.off, .recenter, .navigation]) == .autoPanCycle
+                Action(
+                    status: .started,
+                    autoPanMode: .navigation,
+                    autoPanOptions: [.off]
+                ) == .autoPanCycle
             )
             #expect(
-                Action(status: .starting, autoPanOptions: []) == nil
+                Action(
+                    status: .started,
+                    autoPanMode: .recenter,
+                    autoPanOptions: [.recenter, .navigation]
+                ) == .autoPanCycle
             )
             #expect(
-                Action(status: .stopping, autoPanOptions: []) == nil
+                Action(
+                    status: .starting,
+                    autoPanMode: .off,
+                    autoPanOptions: []
+                ) == nil
+            )
+            #expect(
+                Action(
+                    status: .stopping,
+                    autoPanMode: .off,
+                    autoPanOptions: []
+                ) == nil
             )
         }
     }


### PR DESCRIPTION
## Summary

- Fix `LocationButton` so a sole configured auto-pan mode is restored after map interaction turns auto-pan off.
- Add `allowsHidingLocationDisplay(_:)`, enabled by default, to control whether **Hide Location** appears in the context menu.
- Keep hiding context-menu-only and show auto-pan menu options only when multiple modes are configured.
- Limit context-menu choices to explicitly configured modes; `.off` is moved first only when supplied.
- Guard asynchronous start and stop actions against duplicate requests.
- Update component documentation and regression coverage for mode cycling and menu configurations.

## Testing

- Added unit coverage for current-mode action availability, hide configuration, and context-menu options.