### PR TITLE
`FeatureEditor`: Fix example console error

### DIFF
--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -23,7 +23,7 @@ struct ExampleMapView: View {
     /// The geometry editor that the feature editor will use to edit geometries
     /// on the `MapView`.
     @State private var geometryEditor = GeometryEditor()
-    /// The map with the features to edit, created from a Naperville Electric web map portal item.
+    /// The map with the features to edit.
     @State private var map = Map()
     /// The point on the screen where the user tapped.
     @State private var tapPoint: CGPoint?
@@ -79,15 +79,16 @@ struct ExampleMapView: View {
         }
         .task {
             do {
-                try await setUp()
+                map = try await makeMap()
             } catch {
-                print("Setup error:", error)
+                print("Failed to make map:", error)
             }
         }
     }
     
-    /// Sets up the map.
-    private func setUp() async throws {
+    /// Returns a map with the features to edit, created from a Naperville
+    /// Electric web map portal item.
+    private func makeMap() async throws -> Map {
         let url = URL(string: "https://sampleserver7.arcgisonline.com/portal/home/item.html?id=b4565e0a4e4c4a4382914128f10864cd")!
         let map = Map(url: url)!
         
@@ -107,6 +108,6 @@ struct ExampleMapView: View {
         ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(credential)
         try await map.load()
         
-        self.map = map
+        return map
     }
 }

--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -23,8 +23,9 @@ struct ExampleMapView: View {
     /// The geometry editor that the feature editor will use to edit geometries
     /// on the `MapView`.
     @State private var geometryEditor = GeometryEditor()
-    /// The map with the features to edit.
-    @State private var map = Map()
+    /// The result of loading the map used by the example. When the operation
+    /// succeeds, this will contain a map with features to edit.
+    @State private var mapLoadResult: Result<Map, (any Error)>?
     /// The point on the screen where the user tapped.
     @State private var tapPoint: CGPoint?
     
@@ -39,50 +40,59 @@ struct ExampleMapView: View {
     }
     
     var body: some View {
-        MapViewReader { mapViewProxy in
-            MapView(map: map)
-                .contentInsets(contentInsets)
-                .geometryEditor(geometryEditor)
-                .onSingleTapGesture { screenPoint, _ in
-                    guard tapPoint == nil else { return }
-                    tapPoint = screenPoint
-                }
-                .task(id: tapPoint) {
-                    // Identifies the feature at the tapped screen point and
-                    // uses it to display the feature editor.
-                    guard let tapPoint else { return }
-                    defer { self.tapPoint = nil }
-                    
-                    do {
-                        let results = try await mapViewProxy.identifyLayers(
-                            screenPoint: tapPoint,
-                            tolerance: 10
-                        )
-                        let firstFeature = results.first?.geoElements.first as? ArcGISFeature
-                        // The identified feature is passed to the feature editor.
-                        featureToEdit = firstFeature
-                    } catch {
-                        print("Identify error:", error)
+        switch mapLoadResult {
+        case .success(let map):
+            MapViewReader { mapViewProxy in
+                MapView(map: map)
+                    .contentInsets(contentInsets)
+                    .geometryEditor(geometryEditor)
+                    .onSingleTapGesture { screenPoint, _ in
+                        guard tapPoint == nil else { return }
+                        tapPoint = screenPoint
                     }
-                }
-                .overlay(alignment: .topTrailing) {
-                    // The feature editor needs to be placed below the
-                    // `featureEditorInspector` modifier in the view hierarchy.
-                    FeatureEditor(
-                        $featureToEdit,
-                        geometryEditor: geometryEditor,
-                        map: map,
-                        mapViewProxy: mapViewProxy
-                    )
-                    .padding()
-                }
-        }
-        .task {
-            do {
-                map = try await makeMap()
-            } catch {
-                print("Failed to make map:", error)
+                    .task(id: tapPoint) {
+                        // Identifies the feature at the tapped screen point and
+                        // uses it to display the feature editor.
+                        guard let tapPoint else { return }
+                        defer { self.tapPoint = nil }
+                        
+                        do {
+                            let results = try await mapViewProxy.identifyLayers(
+                                screenPoint: tapPoint,
+                                tolerance: 10
+                            )
+                            let firstFeature = results.first?.geoElements.first as? ArcGISFeature
+                            // The identified feature is passed to the feature editor.
+                            featureToEdit = firstFeature
+                        } catch {
+                            print("Identify error:", error)
+                        }
+                    }
+                    .overlay(alignment: .topTrailing) {
+                        // The feature editor needs to be placed below the
+                        // `featureEditorInspector` modifier in the view hierarchy.
+                        FeatureEditor(
+                            $featureToEdit,
+                            geometryEditor: geometryEditor,
+                            map: map,
+                            mapViewProxy: mapViewProxy
+                        )
+                        .padding()
+                    }
             }
+        case .failure(let error):
+            ContentUnavailableView {
+                Label("Failed to load map", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error.localizedDescription)
+            } actions: {
+                Button("Retry") { mapLoadResult = nil }
+            }
+        case .none:
+            ProgressView("Loading map")
+                .task {
+                    mapLoadResult = await Result { try await makeMap() }
+                }
         }
     }
     

--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -24,18 +24,7 @@ struct ExampleMapView: View {
     /// on the `MapView`.
     @State private var geometryEditor = GeometryEditor()
     /// The map with the features to edit, created from a Naperville Electric web map portal item.
-    @State private var map: Map = {
-        let url = URL(string: "https://sampleserver7.arcgisonline.com/portal/home/item.html?id=b4565e0a4e4c4a4382914128f10864cd")!
-        let map = Map(url: url)!
-        
-        // Enables full resolution feature tiling to improve snapping accuracy.
-        map.loadSettings.featureTilingMode = .enabledWithFullResolutionWhenSupported
-        
-        let initialExtent = Envelope(xRange: -9812750 ... -9812387, yRange: 5131332 ... 5131965)
-        map.initialViewpoint = Viewpoint(boundingGeometry: initialExtent)
-        
-        return map
-    }()
+    @State private var map = Map()
     /// The point on the screen where the user tapped.
     @State private var tapPoint: CGPoint?
     
@@ -99,6 +88,15 @@ struct ExampleMapView: View {
     
     /// Sets up the map.
     private func setUp() async throws {
+        let url = URL(string: "https://sampleserver7.arcgisonline.com/portal/home/item.html?id=b4565e0a4e4c4a4382914128f10864cd")!
+        let map = Map(url: url)!
+        
+        // Enables full resolution feature tiling to improve snapping accuracy.
+        map.loadSettings.featureTilingMode = .enabledWithFullResolutionWhenSupported
+        
+        let initialExtent = Envelope(xRange: -9812750 ... -9812387, yRange: 5131332 ... 5131965)
+        map.initialViewpoint = Viewpoint(boundingGeometry: initialExtent)
+        
         // Note: Never hardcode login information in a production application.
         // This is done solely for the sake of the example.
         let credential = try await TokenCredential.credential(
@@ -107,6 +105,8 @@ struct ExampleMapView: View {
             password: "I68VGU^nMurF"
         )
         ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(credential)
-        try await map.retryLoad()
+        try await map.load()
+        
+        self.map = map
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a `FeatureEditorExample` bug where an authentication error would print in the console when opening the `ExampleMapView`, even though authentication was successful.
- Closes `swift/issues/8545`


## How To Test

- Run the `FeatureEditorExample` project, tap "Open Map View", and ensure this error is not printed in the console:

    ```
    An ArcGIS authentication error occurred when accessing 'sampleserver7.arcgisonline.com'. An API key or credential may be required. For more information see 'https://developers.arcgis.com/swift/security-and-authentication'.
    ```
- Ensure the example still otherwise works as expected.