### PR TITLE
`FeatureFormView` - Fix test case 14.1

### DIFF
--- a/Test Runner/UI Tests/FeatureFormViewTests.swift
+++ b/Test Runner/UI Tests/FeatureFormViewTests.swift
@@ -2430,19 +2430,17 @@ private extension XCUIApplication {
     /// - Parameter text: The title of the form element to filter with.
     func filterElements(_ text: String) {
         filterElementsField.assertExistenceAndTap()
-        
 #if targetEnvironment(macCatalyst)
         let hasCurrentValue = !(filterElementsField.stringValue?.isEmpty ?? true)
 #else
         let hasCurrentValue = filterElementsField.stringValue != filterElementsField.placeholderValue
 #endif
-        
         if hasCurrentValue {
             clearElementFilter()
             filterElementsField.assertExistenceAndTap()
         }
-        
         filterElementsField.typeText(text)
+        filterElementsField.typeText("\n")
     }
 }
 


### PR DESCRIPTION
Test run 5092

Fixes FFV test case 14.1 which was working reliably up until Aug 18 when we started seeing another keyboard key being pressed at a certain step, causing the remainder of the test to fail. This repairs the test by explicitly closing the keyboard after the full element title has been keyed in.

I have no viable explanation as to what triggered this sudden change in behavior.

See discussion in swift-testing from Aug 24 for more context.