### PR TITLE
Improve Google VPS localization guidance

### DIFF
--- a/CustomVPSProviderExample/CustomVPSProviderExample/CustomVPSProviderExampleView.swift
+++ b/CustomVPSProviderExample/CustomVPSProviderExample/CustomVPSProviderExampleView.swift
@@ -57,6 +57,17 @@ struct CustomVPSProviderExampleView: View {
                         SceneView(scene: scene)
                     }
                     .calibrationViewHidden(true)
+                    .safeAreaInset(edge: .top) {
+                        Label(
+                            provider.statusMessage,
+                            systemImage: provider.hasBlockingError
+                                ? "exclamationmark.triangle"
+                                : "location.viewfinder"
+                        )
+                        .padding(.horizontal)
+                        .padding(.vertical, 8)
+                        .background(.regularMaterial, in: .capsule)
+                    }
                     .toolbar {
                         ToolbarItem(placement: .bottomBar) {
                             Toggle("Show Buildings", isOn: $streetscapeGeometryEnabled)

--- a/CustomVPSProviderExample/CustomVPSProviderExample/CustomWorldTracking.swift
+++ b/CustomVPSProviderExample/CustomVPSProviderExample/CustomWorldTracking.swift
@@ -17,32 +17,49 @@ import ArcGISToolkit
 import ARCore
 import ARCoreGeospatial
 import ARKit
+import CoreLocation
+import Observation
 import os
 import RealityKit
 
 /// A world-tracking provider backed by the Google ARCore SDK.
-final class CustomWorldTracking {
-    @MainActor let arSessionProvider = ARSessionProvider<ARView>()
+@MainActor
+@Observable
+final class CustomWorldTracking: NSObject {
+    let arSessionProvider = ARSessionProvider<ARView>()
     /// The ARCore session that produces geospatial and streetscape updates.
     let garSession: GARSession
     /// The root world origin anchor for all generated streetscape content.
-    @MainActor let worldOrigin = AnchorEntity(world: matrix_identity_float4x4)
+    let worldOrigin = AnchorEntity(world: matrix_identity_float4x4)
     /// A cache of generated streetscape models keyed by ARCore geometry
     /// identifier.
-    var streetscapeGeometryModels: [UUID: ModelEntity] = [:]
+    @ObservationIgnored var streetscapeGeometryModels: [UUID: ModelEntity] = [:]
+    /// Guidance or failure information for the current localization state.
+    private(set) var statusMessage = "Starting Google VPS…"
+    /// A Boolean value indicating whether an unrecoverable issue prevents
+    /// localization.
+    private(set) var hasBlockingError = false
+    
+    /// The location manager retained for the asynchronous authorization and
+    /// VPS availability flow.
+    private let locationManager = CLLocationManager()
+    /// A Boolean value indicating whether the ARCore session is ready for
+    /// frame updates.
+    @ObservationIgnored private(set) var isGARSessionConfigured = false
     
     /// Creates an instance with the given API key and bundle identifier.
     /// - Parameters:
     ///   - apiKey: An API key for Google Cloud Services.
     ///   - bundleIdentifier: The bundle identifier associated to the API key.
     ///   If `nil`, defaults to `Bundle.main.bundleIdentifier`.
-    @MainActor
     init(apiKey: String, bundleIdentifier: String? = nil) throws {
         garSession = try GARSession(apiKey: apiKey, bundleIdentifier: bundleIdentifier)
+        super.init()
+        locationManager.delegate = self
     }
 }
 
-extension CustomWorldTracking: WorldTrackingProvider {
+extension CustomWorldTracking: @MainActor WorldTrackingProvider {
     typealias CameraFeedView = CustomWorldTrackingCameraFeedView
     
     var arConfiguration: ARConfiguration {
@@ -58,35 +75,128 @@ extension CustomWorldTracking: WorldTrackingProvider {
             setProjectionEngineDirectoryURL()
         }
         
-        let locationManager = CLLocationManager()
-        if locationManager.authorizationStatus == .notDetermined {
-            locationManager.requestWhenInUseAuthorization()
-        }
-        
-        guard locationManager.authorizationStatus == .authorizedWhenInUse else {
-            return
-        }
-        
         runARSession()
         arSessionProvider.scene.addAnchor(worldOrigin)
-        setupGARSession()
+        updateLocationAuthorization()
     }
     
     func stop() {
         pauseARSession()
+        locationManager.stopUpdatingLocation()
+    }
+    
+    func reset() {
+        updateStatus("Localizing with Google VPS…")
+        runARSession(options: .resetTracking)
+    }
+}
+
+extension CustomWorldTracking: @MainActor CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        updateLocationAuthorization()
+    }
+    
+    func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]
+    ) {
+        guard let coordinate = locations.last?.coordinate else { return }
+        manager.stopUpdatingLocation()
+        garSession.checkVPSAvailability(coordinate: coordinate) { availability in
+            Task { @MainActor in
+                if availability != .available {
+                    self.updateStatus(
+                        "Google VPS is unavailable at the current location.",
+                        isBlocking: true
+                    )
+                }
+            }
+        }
+    }
+    
+    func locationManager(
+        _ manager: CLLocationManager,
+        didFailWithError error: any Error
+    ) {
+        Logger.customVPSProviderExample.error(
+            "Location request failed: \(error.localizedDescription)"
+        )
+        updateStatus(
+            "Google VPS could not determine the current location.",
+            isBlocking: true
+        )
     }
 }
 
 extension CustomWorldTracking {
+    /// Updates the user-facing localization status.
+    /// - Parameters:
+    ///   - message: The guidance or error to display.
+    ///   - isBlocking: A Boolean value indicating whether localization cannot
+    ///   continue without user action.
+    func updateStatus(_ message: String, isBlocking: Bool = false) {
+        statusMessage = message
+        hasBlockingError = isBlocking
+    }
+    
+    /// Updates ARCore setup in response to location authorization.
+    private func updateLocationAuthorization() {
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            guard locationManager.accuracyAuthorization == .fullAccuracy else {
+                updateStatus(
+                    "Google VPS requires Precise Location.",
+                    isBlocking: true
+                )
+                return
+            }
+            setupGARSession()
+            guard isGARSessionConfigured else { return }
+            updateStatus("Point the camera at nearby buildings and signs.")
+            locationManager.requestLocation()
+        case .notDetermined:
+            updateStatus("Allow location access to use Google VPS.")
+            locationManager.requestWhenInUseAuthorization()
+        case .denied, .restricted:
+            updateStatus(
+                "Google VPS requires location permission.",
+                isBlocking: true
+            )
+        @unknown default:
+            updateStatus(
+                "Google VPS could not determine location authorization.",
+                isBlocking: true
+            )
+        }
+    }
+    
     /// Configures the ARCore session.
     private func setupGARSession() {
-        guard garSession.isGeospatialModeSupported(.enabled) else { return }
+        guard !isGARSessionConfigured else { return }
+        guard garSession.isGeospatialModeSupported(.enabled) else {
+            updateStatus(
+                "Google geospatial tracking is unsupported on this device.",
+                isBlocking: true
+            )
+            return
+        }
         
         let configuration = GARSessionConfiguration()
         configuration.geospatialMode = .enabled
         configuration.streetscapeGeometryMode = .enabled
         var error: NSError?
         garSession.setConfiguration(configuration, error: &error)
+        if let error {
+            Logger.customVPSProviderExample.error(
+                "ARCore configuration failed: \(error.localizedDescription)"
+            )
+            updateStatus(
+                "Google VPS could not be configured.",
+                isBlocking: true
+            )
+        } else {
+            isGARSessionConfigured = true
+        }
     }
 }
 

--- a/CustomVPSProviderExample/CustomVPSProviderExample/CustomWorldTrackingCameraFeedView.swift
+++ b/CustomVPSProviderExample/CustomVPSProviderExample/CustomWorldTrackingCameraFeedView.swift
@@ -24,6 +24,17 @@ import SwiftUI
 /// Displays the AR camera feed and updates world-scale camera state using
 /// Google geospatial tracking.
 struct CustomWorldTrackingCameraFeedView: View {
+    // These thresholds match Google's ARCore Geospatial example:
+    // https://github.com/google-ar/arcore-ios-sdk/blob/5aa221f8e9a516643fcc7b080c565f22b20ab57c/Examples/GeospatialExample/GeospatialExample/GeospatialManager.swift#L43-L53
+    /// Accuracy required to initially consider the device localized.
+    private static let localizedHorizontalAccuracy = 10.0
+    /// Yaw accuracy required to initially consider the device localized.
+    private static let localizedYawAccuracy = 15.0
+    /// Accuracy at which an already-localized device loses localization.
+    private static let retainedHorizontalAccuracy = 20.0
+    /// Yaw accuracy at which an already-localized device loses localization.
+    private static let retainedYawAccuracy = 25.0
+    
     /// Shared world-scale context used to read provider state and update the
     /// scene.
     let context: WorldScaleSceneView<CustomWorldTracking>.Context
@@ -46,13 +57,16 @@ struct CustomWorldTrackingCameraFeedView: View {
     var body: some View {
         SwiftUIARView(sessionProvider: context.provider.arSessionProvider)
             .onDidUpdateFrame { _, frame in
-                guard let interfaceOrientation,
+                guard context.provider.isGARSessionConfigured,
+                      !context.provider.hasBlockingError,
+                      let interfaceOrientation,
                       let garFrame = try? context.provider.garSession.update(frame),
                       let earth = garFrame.earth else {
                     return
                 }
                 
                 let camera = frame.camera
+                updateLocalizationState(for: earth)
                 
                 if context.isLocalized {
                     updateCameraController(
@@ -68,8 +82,6 @@ struct CustomWorldTrackingCameraFeedView: View {
                     if streetscapeGeometryEnabled {
                         updateStreetscapeGeometry(using: garFrame.streetscapeGeometries ?? [])
                     }
-                } else {
-                    updateLocalizationState(for: earth.trackingState)
                 }
             }
             .onCameraDidChangeTrackingState { _, trackingState in
@@ -82,11 +94,41 @@ struct CustomWorldTrackingCameraFeedView: View {
             }
     }
     
-    /// Updates the localization based on the given tracking state.
-    /// - Parameter trackingState: The ARCore frame tracking state.
-    func updateLocalizationState(for trackingState: GARTrackingState?) {
-        guard trackingState == .tracking else { return }
-        context.isLocalized = true
+    /// Updates localization using ARCore Earth state and geospatial accuracy.
+    /// - Parameter earth: The ARCore Earth state for the current frame.
+    func updateLocalizationState(for earth: GAREarth) {
+        guard earth.earthState == .enabled else {
+            context.isLocalized = false
+            context.provider.updateStatus(
+                "Google Earth localization is unavailable.",
+                isBlocking: true
+            )
+            return
+        }
+        
+        guard earth.trackingState == .tracking,
+              let transform = earth.cameraGeospatialTransform else {
+            context.isLocalized = false
+            context.provider.updateStatus(
+                "Point the camera at nearby buildings and signs."
+            )
+            return
+        }
+        
+        let isAccurate = if context.isLocalized {
+            transform.horizontalAccuracy < Self.retainedHorizontalAccuracy
+                && transform.orientationYawAccuracy < Self.retainedYawAccuracy
+        } else {
+            transform.horizontalAccuracy < Self.localizedHorizontalAccuracy
+                && transform.orientationYawAccuracy < Self.localizedYawAccuracy
+        }
+        
+        context.isLocalized = isAccurate
+        context.provider.updateStatus(
+            isAccurate
+                ? "Localization complete."
+                : "Improving Google VPS accuracy…"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Improve the Google-backed custom VPS example so it does not treat ARCore's basic tracking state as sufficient geospatial localization.

- retain `CLLocationManager` for the complete asynchronous authorization flow
- require Precise Location before configuring ARCore Geospatial
- check VPS availability at the device's current coordinate
- require horizontal and yaw accuracy thresholds before revealing ArcGIS scene content
- use wider thresholds after localization to prevent rapid localized/unlocalized flicker
- surface permission, support, configuration, availability, and localization states in the example UI
- preserve the existing streetscape geometry configuration and toggle

## Why these changes are needed

### Location authorization is asynchronous

The existing example creates a local `CLLocationManager`, requests permission, and immediately checks its authorization status. The permission result arrives asynchronously, and the temporary manager is not retained to receive delegate callbacks. On a first run, `start()` therefore returns before ARCore is configured and has no path that resumes setup after the user grants access.

Retaining the manager and handling `locationManagerDidChangeAuthorization(_:)` allows setup to continue after the authorization prompt and also responds to later permission changes.

### Google VPS requires precise location

ARCore Geospatial requires location permission with full accuracy. Checking only `.authorizedWhenInUse` can allow setup to proceed with reduced accuracy, where localization cannot meet the accuracy expected by the example. The updated flow accepts both authorized states and explicitly reports when Precise Location is disabled.

### ARCore tracking is not the same as accurate geospatial localization

`GARTrackingState.tracking` indicates that Earth tracking is active, but it does not guarantee that the camera's global position and orientation are accurate enough to align ArcGIS content. Revealing the scene immediately can place content at a visibly incorrect position or heading.

Following Google's Geospatial sample, initial localization now requires:

- horizontal accuracy below 10 meters
- orientation yaw accuracy below 15 degrees

Once localized, the example retains that state until accuracy exceeds 20 meters or 25 degrees. This hysteresis avoids flickering when measurements hover around the initial threshold.

### VPS availability and failures need visible feedback

VPS coverage varies by location, and ARCore configuration can also fail because of permissions, unsupported devices, invalid authorization, or service errors. Previously these conditions either returned silently or left the camera running without explaining why scene content never appeared.

The example now checks `checkVPSAvailability(coordinate:)` and presents concise guidance or blocking errors over the camera feed. This makes the sample diagnosable and demonstrates the status handling an integrating application needs.

## Scope

This keeps the provider implementation directly in `CustomVPSProviderExample` so the integration remains easy to study. Streetscape geometry remains enabled and its existing **Show Buildings** toggle is unchanged.

## Validation

- Built the `CustomVPSProviderExample` scheme for a generic iOS Simulator destination.
- Ran the example target's existing SwiftLint build phase without violations.

## Commit breakdown

1. [`19981b65d`](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/commit/19981b65d) **Harden Google VPS provider setup** — Retains `CLLocationManager` for asynchronous authorization, requires Precise Location, checks VPS availability, and reports unsupported or failed provider setup.
2. [`d5194a7c1`](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/commit/d5194a7c1) **Require accurate Google VPS localization** — Requires horizontal and yaw accuracy before revealing scene content and adds wider retention thresholds to prevent localization flicker.
3. [`087ad9cb7`](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit/commit/087ad9cb7) **Display Google VPS localization status** — Presents actionable tracking guidance and blocking failures over the camera feed.

## Source for accuracy thresholds

The 10 m / 15° initial-localization thresholds and 20 m / 25° loss-of-localization thresholds come directly from [Google’s ARCore Geospatial example](https://github.com/google-ar/arcore-ios-sdk/blob/5aa221f8e9a516643fcc7b080c565f22b20ab57c/Examples/GeospatialExample/GeospatialExample/GeospatialManager.swift#L43-L53). The link is pinned to the ARCore 1.54.0 revision used by this example so the cited values cannot drift with `main`.