### PR TITLE
`FeatureEditor`: Fix handle edit buttons visibility

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -43,12 +43,21 @@ struct FeatureEditorFormView: View {
     /// non-`nil` only when there are edits, so the `FeatureFormView`
     /// knows when to show the editing buttons and block navigation.
     private var saveGeometryEditsAction: (() throws -> Void)? {
-        guard model.geometryEditorCanUndo else { return nil }
+        let initialGeometry = model.initialGeometry
+        let currentGeometry = model.geometryEditorGeometry
+        let geometryIsUnchanged = currentGeometry == initialGeometry
+        // This is needed because the geometry editor starts with an empty
+        // geometry when initialGeometry is nil, which causes
+        // geometryIsUnchanged to be false even though no edits have been made.
+        let startedWithGeometryType = initialGeometry == nil && currentGeometry?.isEmpty == true
+        
+        guard !geometryIsUnchanged, !startedWithGeometryType else { return nil }
+        
         return {
-            guard let geometry = model.geometryEditorGeometry, geometry.sketchIsValid else {
+            guard let currentGeometry, currentGeometry.sketchIsValid else {
                 throw GeometryEditorError.invalidGeometry
             }
-            model.feature?.geometry = geometry
+            model.feature?.geometry = currentGeometry
         }
     }
     

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorFormView.swift
@@ -44,17 +44,15 @@ struct FeatureEditorFormView: View {
     /// knows when to show the editing buttons and block navigation.
     private var saveGeometryEditsAction: (() throws -> Void)? {
         let initialGeometry = model.initialGeometry
-        let currentGeometry = model.geometryEditorGeometry
-        let geometryIsUnchanged = currentGeometry == initialGeometry
-        // This is needed because the geometry editor starts with an empty
-        // geometry when initialGeometry is nil, which causes
-        // geometryIsUnchanged to be false even though no edits have been made.
-        let startedWithGeometryType = initialGeometry == nil && currentGeometry?.isEmpty == true
-        
-        guard !geometryIsUnchanged, !startedWithGeometryType else { return nil }
+        guard model.geometryEditorIsStarted,
+              let currentGeometry = model.geometryEditorGeometry,
+              currentGeometry != initialGeometry,
+              initialGeometry != nil || !currentGeometry.isEmpty else {
+            return nil
+        }
         
         return {
-            guard let currentGeometry, currentGeometry.sketchIsValid else {
+            guard currentGeometry.sketchIsValid else {
                 throw GeometryEditorError.invalidGeometry
             }
             model.feature?.geometry = currentGeometry

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -42,10 +42,8 @@ final class FeatureEditorModel {
     var feature: ArcGISFeature? {
         presentedFeatureForm?.feature ?? rootFeatureForm?.feature
     }
-    /// The geometry of the `feature` before editing, used to reset the
-    /// geometry when edits are discarded.
-    @ObservationIgnored
-    private var initialGeometry: Geometry?
+    /// The geometry of the `feature` before editing.
+    private(set) var initialGeometry: Geometry?
     /// A Boolean value that indicates whether the Feature Editor inspector is presented.
     var isPresented: Bool {
         get { state != .stopped }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -208,7 +208,6 @@ final class FeatureEditorModel {
     /// This is needed to prevent the current state from interfering with
     /// future uses of the `FeatureEditor` view.
     private func resetProperties() {
-        initialGeometry = nil
         rootFeatureForm = nil
         presentedFeatureForm = nil
         snapSettingsSheetIsPresented = false
@@ -318,5 +317,6 @@ final class FeatureEditorModel {
         geometryEditorCanUndo = false
         geometryEditorGeometry = nil
         geometryEditorIsStarted = false
+        initialGeometry = nil
     }
 }

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -247,6 +247,7 @@ struct FeatureEditorModelTests {
         let modelGeometry = try #require(model.geometryEditorGeometry)
         #expect(modelGeometry is Point)
         #expect(modelGeometry.isEmpty)
+        #expect(model.initialGeometry == nil)
         #expect(model.viewpointGeometry == nil)
     }
     
@@ -316,6 +317,7 @@ private extension FeatureEditorModel {
     func expectDefaultPropertyValues(sourceLocation: SourceLocation = #_sourceLocation) async {
         #expect(state == .stopped, sourceLocation: sourceLocation)
         #expect(feature == nil, sourceLocation: sourceLocation)
+        #expect(initialGeometry == nil, sourceLocation: sourceLocation)
         #expect(!isPresented, sourceLocation: sourceLocation)
         #expect(rootFeatureForm == nil, sourceLocation: sourceLocation)
         #expect(loadResult == nil, sourceLocation: sourceLocation)
@@ -350,6 +352,7 @@ private extension FeatureEditorModel {
             self.geometryEditorGeometry == geometry,
             sourceLocation: sourceLocation
         )
+        #expect(initialGeometry == geometry, sourceLocation: sourceLocation)
         
         // The geometry is used to set the viewpoint.
         #expect(viewpointGeometry == geometry, sourceLocation: sourceLocation)


### PR DESCRIPTION
## Description

This PR fixes a Feature Editor bug where the `FeatureFormView` handle-edit buttons would show when the current geometry matched the feature's initial geometry (i.e, there are no edits to handle) if the geometry editor could undo.
Closes `swift/issues/8543`.


## How To Test

- Run `FeatureEditorExample`, tap on a feature to edit, and make geometry edits that result in the feature's initial geometry and an undo stack. (See example workflow in the GIFs below.) 
- Ensure `FeatureEditorModelTests` still pass. 


## Screenshots

|Before|After|
|:-:|:-:|
| <img width="275" height="597" alt="d7d2b222-b71d-4520-bc9c-93b44d7e7eff" src="https://github.com/user-attachments/assets/025c7199-35ee-4a36-b359-8fcddf8221fb" /> | <img width="275" height="597" alt="SimulatorScreenRecording-iPhone17Pro-2026-08-31at16 22 30-ezgif com-resize" src="https://github.com/user-attachments/assets/28ce862f-34c0-48d4-b98c-c388885bd2d3" /> |





