### PR TITLE
`FeatureEditor`: Use `ServiceGeodatabase.utilityNetwork` for creating snap rules

### DIFF
--- a/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
+++ b/FeatureEditorExample/FeatureEditorExample/ExampleMapView.swift
@@ -74,7 +74,6 @@ struct ExampleMapView: View {
                         FeatureEditor(
                             $featureToEdit,
                             geometryEditor: geometryEditor,
-                            map: map,
                             mapViewProxy: mapViewProxy
                         )
                         .padding()

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditor.swift
@@ -57,8 +57,6 @@ public struct FeatureEditor: View {
     @Binding private var feature: ArcGISFeature?
     /// A geometry editor used to edit the feature's geometry on an associated `MapView`.
     private let geometryEditor: GeometryEditor
-    /// The map that `feature` is part of, used to set up rule-based snapping.
-    private let map: Map?
     /// A proxy for performing map view operations.
     private let mapViewProxy: MapViewProxy?
     /// The style to apply to the toolbar's controls.
@@ -73,10 +71,6 @@ public struct FeatureEditor: View {
     ///   The Feature Editor is displayed when the value is non-`nil`.
     ///   - geometryEditor: A geometry editor used to edit the feature's
     ///   geometry on an associated `MapView`.
-    ///   - map: The map that `feature` is part of, used to set up rule-based
-    ///   snapping for the geometry editor. If `nil` is passed, or the feature
-    ///   is not part of a utility network contained in the map, snapping is
-    ///   set up without snap rules.
     ///   - mapViewProxy: A proxy used to set the viewpoint on an associated
     ///   `MapView`.
     ///   - toolbarStyle: The style that determines the toolbar's appearance and
@@ -86,22 +80,13 @@ public struct FeatureEditor: View {
     public init(
         _ feature: Binding<ArcGISFeature?>,
         geometryEditor: GeometryEditor,
-        map: Map?,
         mapViewProxy: MapViewProxy? = nil,
         toolbarStyle: ToolbarStyle? = .vertical
     ) {
         self._feature = feature
         self.geometryEditor = geometryEditor
-        self.map = map
         self.mapViewProxy = mapViewProxy
         self.toolbarStyle = toolbarStyle
-    }
-    
-    /// A collection of object ids used to determine when to start editing.
-    /// This updates when the `feature` or `map` instances change.
-    private var startEditingIDs: [ObjectIdentifier] {
-        let objects: [AnyObject?] = [feature, map]
-        return objects.compactMap { $0.map(ObjectIdentifier.init) }
     }
     
     public var body: some View {
@@ -111,9 +96,9 @@ public struct FeatureEditor: View {
                 await model.restartGeometryEditor()
                 await model.monitorGeometryEditorStreams()
             }
-            .task(id: startEditingIDs) {
+            .task(id: feature.map(ObjectIdentifier.init)) {
                 if let feature {
-                    await model.startEditingFeature(feature, on: map)
+                    await model.startEditingFeature(feature)
                 } else {
                     model.stopEditing()
                 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -76,23 +76,10 @@ final class FeatureEditorModel {
     private(set) var geometryEditorGeometry: Geometry?
     /// A Boolean value indicating whether the geometry editor has started.
     private(set) var geometryEditorIsStarted = false
-    
-    // MARK: Snapping Properties
-    
-    /// The map that contains the utility network being edited.
-    @ObservationIgnored
-    private var map: Map?
     /// The snap rules for the `feature`, used to sync snap source settings.
-    /// This is non-`nil` when snap rules were successfully created using the `utilityNetwork`.
+    /// These are created from the feature's utility network, if available.
     @ObservationIgnored
     private var snapRules: SnapRules?
-    /// The `feature`'s utility network used to create snap rules.
-    /// This is non-`nil` when a map containing the feature's UN is used to start editing.
-    private var utilityNetwork: UtilityNetwork? {
-        guard let map, let feature else { return nil }
-        return map.utilityNetworks
-            .first(where: { $0.makeElement(arcGISFeature: feature) != nil })
-    }
     
     // MARK: Methods
     
@@ -151,47 +138,23 @@ final class FeatureEditorModel {
     func startEditingFeatureForm(_ featureForm: FeatureForm) async {
         stopGeometryEditing()
         presentedFeatureForm = featureForm
-        
-        loadResult = await Result {
-            try await loadFeature()
-            try await setUpGeometryEditing()
-        }
+        await setUpGeometryEditing()
     }
     
     /// Starts an editing session for the given `feature`.
-    /// - Parameters:
-    ///   - feature: The root feature to edit.
-    ///   - map: The map that `feature` is part of, used to set up rule-based snapping.
-    func startEditingFeature(_ feature: ArcGISFeature, on map: Map?) async {
+    /// - Parameter feature: The root feature to edit.
+    func startEditingFeature(_ feature: ArcGISFeature) async {
         state = .editing
         resetProperties()
         rootFeatureForm = FeatureForm(feature: feature)
-        self.map = map
-        loadResult = await Result {
-            try await loadFeature()
-            if let map {
-                // When a map is provided, it implies the user wants to set up
-                // rule-based snapping for the geometry editor. Loads the
-                // utility network so snap rules can be created.
-                try await map.load()
-                await map.utilityNetworks.load()
-            }
-            try await setUpGeometryEditing()
-        }
+        await setUpGeometryEditing()
     }
     
     /// Retries starting an editing session.
     func retryStartEditing() async {
         // Makes sure the previous load failed and sets the loadResult to nil.
         guard case .failure = loadResult.take() else { return }
-        loadResult = await Result { [weak map] in
-            try await loadFeature()
-            if let map {
-                try await map.retryLoad()
-                await map.utilityNetworks.retryLoad()
-            }
-            try await setUpGeometryEditing()
-        }
+        await setUpGeometryEditing()
     }
     
     /// Stops the feature editor and resets the model's properties.
@@ -215,8 +178,6 @@ final class FeatureEditorModel {
         
         stopGeometryEditing()
         
-        snapRules = nil
-        map = nil
         loadResult = nil
     }
     
@@ -226,7 +187,10 @@ final class FeatureEditorModel {
             let snapSettings = geometryEditor.snapSettings
             
             if let snapRules {
-                try snapSettings.syncSourceSettings(rules: snapRules, sourceEnablingBehavior: .preserve)
+                try snapSettings.syncSourceSettings(
+                    rules: snapRules,
+                    sourceEnablingBehavior: .preserve
+                )
             } else {
                 try snapSettings.syncSourceSettings()
             }
@@ -252,23 +216,6 @@ final class FeatureEditorModel {
         try await setFormGeometry(to: geometry)
     }
     
-    /// Loads the feature and its table if needed to allow geometry editing.
-    private func loadFeature() async throws {
-        guard let feature else { return }
-        // Loads the feature so canUpdateGeometry can be accessed. It is always
-        // false otherwise.
-        try await feature.retryLoad()
-        // No need to load the feature's table upfront if we don't edit its
-        // geometry.
-        guard feature.canUpdateGeometry else { return }
-        
-        // Loads the feature's table if the geometry is nil so geometryType
-        // can be accessed. It is always nil otherwise.
-        if feature.geometry == nil, let table = feature.table {
-            try await table.retryLoad()
-        }
-    }
-    
     /// Sets the form's feature geometry and reevaluates expressions to update
     /// possible geometry-dependent form elements.
     /// - Parameter geometry: The new geometry to set on the feature.
@@ -283,19 +230,73 @@ final class FeatureEditorModel {
     }
     
     /// Performs setup needed for geometry editing and starts the geometry editor if applicable.
-    private func setUpGeometryEditing() async throws {
-        guard let feature, feature.canUpdateGeometry else { return }
-        // Sets up the snap rules and syncs the snap source settings.
-        if let utilityNetwork, let element = utilityNetwork.makeElement(arcGISFeature: feature) {
-            // Errors are ignored to set snapRules to nil if creation fails, so
-            // the old rules don't get used in future syncing.
-            snapRules = try? await .rules(for: utilityNetwork, assetType: element.assetType)
-        } else {
-            snapRules = nil
+    private func setUpGeometryEditing() async {
+        loadResult = await Result { @MainActor in
+            guard let feature else { return }
+            
+            // Loads the feature so canUpdateGeometry can be accessed. It is always
+            // false otherwise.
+            try await feature.retryLoad()
+            guard feature.canUpdateGeometry else { return }
+            
+            snapRules = try await makeSnapRules(for: feature)
+            syncSnapSourceSettings()
+            
+            startGeometryEditor()
         }
-        syncSnapSourceSettings()
+    }
+    
+    /// Creates snap rules created from the given feature's utility network, if available.
+    /// - Parameter feature: The feature to create snap rules for.
+    private func makeSnapRules(for feature: ArcGISFeature) async throws -> SnapRules? {
+        guard let featureTable = feature.table else { return nil }
+        try await featureTable.retryLoad()
         
-        startGeometryEditor()
+        if let serviceFeatureTable = featureTable as? ServiceFeatureTable,
+           let serviceGeodatabase = serviceFeatureTable.serviceGeodatabase {
+            try await serviceGeodatabase.retryLoad()
+            
+            guard let utilityNetwork = serviceGeodatabase.utilityNetwork else { return nil }
+            try await utilityNetwork.retryLoad()
+            
+            if let element = utilityNetwork.makeElement(arcGISFeature: feature) {
+                return try await .rules(for: utilityNetwork, assetType: element.assetType)
+            } else {
+                return try await .rules(
+                    for: utilityNetwork,
+                    featureTable: featureTable,
+                    attributes: feature.attributes
+                )
+            }
+        } else if let geodatabaseFeatureTable = feature.table as? GeodatabaseFeatureTable,
+                  let geodatabase = geodatabaseFeatureTable.geodatabase {
+            try await geodatabase.retryLoad()
+            
+            let utilityNetworks = geodatabase.utilityNetworks
+            await utilityNetworks.retryLoad()
+            
+            for utilityNetwork in utilityNetworks {
+                if let element = utilityNetwork.makeElement(arcGISFeature: feature) {
+                    return try await .rules(for: utilityNetwork, assetType: element.assetType)
+                }
+            }
+            
+            if let utilityNetwork = utilityNetworks.first(
+                where: { utilityNetwork in
+                    utilityNetwork.definition?.networkSources.contains(
+                        where: { $0.featureTable.tableName == featureTable.tableName }
+                    ) ?? false
+                }
+            ) {
+                return try await .rules(
+                    for: utilityNetwork,
+                    featureTable: featureTable,
+                    attributes: feature.attributes
+                )
+            }
+        }
+        
+        return nil
     }
     
     /// Starts the geometry editor using the `feature`.
@@ -318,5 +319,6 @@ final class FeatureEditorModel {
         geometryEditorGeometry = nil
         geometryEditorIsStarted = false
         initialGeometry = nil
+        snapRules = nil
     }
 }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -246,7 +246,7 @@ final class FeatureEditorModel {
         }
     }
     
-    /// Creates snap rules created from the given feature's utility network, if available.
+    /// Creates snap rules from the given feature's utility network, if available.
     /// - Parameter feature: The feature to create snap rules for.
     private func makeSnapRules(for feature: ArcGISFeature) async throws -> SnapRules? {
         guard let featureTable = feature.table else { return nil }

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -259,10 +259,10 @@ final class FeatureEditorModel {
             guard let utilityNetwork = serviceGeodatabase.utilityNetwork else { return nil }
             try await utilityNetwork.retryLoad()
             
-            if let element = utilityNetwork.makeElement(arcGISFeature: feature) {
-                return try await .rules(for: utilityNetwork, assetType: element.assetType)
+            return if let element = utilityNetwork.makeElement(arcGISFeature: feature) {
+                try await .rules(for: utilityNetwork, assetType: element.assetType)
             } else {
-                return try await .rules(
+                try await .rules(
                     for: utilityNetwork,
                     featureTable: featureTable,
                     attributes: feature.attributes

--- a/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
@@ -33,7 +33,6 @@ struct FeatureEditorTestView: View {
                 FeatureEditor(
                     $featureToEdit,
                     geometryEditor: geometryEditor,
-                    map: map
                 )
                 .padding()
             }

--- a/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
+++ b/Test Runner/Test Runner/TestViews/FeatureEditorTestView.swift
@@ -30,11 +30,8 @@ struct FeatureEditorTestView: View {
         MapView(map: map)
             .geometryEditor(geometryEditor)
             .overlay(alignment: .topTrailing) {
-                FeatureEditor(
-                    $featureToEdit,
-                    geometryEditor: geometryEditor,
-                )
-                .padding()
+                FeatureEditor($featureToEdit, geometryEditor: geometryEditor)
+                    .padding()
             }
             .task(setUpTest)
             .alert("Error", isPresented: .init(optionalValue: $errorDescription), actions: {}) {

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -205,7 +205,7 @@ struct FeatureEditorModelTests {
         let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         
-        // Verifies startEditingFeature(_:) starts the feature editor and geometry editor.
+        // Verifies 'startEditingFeature(_:)' starts the feature editor and geometry editor.
         do {
             let geometry = Point(latitude: 0, longitude: 0)
             let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -122,7 +122,7 @@ struct FeatureEditorModelTests {
             password: "I68VGU^nMurF"
         )
         ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(credential)
-        defer { ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll() }
+        defer { ArcGISEnvironment.authenticationManager.arcGISCredentialStore.remove(credential) }
         
         let serviceFeatureTable = ServiceFeatureTable(url: electricDistributionDeviceURL)
         try await serviceFeatureTable.load()
@@ -135,7 +135,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(features.first as? ArcGISFeature)
         
         // Removes the credential and verifies startEditingFeature doesn't start geometry editing.
-        ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll()
+        ArcGISEnvironment.authenticationManager.arcGISCredentialStore.remove(credential)
         await model.startEditingFeature(feature)
         
         let error = #expect(throws: ArcGISAuthenticationError.self) {

--- a/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
+++ b/Tests/ArcGISToolkitTests/FeatureEditorModelTests.swift
@@ -41,7 +41,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
         // Verifies isPresented is true when feature editor starts.
-        await model.startEditingFeature(feature, on: nil)
+        await model.startEditingFeature(feature)
         model.expectIsEditing(rootFeature: feature)
         
         await model.expectIsGeometryEditing()
@@ -91,7 +91,7 @@ struct FeatureEditorModelTests {
         let initialGeometry = Point(latitude: 0, longitude: 0)
         let feature = try #require(table.makeFeature(geometry: initialGeometry) as? ArcGISFeature)
         
-        await model.startEditingFeature(feature, on: nil)
+        await model.startEditingFeature(feature)
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: initialGeometry)
         
@@ -115,27 +115,45 @@ struct FeatureEditorModelTests {
         let monitorGeometryEditorStreamsTask = Task(operation: model.monitorGeometryEditorStreams)
         defer { monitorGeometryEditorStreamsTask.cancel() }
         
-        let geodatabaseFile = try await TemporaryGeodatabaseFile()
-        let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
-        let geometry = Point(latitude: 2, longitude: 2)
-        let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
-        let map = Map(spatialReference: nil)
+        let electricDistributionDeviceURL = URL(string: "https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/0")!
+        let credential = try await TokenCredential.credential(
+            for: electricDistributionDeviceURL,
+            username: "viewer01",
+            password: "I68VGU^nMurF"
+        )
+        ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(credential)
+        defer { ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll() }
         
-        // Simulates map fails to load by creating a map with nil spatial reference.
-        await model.startEditingFeature(feature, on: map)
-        let error = #expect(throws: MappingError.self) {
+        let serviceFeatureTable = ServiceFeatureTable(url: electricDistributionDeviceURL)
+        try await serviceFeatureTable.load()
+        
+        let parameters = QueryParameters()
+        parameters.addObjectID(3726)
+        
+        let result = try await serviceFeatureTable.queryFeatures(using: parameters)
+        let features = Array(result.features())
+        let feature = try #require(features.first as? ArcGISFeature)
+        
+        // Removes the credential and verifies startEditingFeature doesn't start geometry editing.
+        ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll()
+        await model.startEditingFeature(feature)
+        
+        let error = #expect(throws: ArcGISAuthenticationError.self) {
             try #require(model.loadResult).get()
         }
-        #expect(error == .missingSpatialReference(details: ""))
+        #expect(error == .tokenRequired)
+        
         await Task.yieldExpect(!model.geometryEditorIsStarted)
         await Task.yieldExpect(model.geometryEditorGeometry == nil)
         
-        // Sets the map's spatial reference to a valid value and retries starting the feature editor.
-        map.setSpatialReference(.wgs84)
+        // Re-adds the credential and verifies retry-start-editing starts geometry editing.
+        ArcGISEnvironment.authenticationManager.arcGISCredentialStore.add(credential)
         await model.retryStartEditing()
         
         try #require(model.loadResult).get()
         await model.expectIsGeometryEditing()
+        
+        let geometry = try #require(feature.geometry)
         await model.expectIsEditing(geometry: geometry)
     }
     
@@ -153,7 +171,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: initialGeometry) as? ArcGISFeature)
         #expect(feature.geometry == initialGeometry)
         
-        await model.startEditingFeature(feature, on: nil)
+        await model.startEditingFeature(feature)
         await model.expectIsGeometryEditing()
         
         // Verifies updateFormGeometry() resets the feature's geometry to its
@@ -176,7 +194,7 @@ struct FeatureEditorModelTests {
         #expect(feature.geometry == newGeometry)
     }
     
-    /// Verifies `startEditingFeature(_:on:)` and `startEditingFeatureForm(_:)` using
+    /// Verifies `startEditingFeature(_:)` and `startEditingFeatureForm(_:)` using
     /// features with geometries.
     @Test
     func startEditing() async throws {
@@ -187,22 +205,18 @@ struct FeatureEditorModelTests {
         let geodatabaseFile = try await TemporaryGeodatabaseFile()
         let table = try await geodatabaseFile.geodatabase.makeTable(description: .points)
         
-        // Verifies startEditingFeature(_:on:) starts the feature editor and geometry editor.
+        // Verifies startEditingFeature(_:) starts the feature editor and geometry editor.
         do {
             let geometry = Point(latitude: 0, longitude: 0)
             let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
-            let map = Map(spatialReference: .wgs84)
             
             // Verifies feature editor is started using the feature instance.
-            await model.startEditingFeature(feature, on: map)
+            await model.startEditingFeature(feature)
             model.expectIsEditing(rootFeature: feature)
             
             // Verifies geometry editor is started using the feature's geometry.
             await model.expectIsGeometryEditing()
             await model.expectIsEditing(geometry: geometry)
-            
-            // Verifies map is loaded when starting.
-            #expect(map.loadStatus == .loaded)
         }
         
         // Verifies startEditingFeatureForm(_:) updates the correct model properties.
@@ -226,7 +240,7 @@ struct FeatureEditorModelTests {
         }
     }
     
-    /// Verifies `startEditingFeature(_:on:)` using a feature without a geometry.
+    /// Verifies `startEditingFeature(_:)` using a feature without a geometry.
     @Test
     func startEditingFeatureWithoutGeometry() async throws {
         let model = FeatureEditorModel()
@@ -239,7 +253,7 @@ struct FeatureEditorModelTests {
         #expect(feature.geometry == nil)
         
         // Verifies feature editor and geometry editor are started.
-        await model.startEditingFeature(feature, on: nil)
+        await model.startEditingFeature(feature)
         model.expectIsEditing(rootFeature: feature)
         await model.expectIsGeometryEditing()
         
@@ -251,7 +265,7 @@ struct FeatureEditorModelTests {
         #expect(model.viewpointGeometry == nil)
     }
     
-    /// Verifies `startEditingFeature(_:on:)` using a non-spatial feature.
+    /// Verifies `startEditingFeature(_:)` using a non-spatial feature.
     @Test
     func startEditingNonSpatialFeature() async throws {
         let model = FeatureEditorModel()
@@ -267,7 +281,7 @@ struct FeatureEditorModelTests {
         #expect(!feature.canUpdateGeometry)
         
         // Verifies feature editor is started using the feature instance.
-        await model.startEditingFeature(feature, on: nil)
+        await model.startEditingFeature(feature)
         model.expectIsEditing(rootFeature: feature)
         
         // Geometry editor is not started.
@@ -291,7 +305,7 @@ struct FeatureEditorModelTests {
         let feature = try #require(table.makeFeature(geometry: geometry) as? ArcGISFeature)
         
         // Verifies feature editor and geometry editor are started.
-        await model.startEditingFeature(feature, on: nil)
+        await model.startEditingFeature(feature)
         model.expectIsEditing(rootFeature: feature)
         await model.expectIsGeometryEditing()
         await model.expectIsEditing(geometry: geometry)


### PR DESCRIPTION
### Description

This PR updates the Feature Editor to use the new `ServiceGeodatabase.utilityNetwork` property to create snap rules, removing the need for the map parameter. 
Closes `swift/issues/8562`.


### How To Test

- Update `Package.swift` to use `swift-daily` (`300.2.0-5075`+).
- Run `FeatureEditorExample`, tap on a feature to edit, and tap on the toolbar settings button to ensure snap settings are still synced with snap rules.  

