### PR TITLE
`FeatureEditor`: Hide feature during geometry editing

### DIFF
--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -43,7 +43,7 @@ final class FeatureEditorModel {
         presentedFeatureForm?.feature ?? rootFeatureForm?.feature
     }
     /// The feature hidden to prevent its symbol from conflicting with the geometry editor.
-    /// This is needed reset the feature's visibility after geometry editing stops.
+    /// This is needed to reset the feature's visibility after geometry editing stops.
     @ObservationIgnored
     private var hiddenFeature: ArcGISFeature?
     /// The geometry of the `feature` before editing.

--- a/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
+++ b/Sources/ArcGISToolkit/Components/FeatureEditor/FeatureEditorModel.swift
@@ -42,6 +42,10 @@ final class FeatureEditorModel {
     var feature: ArcGISFeature? {
         presentedFeatureForm?.feature ?? rootFeatureForm?.feature
     }
+    /// The feature hidden to prevent its symbol from conflicting with the geometry editor.
+    /// This is needed reset the feature's visibility after geometry editing stops.
+    @ObservationIgnored
+    private var hiddenFeature: ArcGISFeature?
     /// The geometry of the `feature` before editing.
     private(set) var initialGeometry: Geometry?
     /// A Boolean value that indicates whether the Feature Editor inspector is presented.
@@ -306,6 +310,11 @@ final class FeatureEditorModel {
         if let geometry = feature.geometry {
             geometryEditor.start(withInitial: geometry)
             viewpointGeometry = geometry
+            
+            if let featureLayer = feature.featureLayer {
+                featureLayer.setVisible(false, for: feature)
+                hiddenFeature = feature
+            }
         } else if let geometryType = feature.table?.geometryType {
             geometryEditor.start(withType: geometryType)
         }
@@ -320,5 +329,9 @@ final class FeatureEditorModel {
         geometryEditorIsStarted = false
         initialGeometry = nil
         snapRules = nil
+        
+        if let hiddenFeature = hiddenFeature.take(), let featureLayer = hiddenFeature.featureLayer {
+            featureLayer.setVisible(true, for: hiddenFeature)
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR updates the Feature Editor to hide the feature when it is being geometry edited, to prevent its symbol from conflicting with the geometry editor.
Closes `swift/issues/8540`.


## How To Test

- Run `FeatureEditorExample`.
- Tap on a feature to edit and ensure its symbol is hidden on the map.
- Close the Feature Editor and ensure feature re-appears on the map. 


## Screenshots

|Before|After|
|:-:|:-:|
| <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-09-03 at 15 55 38" src="https://github.com/user-attachments/assets/18049313-adea-4eae-b980-c014038ef717" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-09-03 at 15 51 49" src="https://github.com/user-attachments/assets/55600d99-8b3b-44b6-856b-27367b65f27d" /> |
